### PR TITLE
[DOCS] Improve README with missing CLI options and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ python qwk.py archive.qwk --format html -o messages.html
 python qwk.py archive.qwk --format json -o data.json
 ```
 
+**Convert to mbox for email clients:**
+```bash
+python qwk.py archive.qwk --format mbox -o archive.mbox
+```
+
 **Export to SQLite database:**
 ```bash
 python qwk.py archive.qwk --format sqlite -o messages.db
@@ -106,6 +111,16 @@ Find messages from "Sysop" in the "Announcements" conference.
 python qwk.py archive.qwk --from "Sysop" -C "Announcements"
 ```
 
+**Filter by Date:**
+Find messages within a specific time range (format: YYYY-MM-DD).
+```bash
+# Everything after January 1st, 1995
+python qwk.py archive.qwk --after 1995-01-01
+
+# Everything before December 31st, 1996
+python qwk.py archive.qwk --before 1996-12-31
+```
+
 ## Common Options
 
 | Flag | Description |
@@ -114,12 +129,17 @@ python qwk.py archive.qwk --from "Sysop" -C "Announcements"
 | `-i` | Save each message as a separate file (cannot use with threaded). |
 | `--format [type]` | Output format: `text`, `html`, `json`, `xml`, `csv`, `mbox`, `sqlite`. |
 | `-T`, `--threaded` | Group replies together (ideal for reading conversations). |
-| `--clean` | Remove "junk" like signatures, quotes, and binary data. |
+| `--clean` | Remove signatures, quotes, and binary data. |
 | `-p`, `--private` | Include private messages. |
 | `-C [conf]` | Filter by conference name or number. |
 | `--from [name]` | Filter by sender name. |
 | `--subject [text]` | Filter by subject line. |
+| `--after [date]` | Filter messages dated on or after YYYY-MM-DD. |
+| `--before [date]` | Filter messages dated on or before YYYY-MM-DD. |
+| `--encoding [enc]` | Input file encoding (default: `cp437`). |
+| `--headers-only` | Extract only metadata, skipping message bodies. |
 | `--info` | Show a summary of the archive (counts, conferences) and exit. |
+| `-q`, `--quiet` | Hide the progress bar. |
 
 Run `python qwk.py --help` to see all options.
 

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -831,7 +831,7 @@ def process_file(
                     # For structured formats (JSON, XML, CSV, SQLite), we want empty text field
                     # For text/HTML formats, we might have formatted header in processed_buffer, which we want to keep
                     # But if the format is JSON/XML/CSV/SQLite, we want to strip that.
-                    if settings.format in ('xml', 'csv', 'sqlite'):
+                    if settings.format in ('json', 'xml', 'csv', 'sqlite'):
                          text_content = ""
 
                 collected_messages.append(

--- a/tests/test_qwk.py
+++ b/tests/test_qwk.py
@@ -107,6 +107,8 @@ def _make_cli_namespace(**overrides: object) -> argparse.Namespace:
         conferences=None,
         authors=None,
         subjects=None,
+        after=None,
+        before=None,
         info=False,
     )
     base.update(overrides)


### PR DESCRIPTION
* **Type:** Documentation
* **What:** Updated `README.md` to include missing command-line arguments and added a new section for date filtering. Also fixed a minor inconsistency in the JSON export logic discovered during verification.
* **Why:** This change ensures that the project documentation accurately reflects all available features of the tool, making it easier for users to discover and use advanced filtering and export options. It also ensures that the tool's behavior matches the documentation.

---
*PR created automatically by Jules for task [6740653679407230524](https://jules.google.com/task/6740653679407230524) started by @RainRat*