### PR TITLE
Enhance typing, docs, and CLI coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,64 @@ If this is set, pyqwk will put each individual message in its own file according
 - `--redactpii` or `-r`
 If this is set, pyqwk will redact PII (Personally Identifiable Information), currently only phone numbers and e-mails. (default: off)
 
+## JSON and XML output formats
+
+When `--format json` or `--format xml` is selected, pyqwk emits structured representations of each processed message. The `header` section mirrors the fields from `messages.dat`, and missing numeric fields such as `msgnum` or `refnum` appear as empty strings.
+
+### JSON example
+
+```json
+[
+    {
+        "header": {
+            "status": "+",
+            "msgnum": "28",
+            "msgdate": "10-04-94",
+            "msgtime": "11:15",
+            "msgto": "ALL",
+            "msgfrom": "DIVER",
+            "msgsubject": "NET/MESSAGE COORDINATION",
+            "msgpassword": "",
+            "refnum": "",
+            "numblocks": "1",
+            "msgflag": " ",
+            "confnum": 3,
+            "lognum": 0,
+            "nettag": ""
+        },
+        "text": "<message body with \r\n newlines>"
+    }
+]
+```
+
+### XML example
+
+```xml
+<messages>
+  <message>
+    <header>
+      <status>+</status>
+      <msgnum>28</msgnum>
+      <msgdate>10-04-94</msgdate>
+      <msgtime>11:15</msgtime>
+      <msgto>ALL</msgto>
+      <msgfrom>DIVER</msgfrom>
+      <msgsubject>NET/MESSAGE COORDINATION</msgsubject>
+      <msgpassword />
+      <refnum />
+      <numblocks>1</numblocks>
+      <msgflag> </msgflag>
+      <confnum>3</confnum>
+      <lognum>0</lognum>
+      <nettag />
+    </header>
+    <text>&lt;message body with \r\n newlines&gt;</text>
+  </message>
+</messages>
+```
+
+In both formats the `header` fields map directly to the `MessageHeader` dataclass in `qwk.py`, while `text` contains the processed body with DOS-style newlines preserved.
+
 ## Known Issues
 
 - Some `.qwk` packets from this era use a ZIP compression method that modern Python doesn't know. To work around this issue:

--- a/qwk.py
+++ b/qwk.py
@@ -87,7 +87,7 @@ class ParsedMessage:
     msgnum: Optional[int]
     refnum: Optional[int]
     confnum: int
-    header: 'MessageHeader'
+    header: "MessageHeader"
 
 
 @dataclass
@@ -96,28 +96,28 @@ class ProcessedMessage:
     msgnum: Optional[int]
     refnum: Optional[int]
     confnum: int
-    header: 'MessageHeader'
+    header: "MessageHeader"
 
 
 @dataclass
 class MessageHeader:
     status: bytes
-    msgnum: bytes
+    msgnum: Optional[bytes]
     msgdate: bytes
     msgtime: bytes
     msgto: bytes
     msgfrom: bytes
     msgsubject: bytes
     msgpassword: bytes
-    refnum: bytes
+    refnum: Optional[bytes]
     numblocks: bytes
     msgflag: bytes
     confnum: int
     lognum: int
     nettag: bytes
 
-    def _to_dict(self):
-        result = {}
+    def _to_dict(self) -> Dict[str, Any]:
+        result: Dict[str, Any] = {}
         for field in fields(self):
             value = getattr(self, field.name)
             if isinstance(value, bytes):
@@ -214,6 +214,19 @@ def parse_messages(
     file_data: bytearray,
     progress_bar: Optional[Any],
 ) -> Iterator[ParsedMessage]:
+    """Parse a QWK messages.dat payload into message objects.
+
+    Args:
+        file_data: Raw bytes from a messages.dat file.
+        progress_bar: Optional tqdm-compatible progress reporter to update as blocks are read.
+
+    Yields:
+        ParsedMessage instances containing the message body, header, and metadata flags.
+
+    Raises:
+        MessagesDatFormatError: If the payload does not start with a valid messages.dat header.
+        InvalidMessageTypeError: If a message header encodes an unknown message type.
+    """
     blocks_remaining = 0
     message_buffer = ''
     is_private = True
