### PR TITLE
Fix logic bug in UUE block detection

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -108,9 +108,7 @@ def _is_binary_line(
             return True, in_yenc_block, True
 
     if in_uue_block:
-        if line.strip() == 'end':
-            return True, in_yenc_block, False
-        return False, in_yenc_block, False
+        return True, in_yenc_block, line.strip() != 'end'
 
     return False, in_yenc_block, False
 

--- a/tests/test_binary_detection.py
+++ b/tests/test_binary_detection.py
@@ -37,6 +37,16 @@ class TestBinaryDetection:
         assert in_yenc is False
         assert in_uue is False
 
+    def test_detects_uue_backtick_line(self):
+        # A single backtick is often used as a zero-length data line in UUE
+        line = "`"
+        skip, in_yenc, in_uue = _is_binary_line(
+            line, previous_line=None, in_yenc_block=False, in_uue_block=True
+        )
+        assert skip is True
+        assert in_yenc is False
+        assert in_uue is True
+
     def test_detects_uue_start(self):
         line = "begin 644 test.txt"
         skip, in_yenc, in_uue = _is_binary_line(
@@ -102,9 +112,9 @@ class TestBinaryDetection:
         skip, in_yenc, in_uue = _is_binary_line(
             line, previous_line=None, in_yenc_block=False, in_uue_block=True
         )
-        assert skip is False
+        assert skip is True
         assert in_yenc is False
-        assert in_uue is False
+        assert in_uue is True
 
     def test_detects_base64(self):
         line = "VGhpcyBpcyBhIHRlc3QgbWVzc2FnZQ==" # Base64 for "This is a test message"

--- a/tests/test_content_processing.py
+++ b/tests/test_content_processing.py
@@ -84,6 +84,7 @@ def test_process_message_removes_uue_binaries() -> None:
         "Intro line\r\n"
         "begin 644 test.txt\r\n"
         "M" + ("A" * 60) + "\r\n"
+        "end\r\n"
         "Another line\r\n"
     )
 


### PR DESCRIPTION
Fixed a logic bug in `pyqwk/core.py` where UUEncode (UUE) binary blocks were prematurely exited if an intermediate line (like a backtick) did not match expected data patterns. The fix ensures all lines within the block are skipped until the explicit 'end' marker is found. Updated tests to verify correct skipping and block maintenance.

---
*PR created automatically by Jules for task [17950694446673948975](https://jules.google.com/task/17950694446673948975) started by @RainRat*