### PR TITLE
Improve threading cycle warnings and Control.DAT validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If this is set, pyqwk will truncate each message at the signature. Truncation ha
 If this is set, pyqwk will delete quoted text (that uses ">" as quoting character). (default: off)
 
 - `--binariesremoval` or `-b`
-If this is set, pyqwk will delete binaries (currently removes uuencoded and Base64-encoded blocks). (default: off)
+If this is set, pyqwk will delete binaries (currently removes uuencoded, Base64-encoded, and yEnc blocks). (default: off)
 
 - `--individualfiles` or `-i`
 If this is set, pyqwk will put each individual message in its own file according to its SHA1 hash (if you have contributions of qwk packets from multiple people, avoids duplication). (default: off)

--- a/qwk.py
+++ b/qwk.py
@@ -169,10 +169,19 @@ def load_data(input_path: str, logger: logging.Logger) -> Tuple[bytearray, Dict[
                     for i in range(num_conferences):
                         index = 11 + i * 2
                         try:
-                            conf_number = int(control_data[index])
-                            conf_name = control_data[index + 1].decode('latin1')
+                            conf_number_raw = control_data[index]
+                            conf_name_raw = control_data[index + 1]
                         except IndexError as error:
-                            raise ControlDatFormatError from error
+                            raise ControlDatFormatError(
+                                "CONTROL.DAT is truncated; missing conference entries."
+                            ) from error
+                        try:
+                            conf_number = int(conf_number_raw)
+                        except ValueError as error:
+                            raise ControlDatFormatError(
+                                f"Invalid conference number in CONTROL.DAT: {conf_number_raw!r}"
+                            ) from error
+                        conf_name = conf_name_raw.decode('latin1')
                         board_dict[conf_number] = conf_name
                 else:
                     logger.warning("CONTROL.DAT not found, conference names will not be available.")
@@ -228,7 +237,9 @@ def parse_messages(
 
             refnum_text = header.refnum.decode('latin1').strip()
             if refnum_text.isdigit():
-                current_refnum = int(refnum_text) or None
+                current_refnum = int(refnum_text)
+                if current_refnum == 0:
+                    current_refnum = None
             else:
                 current_refnum = None
 
@@ -605,6 +616,7 @@ def _order_messages_by_thread(messages: List[ProcessedMessage]) -> List[Processe
     if not messages:
         return []
 
+    logger = logging.getLogger(__name__)
     index_by_key: Dict[Tuple[int, int], int] = {}
     children: Dict[int, List[int]] = defaultdict(list)
 
@@ -626,8 +638,18 @@ def _order_messages_by_thread(messages: List[ProcessedMessage]) -> List[Processe
     ordered_indices: List[int] = []
     visited: set[int] = set()
 
+    cycle_reported: set[int] = set()
+
     def visit(idx: int, path: set[int]) -> None:
         if idx in path:
+            if idx not in cycle_reported:
+                message = messages[idx]
+                logger.warning(
+                    "Circular reference detected while threading messages (conf %s, msgnum %s).",
+                    message.confnum,
+                    message.msgnum if message.msgnum is not None else "unknown",
+                )
+                cycle_reported.add(idx)
             return
         if idx in visited:
             return

--- a/tests/test_qwk.py
+++ b/tests/test_qwk.py
@@ -14,6 +14,7 @@ from qwk import (
     ParsedMessage,
     ProcessedMessage,
     MessageHeader,
+    ControlDatFormatError,
     _format_message_header,
     _order_messages_by_thread,
     load_data,
@@ -258,6 +259,36 @@ def test_order_messages_by_thread_groups_children() -> None:
     ]
 
 
+def test_order_messages_by_thread_logs_circular_reference(caplog: pytest.LogCaptureFixture) -> None:
+    header = MessageHeader(
+        status=b'',
+        msgnum=b'',
+        msgdate=b'',
+        msgtime=b'',
+        msgto=b'',
+        msgfrom=b'',
+        msgsubject=b'',
+        msgpassword=b'',
+        refnum=b'',
+        numblocks=b'',
+        msgflag=b'',
+        confnum=0,
+        lognum=0,
+        nettag=b'',
+    )
+    messages = [
+        ProcessedMessage("first\r\n", msgnum=1, refnum=3, confnum=1, header=header),
+        ProcessedMessage("second\r\n", msgnum=2, refnum=1, confnum=1, header=header),
+        ProcessedMessage("third\r\n", msgnum=3, refnum=2, confnum=1, header=header),
+    ]
+
+    with caplog.at_level(logging.WARNING, logger="qwk"):
+        ordered = _order_messages_by_thread(messages)
+
+    assert [message.msgnum for message in ordered] == [1, 2, 3]
+    assert "Circular reference detected" in caplog.text
+
+
 @pytest.mark.parametrize(
     "archive_name, expected_boarddict",
     [
@@ -290,6 +321,36 @@ def test_load_data_reads_all_conferences_from_control_dat(
 
     assert isinstance(file_data, bytearray)
     assert boarddict == expected_boarddict
+
+
+def test_load_data_raises_for_invalid_conference_number(
+    tmp_path: Path, testdata_dir: Path, logger: logging.Logger
+) -> None:
+    zip_path = tmp_path / "invalid_control.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.write(testdata_dir / "messages.dat", "MESSAGES.DAT")
+        control_lines = [
+            b"Benden Weyr, Pern, Sagittarius Sector",
+            b"",
+            b"(306) 382-5746",
+            b"Ken Read",
+            b"0 ,Benden",
+            b"09-04-1994,19:25:58",
+            b"CHRIS STUBBS",
+            b"",
+            b"0",
+            b"0",
+            b"0",
+            b"NOT_A_NUMBER",
+            b"Test Conference",
+        ]
+        control_content = b"\r\n".join(control_lines) + b"\r\n"
+        zf.writestr("CONTROL.DAT", control_content)
+
+    with pytest.raises(ControlDatFormatError) as exc_info:
+        load_data(str(zip_path), logger)
+
+    assert "Invalid conference number" in str(exc_info.value)
 
 
 def test_parse_messages_from_qwk_packet(testdata_dir: Path, logger: logging.Logger) -> None:


### PR DESCRIPTION
## Summary
- improve CONTROL.DAT parsing to raise descriptive errors when conference numbers cannot be read
- simplify refnum parsing while keeping zero values treated as missing and log circular threading references
- document yEnc binary removal support and add regression tests for the new behaviours

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914500e97f083309848993bd470e7c4)