### PR TITLE
Improve control.dat error reporting and CLI output handling

### DIFF
--- a/qwk.py
+++ b/qwk.py
@@ -652,14 +652,21 @@ def main():
     logging.basicConfig(level=numeric_level)
     logger = logging.getLogger(__name__)
 
-    if len(args.input_paths) > 1:
-        if not args.output_path:
+    input_paths = args.input_paths
+    output_path = args.output_path
+
+    if not output_path and not args.stdout and len(input_paths) > 1:
+        output_path = input_paths[-1]
+        input_paths = input_paths[:-1]
+
+    if len(input_paths) > 1:
+        if not output_path:
             parser.error('Output directory is required when processing multiple files.')
         if args.stdout:
             parser.error('Output directory is required when processing multiple files.')
         output_target = 'file'
     else:
-        output_target = 'stdout' if args.stdout or not args.output_path else 'file'
+        output_target = 'stdout' if args.stdout or not output_path else 'file'
 
     settings = ProcessingSettings(
         verbose=args.verbose,
@@ -676,11 +683,11 @@ def main():
         output_target=output_target,
     )
 
-    if len(args.input_paths) > 1:
-        process_multiple_files(args.input_paths, args.output_path, settings, logger)
+    if len(input_paths) > 1:
+        process_multiple_files(input_paths, output_path, settings, logger)
     else:
         try:
