### PR TITLE
Add QWK packet tests and fix CONTROL.DAT parsing

### DIFF
--- a/qwk.py
+++ b/qwk.py
@@ -124,9 +124,15 @@ def load_data(input_path: str, logger: logging.Logger) -> Tuple[bytearray, Dict[
                 if controlname:
                     with myzip.open(controlname) as f:
                         controldata = f.read().splitlines()
-                    numlines = int(controldata[10])
-                    for i in range(0, numlines):
-                        boarddict[int(controldata[i * 2 + 11])] = controldata[i * 2 + 12].decode('latin1')
+                    num_conferences = int(controldata[10]) + 1
+                    for i in range(num_conferences):
+                        index = 11 + i * 2
+                        try:
+                            conf_number = int(controldata[index])
+                            conf_name = controldata[index + 1].decode('latin1')
+                        except IndexError as error:
+                            raise MessagesDatFormatError from error
+                        boarddict[conf_number] = conf_name
         except zipfile.BadZipFile as error:
             raise zipfile.BadZipFile("Error: The provided file is not a valid zip file.") from error
     else:

--- a/tests/test_qwk.py
+++ b/tests/test_qwk.py
@@ -26,6 +26,11 @@ def expected_output_path() -> Path:
     return Path(__file__).resolve().parents[1] / "testdata" / "messages_expected.txt"
 
 
+@pytest.fixture
+def testdata_dir() -> Path:
+    return Path(__file__).resolve().parents[1] / "testdata"
+
+
 def _read_expected(path: Path) -> str:
     text = path.read_text(encoding="latin1")
     return text.replace("\n", "\r\n")
@@ -122,3 +127,48 @@ def test_process_file_prints_to_stdout(capsys, baseline_path: Path, expected_out
     expected_message = _read_expected(expected_output_path)
     assert captured.out == expected_message + "\n"
     assert captured.err == ""
+
+
+@pytest.mark.parametrize(
+    "archive_name, expected_boarddict",
+    [
+        (
+            "test1_qwk.zip",
+            {
+                1: "General Mess",
+                2: "FidoNet NetM",
+                3: "Net140.Tech",
+                4: "Pnw.Tech",
+                5: "Stoon.Sysop",
+            },
+        ),
+        (
+            "test2_qwk.zip",
+            {
+                1: "General Mess",
+                2: "FidoNet NetM",
+                3: "Net140.Tech",
+                4: "Pnw.Tech",
+                5: "Stoon.Sysop",
+            },
+        ),
+    ],
+)
+def test_load_data_reads_all_conferences_from_control_dat(
+    archive_name: str, expected_boarddict: dict[int, str], testdata_dir: Path, logger: logging.Logger
+) -> None:
+    file_data, boarddict = load_data(str(testdata_dir / archive_name), logger)
+
+    assert isinstance(file_data, bytearray)
+    assert boarddict == expected_boarddict
+
+
+def test_parse_messages_from_qwk_packet(testdata_dir: Path, logger: logging.Logger) -> None:
+    file_data, boarddict = load_data(str(testdata_dir / "test2_qwk.zip"), logger)
+
+    messages = list(parse_messages(file_data, boarddict, noHeader=False, verbose=False))
+
+    assert len(messages) == 2
+    assert {is_private for _, is_private, _ in messages} == {False}
+    assert {is_password for _, _, is_password in messages} == {False}
+    assert all("Conference: Net140.Tech" in message for message, _, _ in messages)


### PR DESCRIPTION
## Summary
- add regression tests that exercise legacy QWK packets and verify control.dat conference entries
- fix CONTROL.DAT parsing to read the full conference list and raise a clear error on truncation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_69054b0042c48330beae6c5d78aaaa33