### PR TITLE
[UI/UX] [CLI] Add short flags for common filtering and control options

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,18 +116,20 @@ python qwk.py archive.qwk --from "Sysop" -C "Announcements"
 
 | Flag | Description |
 | :--- | :--- |
-| `-o [file/folder]` | Where to save the output. Defaults to screen. |
-| `-i` | Save each message as a separate file (cannot use with threaded). |
-| `--format [type]` | Output format: `text`, `html`, `json`, `xml`, `csv`, `mbox`, `sqlite`. |
-| `-T`, `--threaded` | Group replies together (ideal for reading conversations). |
+| `-o, --output [file/folder]` | Where to save the output. Defaults to screen. |
+| `-i, --individual-files` | Save each message as a separate file (cannot use with threaded). |
+| `-F, --format [type]` | Output format: `text`, `html`, `json`, `xml`, `csv`, `mbox`, `sqlite`. |
+| `-T, --threaded` | Group replies together (ideal for reading conversations). |
 | `--clean` | Remove "junk" like signatures, quotes, and binary data. |
-| `-p`, `--private` | Include private messages. |
-| `-C [conf]` | Filter by conference name or number. |
-| `--from [name]` | Filter by sender name. |
-| `--subject [text]` | Filter by subject line. |
-| `--search [text]` | Search in author, subject, and body. |
-| `--limit [num]` | Limit the number of messages processed. |
-| `--info` | Show a summary of the archive (counts, conferences) and exit. |
+| `-p, --private` | Include private messages. |
+| `-H, --headers-only` | Extract headers only, skip body content. |
+| `-C, --conference [conf]` | Filter by conference name or number. |
+| `-f, --from [name]` | Filter by sender name. |
+| `-s, --subject [text]` | Filter by subject line. |
+| `-S, --search [text]` | Search in author, subject, and body. |
+| `-L, --limit [num]` | Limit the number of messages processed. |
+| `-I, --info` | Show a summary of the archive (counts, conferences) and exit. |
+| `-V, --version` | Show version number and exit. |
 
 Run `python qwk.py --help` to see all options.
 

--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -144,6 +144,7 @@ def main() -> None:
         action='store_true',
     )
     content_group.add_argument(
+        '-H',
         '--headers-only',
         help='Extract only message headers, skipping body text (faster for metadata/stats).',
         action='store_true',
@@ -151,6 +152,7 @@ def main() -> None:
 
     format_group = parser.add_argument_group('Formatting & Structure')
     format_group.add_argument(
+        '-F',
         '--format',
         help=(
             'Choose the output format: text, json, xml, html, csv, mbox, or sqlite. '
@@ -207,18 +209,21 @@ def main() -> None:
         help='Filter messages by conference name or number (can be used multiple times).',
     )
     filter_group.add_argument(
+        '-f',
         '--from',
         dest='authors',
         action='append',
         help='Filter messages by author name (case-insensitive substring match).',
     )
     filter_group.add_argument(
+        '-s',
         '--subject',
         dest='subjects',
         action='append',
         help='Filter messages by subject line (case-insensitive substring match).',
     )
     filter_group.add_argument(
+        '-S',
         '--search',
         dest='search_term',
         help='Search for a keyword in author, subject, and message body.',
@@ -234,6 +239,7 @@ def main() -> None:
         default=None,
     )
     filter_group.add_argument(
+        '-L',
         '--limit',
         help='Limit the number of messages processed.',
         type=int,
@@ -241,11 +247,13 @@ def main() -> None:
     )
 
     parser.add_argument(
+        '-I',
         '--info',
         action='store_true',
         help='Show a summary of the QWK packet (conferences, message counts) and exit.',
     )
     parser.add_argument(
+        '-V',
         '--version',
         action='version',
         version=f"%(prog)s {__version__}",


### PR DESCRIPTION
Improved the CLI usability by adding short-flag aliases for common filtering and control options. This reduces friction for power users and follows standard CLI conventions.

New short flags added:
- `-f` for `--from`
- `-s` for `--subject`
- `-S` for `--search`
- `-L` for `--limit`
- `-F` for `--format`
- `-H` for `--headers-only`
- `-I` for `--info`
- `-V` for `--version`

The README.md was also updated to reflect these changes in the 'Common Options' table, ensuring consistency between the documentation and the tool's behavior.

---
*PR created automatically by Jules for task [12626282060048117421](https://jules.google.com/task/12626282060048117421) started by @RainRat*