-            process_file(args.input_paths[0], args.output_path, settings, logger)
+            process_file(input_paths[0], output_path, settings, logger)
         except (
             MessagesDatFormatError,
             ControlDatFormatError,

--- a/qwk.py
+++ b/qwk.py
@@ -10,6 +10,7 @@ import json
 import xml.etree.ElementTree as ET
 from collections import defaultdict
 from dataclasses import dataclass, fields
+from contextlib import contextmanager
 from typing import Any, Dict, Iterator, List, Mapping, NamedTuple, Optional, Tuple
 
 BLOCK_SIZE = 128
@@ -55,12 +56,6 @@ SIGNATURE_PATTERNS_STARTSWITH = (
     " \xfe ",
     " *** ",
 )
-
-
-try:
-    from tqdm import tqdm as tqdm_factory  # type: ignore
-except ImportError:  # pragma: no cover - tqdm is optional
-    tqdm_factory = None  # type: ignore[assignment]
 
 
 @dataclass
@@ -172,8 +167,10 @@ def load_data(input_path: str, logger: logging.Logger) -> Tuple[bytearray, Dict[
                             conf_number_raw = control_data[index]
                             conf_name_raw = control_data[index + 1]
                         except IndexError as error:
+                            available_entries = max((len(control_data) - 11) // 2, 0)
                             raise ControlDatFormatError(
-                                "CONTROL.DAT is truncated; missing conference entries."
+                                "CONTROL.DAT is truncated; missing conference entry "
+                                f"{i} (expected {num_conferences} entries, found {available_entries})."
                             ) from error
                         try:
                             conf_number = int(conf_number_raw)
@@ -432,19 +429,38 @@ def process_file(
     file_data, board_dict = load_data(input_path, logger)
     collected_messages: List[ProcessedMessage] = []
 
-    progress_bar: Optional[Any] = None
-    if not settings.quiet:
-        if tqdm_factory is None:
+    if settings.quiet:
+        @contextmanager
+        def progress_context() -> Iterator[Optional[Any]]:
+            yield None
+    else:
+        try:
+            from tqdm import tqdm  # type: ignore
+        except ImportError:  # pragma: no cover - tqdm is optional
             logger.info('Install tqdm to enable progress reporting.')
-        else:
-            progress_bar = tqdm_factory(
-                total=len(file_data),
-                unit='B',
-                unit_scale=True,
-                desc='Processing messages',
-            )
 
-    try:
+            @contextmanager
+            def progress_context() -> Iterator[Optional[Any]]:
+                class _NullProgress:
+                    def update(self, *_: object, **__: object) -> None:
+                        return None
+
+                    def close(self) -> None:
+                        return None
+
+                yield _NullProgress()
+        else:
+            @contextmanager
+            def progress_context() -> Iterator[Optional[Any]]:
+                with tqdm(
+                    total=len(file_data),
+                    unit='B',
+                    unit_scale=True,
+                    desc='Processing messages',
+                ) as progress_bar:
+                    yield progress_bar
+
+    with progress_context() as progress_bar:
         for parsed_message in parse_messages(
             file_data,
             progress_bar,
@@ -489,9 +505,6 @@ def process_file(
                             header=parsed_message.header,
                         )
                     )
-    finally:
-        if progress_bar is not None:
-            progress_bar.close()
 
     if not settings.individual_files:
         if settings.threaded:
@@ -589,7 +602,18 @@ def process_multiple_files(
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('input_paths', help='One or more QWK packets or messages.dat files to process.', nargs='+')
-    parser.add_argument('output_path', help='The output filename or directory. Required for multiple input files. (default: print to console for single file)', nargs='?')
+    output_group = parser.add_mutually_exclusive_group()
+    output_group.add_argument(
+        '-o',
+        '--output',
+        dest='output_path',
+        help='The output filename or directory. Required for multiple input files. (default: print to console for single file)',
+    )
+    output_group.add_argument(
+        '--stdout',
+        action='store_true',
+        help='Print output to stdout rather than writing to a file.',
+    )
     parser.add_argument(
         '-v',
         '--verbose',
@@ -620,12 +644,6 @@ def main():
         default='text',
         choices=['text', 'json', 'xml'],
     )
-    parser.add_argument(
-        '-o',
-        '--output',
-        help='Select the output destination for single-file processing',
-        choices=['stdout', 'file'],
-    )
     args = parser.parse_args()
 
     numeric_level = getattr(logging, args.loglevel.upper(), None)
@@ -635,25 +653,13 @@ def main():
     logger = logging.getLogger(__name__)
 
     if len(args.input_paths) > 1:
-        if args.output and args.output != 'file':
-            logger.error('Output must be set to "file" when processing multiple inputs.')
-            sys.exit(1)
         if not args.output_path:
-            logger.error('Output directory is required when processing multiple files.')
-            sys.exit(1)
+            parser.error('Output directory is required when processing multiple files.')
+        if args.stdout:
+            parser.error('Output directory is required when processing multiple files.')
         output_target = 'file'
     else:
-        if args.output is None:
-            output_target = 'file' if args.output_path else 'stdout'
-        else:
-            output_target = args.output
-
-        if output_target == 'file' and not args.output_path:
-            logger.error('An output path is required when --output file is specified.')
-            sys.exit(1)
-        if output_target == 'stdout' and args.output_path:
-            logger.error('Do not provide an output path when --output stdout is specified.')
-            sys.exit(1)
+        output_target = 'stdout' if args.stdout or not args.output_path else 'file'
 
     settings = ProcessingSettings(
         verbose=args.verbose,

--- a/tests/test_qwk.py
+++ b/tests/test_qwk.py
@@ -75,6 +75,7 @@ def _make_cli_namespace(**overrides: object) -> argparse.Namespace:
     base = dict(
         input_paths=[],
         output_path=None,
+        stdout=False,
         verbose=False,
         private=False,
         noheader=False,
@@ -86,7 +87,6 @@ def _make_cli_namespace(**overrides: object) -> argparse.Namespace:
         redactpii=False,
         quiet=False,
         format="text",
-        output=None,
         loglevel="INFO",
     )
     base.update(overrides)
@@ -395,6 +395,39 @@ def test_load_data_raises_for_invalid_conference_number(
     assert "Invalid conference number" in str(exc_info.value)
 
 
+def test_load_data_reports_truncated_control_dat(
+    tmp_path: Path, testdata_dir: Path, logger: logging.Logger
+) -> None:
+    zip_path = tmp_path / "truncated_control.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.write(testdata_dir / "messages.dat", "MESSAGES.DAT")
+        control_lines = [
+            b"Benden Weyr, Pern, Sagittarius Sector",
+            b"",
+            b"(306) 382-5746",
+            b"Ken Read",
+            b"0 ,Benden",
+            b"09-04-1994,19:25:58",
+            b"CHRIS STUBBS",
+            b"",
+            b"0",
+            b"0",
+            b"1",
+            b"1",
+            b"Test Conference",
+        ]
+        control_content = b"\r\n".join(control_lines) + b"\r\n"
+        zf.writestr("CONTROL.DAT", control_content)
+
+    with pytest.raises(ControlDatFormatError) as exc_info:
+        load_data(str(zip_path), logger)
+
+    message = str(exc_info.value)
+    assert "missing conference entry 1" in message
+    assert "expected 2 entries" in message
+    assert "found 1" in message
+
+
 def test_parse_messages_from_qwk_packet(testdata_dir: Path, logger: logging.Logger) -> None:
     file_data, board_dict = load_data(str(testdata_dir / "test2_qwk.zip"), logger)
 
@@ -536,36 +569,38 @@ def test_load_data_logs_warning_if_control_dat_is_missing(
     assert "CONTROL.DAT not found" in caplog.text
 
 
-def test_cli_requires_output_path_when_output_file(
+def test_cli_rejects_stdout_with_output_path(
     monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], baseline_path: Path
 ) -> None:
     logging.basicConfig(level=logging.ERROR, force=True)
-    namespace = _make_cli_namespace(input_paths=[str(baseline_path)], output="file")
-    monkeypatch.setattr(argparse.ArgumentParser, "parse_args", lambda self: namespace)
-
-    with pytest.raises(SystemExit):
-        main()
-
-    stderr = capsys.readouterr().err
-    assert "An output path is required when --output file is specified." in stderr
-
-
-def test_cli_rejects_output_path_for_stdout(
-    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], baseline_path: Path
-) -> None:
-    logging.basicConfig(level=logging.ERROR, force=True)
-    namespace = _make_cli_namespace(
-        input_paths=[str(baseline_path)],
-        output_path="output.txt",
-        output="stdout",
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["prog", str(baseline_path), "-o", "output.txt", "--stdout"],
     )
-    monkeypatch.setattr(argparse.ArgumentParser, "parse_args", lambda self: namespace)
 
     with pytest.raises(SystemExit):
         main()
 
     stderr = capsys.readouterr().err
-    assert "Do not provide an output path when --output stdout is specified." in stderr
+    assert "not allowed with argument -o/--output" in stderr
+
+
+def test_cli_requires_output_directory_for_multiple_inputs(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str], testdata_dir: Path
+) -> None:
+    logging.basicConfig(level=logging.ERROR, force=True)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["prog", str(testdata_dir / "test1_qwk.zip"), str(testdata_dir / "test2_qwk.zip"), "--stdout"],
+    )
+
+    with pytest.raises(SystemExit):
+        main()
+
+    stderr = capsys.readouterr().err
+    assert "Output directory is required when processing multiple files." in stderr
 
 
 def test_cli_rejects_invalid_log_level(
@@ -605,7 +640,6 @@ def test_cli_handles_mixed_batch_inputs(
     namespace = _make_cli_namespace(
         input_paths=[str(baseline_path), str(missing_path)],
         output_path=str(output_dir),
-        output="file",
     )
     monkeypatch.setattr(argparse.ArgumentParser, "parse_args", lambda self: namespace)
 

--- a/tests/test_qwk.py
+++ b/tests/test_qwk.py
@@ -603,6 +603,45 @@ def test_cli_requires_output_directory_for_multiple_inputs(
     assert "Output directory is required when processing multiple files." in stderr
 
 
+def test_cli_allows_positional_output_path(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, baseline_path: Path, expected_output_path: Path
+) -> None:
+    logging.basicConfig(level=logging.ERROR, force=True)
+    output_path = tmp_path / "output.txt"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["prog", str(baseline_path), str(output_path)],
+    )
+
+    main()
+
+    assert output_path.exists()
+    assert output_path.read_text(encoding="latin1") == expected_output_path.read_text(encoding="latin1")
+
+
+def test_cli_allows_positional_output_directory(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, testdata_dir: Path
+) -> None:
+    logging.basicConfig(level=logging.ERROR, force=True)
+    output_dir = tmp_path / "output"
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "prog",
+            str(testdata_dir / "test1_qwk.zip"),
+            str(testdata_dir / "test2_qwk.zip"),
+            str(output_dir),
+        ],
+    )
+
+    main()
+
+    assert (output_dir / "test1_qwk.txt").exists()
+    assert (output_dir / "test2_qwk.txt").exists()
+
+
 def test_cli_rejects_invalid_log_level(
     monkeypatch: pytest.MonkeyPatch, baseline_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary
- clarify CONTROL.DAT truncation errors by reporting the missing conference index and expected versus available entries
- localize optional tqdm usage inside `process_file` with a context-managed fallback progress reporter
- refactor CLI output arguments into a mutually exclusive group and update tests for the new validation logic

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ec26a5674833087b2166d217583e6)