### PR TITLE
Clarify verbose flag behavior and refactor message header

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ For each message, the headers aren't exported in the same order they appear in `
 ## Options
 
 - `--verbose` or `-v`
-If this is set, pyqwk will include message IDs, which probably aren't useful to a modern reader (default: off)
+If this is set, pyqwk will include extra header details: conference information (even when the name can't be found), message numbers, and reference numbers. (default: off)
 
 - `--private` or `-p`
 If this is set, pyqwk will include messages marked as private. If you are an archivist, you may want to not include personal messages from people who kindly donated their qwk packets. But if you're archiving your own, use `--private` to include them. (default: off)

--- a/qwk.py
+++ b/qwk.py
@@ -6,12 +6,13 @@ import re
 import hashlib
 import os
 import logging
-from collections import namedtuple
 from dataclasses import dataclass
 
 BLOCK_SIZE = 128
 MESSAGES_FILENAME = 'messages.dat'
 CONTROL_FILENAME = 'control.dat'
+
+QWK_NEWLINE_CHAR = '\xe3'  # DOS CP437 newline character
 
 QUOTE_HEADER_PATTERNS = [
     re.compile(
@@ -63,25 +64,22 @@ class ProcessingSettings:
     redactPII: bool
 
 
-MessageHeader = namedtuple(
-    'MessageHeader',
-    [
-        'status',
-        'msgnum',
-        'msgdate',
-        'msgtime',
-        'msgto',
-        'msgfrom',
-        'msgsubject',
-        'msgpassword',
-        'refnum',
-        'numblocks',
-        'msgflag',
-        'confnum',
-        'lognum',
-        'nettag',
-    ],
-)
+@dataclass
+class MessageHeader:
+    status: bytes
+    msgnum: bytes
+    msgdate: bytes
+    msgtime: bytes
+    msgto: bytes
+    msgfrom: bytes
+    msgsubject: bytes
+    msgpassword: bytes
+    refnum: bytes
+    numblocks: bytes
+    msgflag: bytes
+    confnum: int
+    lognum: int
+    nettag: bytes
 
 
 class MessagesDatFormatError(Exception):
@@ -182,7 +180,7 @@ def parse_messages(file_data, boarddict, noHeader, verbose):
             tempblocks = header.numblocks.decode('latin1').strip()
             intBlocks = int(tempblocks) - 1
         else:
-            temprecord = record.decode('latin1').replace('\xe3', '\r\n')
+            temprecord = record.decode('latin1').replace(QWK_NEWLINE_CHAR, '\r\n')
             if intBlocks == 1:
                 temprecord = temprecord.rstrip() + '\r\n'
             messagebuffer += temprecord
@@ -276,7 +274,15 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('input_path', help='The messages.dat filename, or the QWK packet (default: messages.dat)', nargs='?', default='messages.dat')
     parser.add_argument('output_path', help='The output filename or directory. (default: print to console)', nargs='?')
-    parser.add_argument('-v', '--verbose', help='verbose output. export message id fields that may not be relevant', action='store_true')
+    parser.add_argument(
+        '-v',
+        '--verbose',
+        help=(
+            'include additional header details such as conference information, '
+            'message numbers, and reference numbers'
+        ),
+        action='store_true',
+    )
     parser.add_argument('-p', '--private', help='export messages marked private', action='store_true')
     parser.add_argument('-n', '--noheader', help='leave out message header', action='store_true')
     parser.add_argument('-t', '--truncatesignatures', help='truncate at signatures (everything after a line that consists only of "---" or starts with " * ")', action='store_true')


### PR DESCRIPTION
## Summary
- update the verbose flag documentation and CLI help to describe the additional header details it prints
- convert MessageHeader from a namedtuple to a dataclass and add a named constant for the QWK newline character

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_6903120f2aa483309ad565a157f28a3f