### PR TITLE
Improve messages.dat error handling and CLI safety

### DIFF
--- a/qwk.py
+++ b/qwk.py
@@ -146,6 +146,9 @@ class MessageHeader:
 class MessagesDatFormatError(Exception):
     """Raised when the input file is not a valid messages.dat file."""
 
+    def __init__(self, message: str | None = None) -> None:
+        super().__init__(message or "Invalid messages.dat format.")
+
 
 class ControlDatFormatError(Exception):
     """Raised when the control.dat file is not a valid format."""
@@ -204,7 +207,12 @@ def load_data(input_path: str, logger: logging.Logger) -> tuple[bytearray, dict[
 
 
 def _parse_header_record(record: bytes) -> tuple[MessageHeader, bool, bool]:
-    header_data = struct.unpack('<c7s8s5s25s25s25s12s8s6scHHc', record)
+    try:
+        header_data = struct.unpack('<c7s8s5s25s25s25s12s8s6scHHc', record)
+    except (struct.error, ValueError) as error:
+        raise MessagesDatFormatError(
+            "messages.dat header record has invalid size or format."
+        ) from error
     header = MessageHeader(*header_data)
     message_type = header.status.decode('latin1')
     is_password = False
@@ -276,7 +284,9 @@ def parse_messages(
             progress_bar.update(len(record))
         if i == 0:
             if record[0:9] != b'Produced ':
-                raise MessagesDatFormatError
+                raise MessagesDatFormatError(
+                    "Input does not start with 'Produced ' header; not a messages.dat file."
+                )
             continue
         if blocks_remaining == 0:
             header, is_private, is_password = _parse_header_record(record)
@@ -298,7 +308,16 @@ def parse_messages(
 
             message_buffer = ''
             temp_blocks = header.numblocks.decode('latin1').strip()
-            blocks_remaining = int(temp_blocks) - 1
+            try:
+                blocks_remaining = int(temp_blocks) - 1
+            except ValueError:
+                logging.warning(
+                    "Invalid block count '%s' in message header at offset %s; skipping message.",
+                    temp_blocks,
+                    i,
+                )
+                blocks_remaining = 0
+                continue
         else:
             temp_record = record.decode('latin1').replace(QWK_NEWLINE_CHAR, '\r\n')
             if blocks_remaining == 1:
@@ -315,6 +334,11 @@ def parse_messages(
                     confnum=current_confnum,
                     header=header,
                 )
+
+    if blocks_remaining != 0:
+        raise MessagesDatFormatError(
+            "messages.dat is truncated; expected more blocks for current message."
+        )
 
 
 def _format_message_header(
@@ -703,10 +727,6 @@ def main() -> None:
 
     input_paths = args.input_paths
     output_path = args.output_path
-
-    if not output_path and not args.stdout and len(input_paths) > 1:
-        output_path = input_paths[-1]
-        input_paths = input_paths[:-1]
 
     if args.individualfiles:
         if output_path is None:

--- a/tests/test_qwk.py
+++ b/tests/test_qwk.py
@@ -119,6 +119,34 @@ def test_parse_messages_matches_baseline(baseline_path: Path, expected_output_pa
     assert message.confnum == 3
 
 
+def test_invalid_messages_dat_reports_clear_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    invalid_file = tmp_path / "not_messages.dat"
+    invalid_file.write_text("This is not a messages.dat file", encoding="latin1")
+
+    monkeypatch.setattr(sys, "argv", ["qwk", str(invalid_file)])
+    with caplog.at_level(logging.ERROR, logger="qwk"):
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+    assert exc_info.value.code == 1
+    assert "Input does not start with 'Produced '" in caplog.text
+
+
+def test_parse_messages_raises_for_truncated_payload(
+    baseline_path: Path, logger: logging.Logger
+) -> None:
+    truncated_data = bytearray(baseline_path.read_bytes()[:-qwk.BLOCK_SIZE])
+
+    with pytest.raises(qwk.MessagesDatFormatError) as exc_info:
+        list(parse_messages(truncated_data, progress_bar=None))
+
+    assert "truncated" in str(exc_info.value)
+
+
 def test_process_message_transforms_content() -> None:
     message = (
         "Intro line\r\n"
@@ -713,7 +741,7 @@ def test_cli_requires_output_directory_for_multiple_inputs(
 
 
 def test_cli_allows_positional_output_path(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, baseline_path: Path, expected_output_path: Path
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, baseline_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     logging.basicConfig(level=logging.ERROR, force=True)
     output_path = tmp_path / "output.txt"
@@ -723,14 +751,15 @@ def test_cli_allows_positional_output_path(
         ["prog", str(baseline_path), str(output_path)],
     )
 
-    main()
+    with pytest.raises(SystemExit):
+        main()
 
-    assert output_path.exists()
-    assert output_path.read_text(encoding="latin1") == expected_output_path.read_text(encoding="latin1")
+    stderr = capsys.readouterr().err
+    assert "Output directory is required when processing multiple files." in stderr
 
 
 def test_cli_allows_positional_output_directory(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, testdata_dir: Path
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, testdata_dir: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     logging.basicConfig(level=logging.ERROR, force=True)
     output_dir = tmp_path / "output"
@@ -745,10 +774,11 @@ def test_cli_allows_positional_output_directory(
         ],
     )
 
-    main()
+    with pytest.raises(SystemExit):
+        main()
 
-    assert (output_dir / "test1_qwk.txt").exists()
-    assert (output_dir / "test2_qwk.txt").exists()
+    stderr = capsys.readouterr().err
+    assert "Output directory is required when processing multiple files." in stderr
 
 
 def test_cli_rejects_invalid_log_level(


### PR DESCRIPTION
## Summary
- add descriptive messages for invalid messages.dat headers, handle malformed block counts, and detect truncated payloads
- require explicit output arguments for multi-file CLI usage instead of inferring positional outputs
- extend tests to cover new error handling and CLI validation cases

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69236c6c39b48330bc92839eca5ead93)