@@ -232,10 +245,12 @@ def parse_messages(
         if blocks_remaining == 0:
             header, is_private, is_password = _parse_header_record(record)
 
-            msgnum_text = header.msgnum.decode('latin1').strip()
+            msgnum_bytes = header.msgnum or b''
+            msgnum_text = msgnum_bytes.decode('latin1').strip()
             current_msgnum = int(msgnum_text) if msgnum_text.isdigit() else None
 
-            refnum_text = header.refnum.decode('latin1').strip()
+            refnum_bytes = header.refnum or b''
+            refnum_text = refnum_bytes.decode('latin1').strip()
             if refnum_text.isdigit():
                 current_refnum = int(refnum_text)
                 if current_refnum == 0:
@@ -271,6 +286,16 @@ def _format_message_header(
     boarddict: Mapping[int, str],
     verbose: bool,
 ) -> str:
+    """Render a message header into readable text.
+
+    Args:
+        header: Parsed header information for the message.
+        boarddict: Mapping of conference numbers to human-readable names.
+        verbose: Whether to include extra metadata such as message numbers and reference numbers.
+
+    Returns:
+        The formatted header text with DOS-style newlines appended.
+    """
     not_found_flag = False
     try:
         conf_name = boarddict[header.confnum]
@@ -284,7 +309,7 @@ def _format_message_header(
         header_parts.append("Conference: " + str(conf_name) + "\r\n")
     if verbose:
         header_parts.append(
-            "Message number: " + header.msgnum.decode("latin1") + (" " * 20)
+            "Message number: " + (header.msgnum or b"").decode("latin1") + (" " * 20)
         )
     header_parts.append(
         "Date: "
@@ -298,7 +323,7 @@ def _format_message_header(
     header_parts.append("Subject: " + header.msgsubject.decode("latin1") + "\r\n")
     if verbose:
         header_parts.append(
-            "Reference number: " + header.refnum.decode("latin1") + "\r\n"
+            "Reference number: " + (header.refnum or b"").decode("latin1") + "\r\n"
         )
     header_parts.append("\r\n")
     return "".join(header_parts)
@@ -311,6 +336,18 @@ def process_message(
     binaries_removal: bool,
     redact_pii: bool,
 ) -> str:
+    """Transform a raw message body according to processing settings.
+
+    Args:
+        message_buffer: The original message text with DOS-style newlines.
+        truncate_signatures: Whether to stop output at common signature separators.
+        cut_quoting: Whether to remove quoted text and quote headers.
+        binaries_removal: Whether to strip uuencoded, Base64, and yEnc payloads.
+        redact_pii: Whether to redact email addresses and phone numbers.
+
+    Returns:
+        The processed message text with transformations applied.
+    """
     lines = message_buffer.splitlines()
 
     new_lines = []
@@ -651,6 +688,19 @@ def main():
 
 
 def _order_messages_by_thread(messages: List[ProcessedMessage]) -> List[ProcessedMessage]:
+    """Order processed messages so that threads are grouped together.
+
+    Messages are rearranged so that parent messages appear before children and
+    warnings are emitted for circular references.
+
+    Args:
+        messages: Messages that have already been processed and may contain
+            reference links to other messages in the same conference.
+
+    Returns:
+        Messages ordered to reflect reply relationships while preserving
+        unattached messages.
+    """
     if not messages:
         return []
 

--- a/tests/test_qwk.py
+++ b/tests/test_qwk.py
@@ -1,3 +1,4 @@
+import argparse
 import logging
 import sys
 import json
@@ -21,6 +22,7 @@ from qwk import (
     parse_messages,
     process_message,
     process_file,
+    main,
 )
 
 
@@ -67,6 +69,28 @@ def _make_settings(**overrides) -> ProcessingSettings:
     )
     defaults.update(overrides)
     return ProcessingSettings(**defaults)
+
+
+def _make_cli_namespace(**overrides: object) -> argparse.Namespace:
+    base = dict(
+        input_paths=[],
+        output_path=None,
+        verbose=False,
+        private=False,
+        noheader=False,
+        truncatesignatures=False,
+        cutquoting=False,
+        individualfiles=False,
+        threaded=False,
+        binariesremoval=False,
+        redactpii=False,
+        quiet=False,
+        format="text",
+        output=None,
+        loglevel="INFO",
+    )
+    base.update(overrides)
+    return argparse.Namespace(**base)
 
 
 def test_parse_messages_matches_baseline(baseline_path: Path, expected_output_path: Path, logger: logging.Logger) -> None:
@@ -510,3 +534,85 @@ def test_load_data_logs_warning_if_control_dat_is_missing(
         load_data(str(zip_path), logger)
 
     assert "CONTROL.DAT not found" in caplog.text
+
+
+def test_cli_requires_output_path_when_output_file(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], baseline_path: Path
+) -> None:
+    logging.basicConfig(level=logging.ERROR, force=True)
+    namespace = _make_cli_namespace(input_paths=[str(baseline_path)], output="file")
+    monkeypatch.setattr(argparse.ArgumentParser, "parse_args", lambda self: namespace)
+
+    with pytest.raises(SystemExit):
+        main()
+
+    stderr = capsys.readouterr().err
+    assert "An output path is required when --output file is specified." in stderr
+
+
+def test_cli_rejects_output_path_for_stdout(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], baseline_path: Path
+) -> None:
+    logging.basicConfig(level=logging.ERROR, force=True)
+    namespace = _make_cli_namespace(
+        input_paths=[str(baseline_path)],
+        output_path="output.txt",
+        output="stdout",
+    )
+    monkeypatch.setattr(argparse.ArgumentParser, "parse_args", lambda self: namespace)
+
+    with pytest.raises(SystemExit):
+        main()
+
+    stderr = capsys.readouterr().err
+    assert "Do not provide an output path when --output stdout is specified." in stderr
+
+
+def test_cli_rejects_invalid_log_level(
+    monkeypatch: pytest.MonkeyPatch, baseline_path: Path
+) -> None:
+    namespace = _make_cli_namespace(input_paths=[str(baseline_path)], loglevel="NOPE")
+    monkeypatch.setattr(argparse.ArgumentParser, "parse_args", lambda self: namespace)
+
+    with pytest.raises(ValueError):
+        main()
+
+
+def test_cli_reports_missing_file(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    missing_path = tmp_path / "missing.dat"
+    logging.basicConfig(level=logging.ERROR, force=True)
+    namespace = _make_cli_namespace(input_paths=[str(missing_path)])
+    monkeypatch.setattr(argparse.ArgumentParser, "parse_args", lambda self: namespace)
+
+    with pytest.raises(SystemExit):
+        main()
+
+    stderr = capsys.readouterr().err
+    assert "No such file or directory" in stderr
+
+
+def test_cli_handles_mixed_batch_inputs(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+    baseline_path: Path,
+) -> None:
+    output_dir = tmp_path / "output"
+    missing_path = tmp_path / "missing.dat"
+    logging.basicConfig(level=logging.ERROR, force=True)
+    namespace = _make_cli_namespace(
+        input_paths=[str(baseline_path), str(missing_path)],
+        output_path=str(output_dir),
+        output="file",
+    )
+    monkeypatch.setattr(argparse.ArgumentParser, "parse_args", lambda self: namespace)
+
+    main()
+
+    stderr = capsys.readouterr().err
+    assert str(missing_path) in stderr
+
+    expected_output = output_dir / "messages.txt"
+    assert expected_output.exists()


### PR DESCRIPTION
## Summary
- add optional type annotations and docstrings for core message parsing helpers
- document the JSON and XML structured outputs in the README
- expand CLI validation tests to cover error handling cases

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691985b972f48330925c8a8b922d296a)