### PR TITLE
Add HTML output format

### DIFF
--- a/qwk.py
+++ b/qwk.py
@@ -7,6 +7,7 @@ import hashlib
 import os
 import logging
 import json
+import html
 import xml.etree.ElementTree as ET
 from collections import defaultdict
 from collections.abc import Iterator, Mapping
@@ -630,6 +631,7 @@ def process_file(
         writers: dict[str, Callable[[list[ProcessedMessage], str | None], None]] = {
             'json': _write_json,
             'xml': _write_xml,
+            'html': _write_html,
             'text': _write_text,
         }
 
@@ -682,6 +684,31 @@ def _write_xml(messages: list[ProcessedMessage], output_path: str | None) -> Non
     _write_text_output(xml_text, output_path, encoding='utf-8')
 
 
+def _write_html(messages: list[ProcessedMessage], output_path: str | None) -> None:
+    html_parts = [
+        '<!DOCTYPE html>',
+        '<html lang="en">',
+        '<head>',
+        '<meta charset="utf-8" />',
+        '<title>QWK Messages</title>',
+        '</head>',
+        '<body>',
+    ]
+
+    for message in messages:
+        escaped_text = html.escape(message.text.replace('\r\n', '\n'))
+        html_parts.append('<div class="message">')
+        html_parts.append('<pre>')
+        html_parts.append(escaped_text)
+        html_parts.append('</pre>')
+        html_parts.append('</div>')
+
+    html_parts.append('</body>')
+    html_parts.append('</html>')
+
+    _write_text_output('\n'.join(html_parts), output_path, encoding='utf-8')
+
+
 def _write_text_output(content: str, output_path: str | None, *, encoding: str = 'latin1') -> None:
     if output_path is None:
         sys.stdout.write(content + '\n')
@@ -704,6 +731,8 @@ def process_multiple_files(
                 output_filename += '.json'
             elif settings.format == 'xml':
                 output_filename += '.xml'
+            elif settings.format == 'html':
+                output_filename += '.html'
             else:
                 output_filename += '.txt'
             output_path = os.path.join(output_dir, output_filename)
@@ -759,9 +788,9 @@ def main() -> None:
     )
     parser.add_argument(
         '--format',
-        help='Set the output format (text, json, xml)',
+        help='Set the output format (text, json, xml, html)',
         default='text',
-        choices=['text', 'json', 'xml'],
+        choices=['text', 'json', 'xml', 'html'],
     )
     parser.add_argument(
         '--version',

--- a/tests/test_qwk.py
+++ b/tests/test_qwk.py
@@ -12,6 +12,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 import qwk
+import html
 
 from qwk import (
     ProcessingSettings,
@@ -28,6 +29,7 @@ from qwk import (
     process_message,
     process_file,
     _sanitize_xml_string,
+    _write_html,
     main,
 )
 
@@ -713,6 +715,25 @@ def test_process_file_writes_xml(
     assert expected_message.replace('\r\n', '\n') in content
 
 
+def test_process_file_writes_html(
+    tmp_path, baseline_path: Path, expected_output_path: Path, logger: logging.Logger
+) -> None:
+    output_path = tmp_path / "messages.html"
+    process_file(
+        str(baseline_path),
+        str(output_path),
+        _make_settings(format="html"),
+        logger=logger,
+    )
+
+    content = output_path.read_text(encoding="utf-8")
+
+    assert "<!DOCTYPE html>" in content
+    assert "<pre>" in content
+    escaped_expected = html.escape(_read_expected(expected_output_path).replace("\r\n", "\n"))
+    assert escaped_expected in content
+
+
 def test_process_file_writes_xml_with_special_characters(
     tmp_path, logger: logging.Logger
 ) -> None:
@@ -749,6 +770,40 @@ def test_process_file_writes_xml_with_special_characters(
 
     assert "&lt;test&gt;&amp;subject" in content
     assert "This is a test message with &lt; &amp; &gt; special characters." in content
+
+
+def test_write_html_escapes_and_wraps_messages(tmp_path: Path) -> None:
+    header = MessageHeader(
+        status=' ',
+        msgnum=1,
+        msgdate='01-01-90',
+        msgtime='12:00',
+        msgto='All',
+        msgfrom='Test User',
+        msgsubject='',
+        msgpassword='',
+        refnum=None,
+        numblocks=1,
+        msgflag=' ',
+        confnum=1,
+        lognum=1,
+        nettag='',
+    )
+    message = ProcessedMessage(
+        text="<b>Hello & welcome></b>",
+        msgnum=1,
+        refnum=0,
+        confnum=1,
+        header=header,
+    )
+
+    output_path = tmp_path / "test.html"
+    _write_html([message], str(output_path))
+
+    content = output_path.read_text(encoding="utf-8")
+
+    assert "<div class=\"message\">" in content
+    assert "&lt;b&gt;Hello &amp; welcome&gt;&lt;/b&gt;" in content
 
 
 def test_sanitize_xml_string_preserves_whitespace_and_drops_invalid() -> None:


### PR DESCRIPTION
## Summary
- add an HTML output option to the CLI and writer mapping
- generate HTML pages that wrap escaped message bodies in div/pre blocks
- update batch output handling and tests for the new format

## Testing
- pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692389cdfdb88330b6aac0575a89d9b6)