### PR TITLE
[TEST] Fix UUE binary removal and increase coverage for edge cases

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -110,7 +110,7 @@ def _is_binary_line(
     if in_uue_block:
         if line.strip() == 'end':
             return True, in_yenc_block, False
-        return False, in_yenc_block, False
+        return True, in_yenc_block, True
 
     return False, in_yenc_block, False
 

--- a/tests/test_binary_detection.py
+++ b/tests/test_binary_detection.py
@@ -19,6 +19,24 @@ class TestBinaryDetection:
         assert in_yenc is True
         assert in_uue is False
 
+    def test_uue_backtick_inside_block(self):
+        # Backtick is a valid UUE line (zero length) but often doesn't match data patterns
+        line = "`"
+        skip, in_yenc, in_uue = _is_binary_line(
+            line, previous_line=None, in_yenc_block=False, in_uue_block=True
+        )
+        assert skip is True
+        assert in_uue is True
+
+    def test_uue_skips_until_end(self):
+        # Any garbage inside a UUE block should be skipped until 'end'
+        line = "This is not UUE data"
+        skip, in_yenc, in_uue = _is_binary_line(
+            line, previous_line=None, in_yenc_block=False, in_uue_block=True
+        )
+        assert skip is True
+        assert in_uue is True
+
     def test_detects_yenc_body(self):
         line = "random_yenc_data"
         skip, in_yenc, in_uue = _is_binary_line(
@@ -97,14 +115,15 @@ class TestBinaryDetection:
         assert in_yenc is False
         assert in_uue is False
 
-    def test_exits_uue_on_invalid_line(self):
+    def test_stays_in_uue_on_invalid_line(self):
         line = "Not a uue line"
         skip, in_yenc, in_uue = _is_binary_line(
             line, previous_line=None, in_yenc_block=False, in_uue_block=True
         )
-        assert skip is False
+        # We should stay in UUE block and skip the line
+        assert skip is True
         assert in_yenc is False
-        assert in_uue is False
+        assert in_uue is True
 
     def test_detects_base64(self):
         line = "VGhpcyBpcyBhIHRlc3QgbWVzc2FnZQ==" # Base64 for "This is a test message"

--- a/tests/test_content_processing.py
+++ b/tests/test_content_processing.py
@@ -84,6 +84,7 @@ def test_process_message_removes_uue_binaries() -> None:
         "Intro line\r\n"
         "begin 644 test.txt\r\n"
         "M" + ("A" * 60) + "\r\n"
+        "end\r\n"
         "Another line\r\n"
     )
 


### PR DESCRIPTION
This PR fixes a bug in the UUEncode (UUE) binary removal logic. Previously, the parser would prematurely exit a UUE block if it encountered a line that didn't match its strict or loose data patterns (such as a backtick '`' line used for zero-length data).

I've updated `_is_binary_line` in `pyqwk/core.py` to use a more robust state-based approach that skips everything between a `begin` and `end` marker. I've also added new unit tests to cover these edge cases and updated existing tests that were codifying the previous incorrect behavior.

---
*PR created automatically by Jules for task [12983474236570705709](https://jules.google.com/task/12983474236570705709) started by @RainRat*