### PR TITLE
Add installable package metadata and CLI version option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pyqwk"
+version = "0.1.0"
+description = "QWK packet extraction and processing tool"
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [{name = "PyQWK Maintainers"}]
+classifiers = [
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+
+[project.scripts]
+qwk = "qwk:main"
+
+[tool.setuptools]
+py-modules = ["qwk"]

--- a/qwk.py
+++ b/qwk.py
@@ -14,6 +14,8 @@ from dataclasses import dataclass, fields
 from contextlib import contextmanager
 from typing import Any, Callable, Protocol
 
+__version__ = "0.1.0"
+
 BLOCK_SIZE = 128
 MESSAGES_FILENAME = 'messages.dat'
 CONTROL_FILENAME = 'control.dat'
@@ -635,7 +637,7 @@ def process_multiple_files(
             logger.error("Error processing file %s: %s", input_path, error)
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument('input_paths', help='One or more QWK packets or messages.dat files to process.', nargs='+')
     output_group = parser.add_mutually_exclusive_group()
@@ -679,6 +681,12 @@ def main():
         help='Set the output format (text, json, xml)',
         default='text',
         choices=['text', 'json', 'xml'],
+    )
+    parser.add_argument(
+        '--version',
+        action='version',
+        version=f"%(prog)s {__version__}",
+        help='Show the version number and exit.',
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
## Summary
- add pyproject.toml with project metadata and console entry point for qwk
- expose __version__ constant and wire --version flag for CLI
- annotate main entry point for use via console script

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ed05bb2148330a33c46c050b16120)