### PR TITLE
[FEAT] Add --limit option to restrict the number of messages processed

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ python qwk.py archive.qwk --from "Sysop" -C "Announcements"
 | `--from [name]` | Filter by sender name. |
 | `--subject [text]` | Filter by subject line. |
 | `--search [text]` | Search in author, subject, and body. |
+| `--limit [num]` | Limit the number of messages processed. |
 | `--info` | Show a summary of the archive (counts, conferences) and exit. |
 
 Run `python qwk.py --help` to see all options.

--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -233,6 +233,12 @@ def main() -> None:
         help='Filter messages dated on or before this date (format: YYYY-MM-DD).',
         default=None,
     )
+    filter_group.add_argument(
+        '--limit',
+        help='Limit the number of messages processed.',
+        type=int,
+        default=None,
+    )
 
     parser.add_argument(
         '--info',
@@ -316,6 +322,7 @@ def main() -> None:
         search_term=args.search_term,
         after=after_date,
         before=before_date,
+        limit=args.limit,
     )
 
     if args.info:

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -144,6 +144,7 @@ class ProcessingSettings:
     search_term: str | None = None
     after: datetime.datetime | None = None
     before: datetime.datetime | None = None
+    limit: int | None = None
 
 
 @dataclass
@@ -790,6 +791,7 @@ def process_file(
         separator_str = "\r\n"
 
     allowed_conferences = get_allowed_conferences(settings.conferences, board_dict)
+    count = 0
 
     desc = f"Processing {os.path.basename(input_path)}"
     with _create_progress_bar(len(file_data), settings.quiet, desc=desc) as progress_bar:
@@ -801,6 +803,10 @@ def process_file(
         ):
             if not matches_filters(parsed_message, settings, allowed_conferences):
                 continue
+
+            count += 1
+            if settings.limit is not None and count > settings.limit:
+                break
 
             processed_buffer = process_message(
                 parsed_message.text,

--- a/tests/test_limit.py
+++ b/tests/test_limit.py
@@ -1,0 +1,111 @@
+
+import pytest
+import logging
+from dataclasses import replace
+from pyqwk.core import process_file, ProcessingSettings, ParsedMessage, MessageHeader
+
+@pytest.fixture
+def mock_logger():
+    return logging.getLogger("test_limit")
+
+@pytest.fixture
+def mock_messages():
+    header_template = MessageHeader(
+        status=' ', msgnum=1, msgdate='01-01-23', msgtime='12:00', msgto='Everyone', msgfrom='Alice',
+        msgsubject='Subject', msgpassword='', refnum=None, numblocks=2,
+        msgflag=' ', confnum=1, lognum=1, nettag=''
+    )
+
+    msgs = []
+    for i in range(1, 11):
+        msgs.append(ParsedMessage(
+            text=f"Message {i}",
+            msgnum=i, refnum=None, confnum=1,
+            header=replace(header_template, msgnum=i)
+        ))
+    return msgs
+
+def test_limit_restricts_output(tmp_path, mock_messages, mock_logger, monkeypatch):
+    output_path = tmp_path / "output.txt"
+
+    def fake_load_data(*args, **kwargs):
+        return bytearray(), {1: "General"}
+
+    def fake_parse_messages(*args, **kwargs):
+        yield from mock_messages
+
+    monkeypatch.setattr("pyqwk.core.load_data", fake_load_data)
+    monkeypatch.setattr("pyqwk.core.parse_messages", fake_parse_messages)
+
+    limit = 3
+    settings = ProcessingSettings(
+        verbose=False, private=False, no_header=True, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False, binaries_removal=False,
+        redact_pii=False, format="text", separator="none", output_mode="file",
+        output_path=str(output_path), encoding="cp437", quiet=True,
+        limit=limit
+    )
+
+    process_file("dummy.qwk", settings, mock_logger)
+
+    content = output_path.read_text(encoding="latin1")
+    # Should contain Message 1, 2, 3 but not 4
+    assert "Message 1" in content
+    assert "Message 2" in content
+    assert "Message 3" in content
+    assert "Message 4" not in content
+
+    # Check number of messages (since separator is none, we just check strings)
+    # But wait, our process_message adds a newline.
+    # Actually, the best way is to check the length of the list if we can.
+    # But we are testing the end-to-end file output.
+
+def test_limit_zero(tmp_path, mock_messages, mock_logger, monkeypatch):
+    output_path = tmp_path / "output.txt"
+
+    def fake_load_data(*args, **kwargs):
+        return bytearray(), {1: "General"}
+
+    def fake_parse_messages(*args, **kwargs):
+        yield from mock_messages
+
+    monkeypatch.setattr("pyqwk.core.load_data", fake_load_data)
+    monkeypatch.setattr("pyqwk.core.parse_messages", fake_parse_messages)
+
+    settings = ProcessingSettings(
+        verbose=False, private=False, no_header=True, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False, binaries_removal=False,
+        redact_pii=False, format="text", separator="none", output_mode="file",
+        output_path=str(output_path), encoding="cp437", quiet=True,
+        limit=0
+    )
+
+    process_file("dummy.qwk", settings, mock_logger)
+
+    content = output_path.read_text(encoding="latin1")
+    assert content == ""
+
+def test_limit_higher_than_total(tmp_path, mock_messages, mock_logger, monkeypatch):
+    output_path = tmp_path / "output.txt"
+
+    def fake_load_data(*args, **kwargs):
+        return bytearray(), {1: "General"}
+
+    def fake_parse_messages(*args, **kwargs):
+        yield from mock_messages
+
+    monkeypatch.setattr("pyqwk.core.load_data", fake_load_data)
+    monkeypatch.setattr("pyqwk.core.parse_messages", fake_parse_messages)
+
+    settings = ProcessingSettings(
+        verbose=False, private=False, no_header=True, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False, binaries_removal=False,
+        redact_pii=False, format="text", separator="none", output_mode="file",
+        output_path=str(output_path), encoding="cp437", quiet=True,
+        limit=20
+    )
+
+    process_file("dummy.qwk", settings, mock_logger)
+
+    content = output_path.read_text(encoding="latin1")
+    assert "Message 10" in content

--- a/tests/test_qwk.py
+++ b/tests/test_qwk.py
@@ -81,6 +81,7 @@ def _make_settings(**overrides) -> ProcessingSettings:
         search_term=None,
         after=None,
         before=None,
+        limit=None,
     )
     defaults.update(overrides)
     return ProcessingSettings(**defaults)
@@ -113,6 +114,7 @@ def _make_cli_namespace(**overrides: object) -> argparse.Namespace:
         search_term=None,
         after=None,
         before=None,
+        limit=None,
         info=False,
     )
     base.update(overrides)


### PR DESCRIPTION
**PR Title:** [FEAT] Add --limit option to restrict the number of messages processed

**Description:**
* **What:** Added a `--limit` flag to the CLI and a `limit` field to `ProcessingSettings`. This allows users to restrict the output to a specific number of messages.
* **Why:** Large QWK archives can contain thousands of messages. When testing filters or just wanting a quick look at the content, processing the entire archive is inefficient. A limit allows for faster previews and more controlled exports.

**Changes:**
- **pyqwk/core.py**: Added `limit` to `ProcessingSettings` and implemented the break condition in the message loop within `process_file`.
- **pyqwk/cli.py**: Added the `--limit` argument to the `argparse` configuration and passed it to the settings.
- **README.md**: Added the `--limit` option to the Common Options table.
- **tests/test_limit.py**: New test suite for the limit feature.
- **tests/test_qwk.py**: Updated test helpers to support the new setting.

---
*PR created automatically by Jules for task [1798220174061778121](https://jules.google.com/task/1798220174061778121) started by @RainRat*