### PR TITLE
Add Markdown export support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ pyqwk is a friendly tool to convert old `.QWK` mail archives (from the BBS era) 
 
 ## Features
 
-- **Multiple Formats:** Export to Text, HTML, JSON, XML, CSV, mbox, or SQLite.
+- **Multiple Formats:** Export to Text, HTML, JSON, XML, Markdown, CSV, mbox, or SQLite.
 - **Conversation Threading:** Group replies together to follow discussions easily.
 - **Content Cleaning:** Automatically remove signatures, old quotes, and binary attachments.
 - **Privacy:** Redact personal information and handle private messages.
@@ -73,6 +73,11 @@ qwk archive.qwk --format mbox -o messages.mbox
 **Convert to JSON for your own scripts:**
 ```bash
 qwk archive.qwk --format json -o data.json
+```
+
+**Save as Markdown:**
+```bash
+qwk archive.qwk --format markdown -o messages.md
 ```
 
 **Process a whole folder of archives:**
@@ -147,7 +152,7 @@ for msg in parse_messages(file_data, None):
 | :--- | :--- |
 | `-o`, `--output [path]` | Where to save the output. Prints to terminal by default. |
 | `-i`, `--individual-files` | Save each message as a separate file. |
-| `--format [type]` | Choose format: `text`, `html`, `json`, `xml`, `csv`, `mbox`, `sqlite`. |
+| `--format [type]` | Choose format: `text`, `html`, `json`, `xml`, `markdown`, `csv`, `mbox`, `sqlite`. |
 | `-T`, `--threaded` | Group replies together into conversations. |
 | `--clean` | Remove signatures, quotes, and binary data automatically. |
 | `--redact-pii` | Hide personal info like email addresses and phone numbers. |

--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -33,6 +33,8 @@ def _resolve_output_format(
                 return 'csv'
             if ext == '.mbox':
                 return 'mbox'
+            if ext == '.md' or ext == '.markdown':
+                return 'markdown'
             if ext == '.sqlite' or ext == '.db':
                 return 'sqlite'
         return 'text'
@@ -153,11 +155,11 @@ def main() -> None:
     format_group.add_argument(
         '--format',
         help=(
-            'Choose the output format: text, json, xml, html, csv, mbox, or sqlite. '
+            'Choose the output format: text, json, xml, html, markdown, csv, mbox, or sqlite. '
             '(Default: auto-detected from output filename, or text)'
         ),
         default=None,
-        choices=['text', 'json', 'xml', 'html', 'csv', 'mbox', 'sqlite'],
+        choices=['text', 'json', 'xml', 'html', 'markdown', 'csv', 'mbox', 'sqlite'],
     )
     format_group.add_argument(
         '--separator',

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -838,7 +838,7 @@ def process_file(
 
     separator_mode = settings.separator
     if separator_mode == 'auto':
-        if settings.individual_files or settings.format in ('json', 'xml', 'html', 'csv'):
+        if settings.individual_files or settings.format in ('json', 'xml', 'html', 'csv', 'markdown'):
             separator_mode = 'none'
         else:
             separator_mode = 'dashes'
@@ -873,7 +873,7 @@ def process_file(
                 settings.binaries_removal,
                 settings.redact_pii,
             )
-            if not settings.no_header and settings.format != 'html':
+            if not settings.no_header and settings.format not in ('html', 'markdown'):
                 leading_newlines = 0
                 text_prefix = parsed_message.text
                 while text_prefix.startswith('\r\n'):
@@ -889,7 +889,7 @@ def process_file(
                 processed_buffer = header_text + processed_buffer
 
             # Add separator for text format, or if headers are enabled (legacy behavior for non-text formats)
-            if settings.format == 'text' or (not settings.no_header and settings.format != 'html'):
+            if settings.format == 'text' or (not settings.no_header and settings.format not in ('html', 'markdown')):
                 processed_buffer = separator_str + processed_buffer
 
             if settings.individual_files:
@@ -912,6 +912,9 @@ def process_file(
                 elif settings.format == 'html':
                     temp_msg = replace(parsed_message, text=processed_buffer)
                     encoded_buffer = _serialize_message_html(temp_msg).encode(target_encoding)
+                elif settings.format == 'markdown':
+                    temp_msg = replace(parsed_message, text=processed_buffer)
+                    encoded_buffer = _serialize_message_markdown(temp_msg).encode(target_encoding)
                 elif settings.format == 'mbox':
                     temp_msg = replace(parsed_message, text=processed_buffer)
                     encoded_buffer = _serialize_message_mbox(temp_msg).encode(target_encoding)
@@ -952,6 +955,7 @@ def process_file(
             'json': _write_json,
             'xml': _write_xml,
             'html': _write_html,
+            'markdown': _write_markdown,
             'text': _write_text,
             'csv': _write_csv,
             'mbox': _write_mbox,
@@ -1091,6 +1095,29 @@ def _serialize_message_html(message: ProcessedMessage) -> str:
     return '\n'.join(html_parts)
 
 
+def _render_single_message_markdown(message: ProcessedMessage) -> list[str]:
+    header = message.header
+    parts = []
+    parts.append(f"## {header.msgsubject}")
+    parts.append(f"- **Date:** {header.msgdate} {header.msgtime}")
+    parts.append(f"- **From:** {header.msgfrom}")
+    parts.append(f"- **To:** {header.msgto}")
+    parts.append(f"- **Conference:** {header.confnum}")
+    if header.msgnum is not None:
+        parts.append(f"- **Number:** {header.msgnum}")
+    parts.append("")
+    parts.append(message.text.replace('\r\n', '\n'))
+    parts.append("")
+    parts.append("---")
+    return parts
+
+
+def _serialize_message_markdown(message: ProcessedMessage) -> str:
+    md_parts = ["# QWK Message\n"]
+    md_parts.extend(_render_single_message_markdown(message))
+    return '\n'.join(md_parts)
+
+
 def _write_html(
     messages: list[ProcessedMessage], output_path: str | None, encoding: str = 'utf-8'
 ) -> None:
@@ -1114,6 +1141,26 @@ def _write_html(
     html_parts.extend(_get_html_footer())
 
     _write_text_output('\n'.join(html_parts), output_path, encoding='utf-8')
+
+
+def _write_markdown(
+    messages: list[ProcessedMessage], output_path: str | None, encoding: str = 'utf-8'
+) -> None:
+    md_parts = ["# QWK Messages\n"]
+
+    for message in messages:
+        single_md = _render_single_message_markdown(message)
+        if message.depth > 0:
+            prefix = "> " * message.depth
+            indented_md = []
+            for line in single_md:
+                indented_md.append(f"{prefix}{line}".rstrip())
+            md_parts.extend(indented_md)
+        else:
+            md_parts.extend(single_md)
+        md_parts.append("")
+
+    _write_text_output('\n'.join(md_parts), output_path, encoding='utf-8')
 
 
 def _parse_qwk_date(msgdate: str, msgtime: str) -> datetime.datetime:
@@ -1429,6 +1476,8 @@ def process_multiple_files(
                 output_filename += '.xml'
             elif settings.format == 'html':
                 output_filename += '.html'
+            elif settings.format == 'markdown':
+                output_filename += '.md'
             elif settings.format == 'csv':
                 output_filename += '.csv'
             elif settings.format == 'mbox':

--- a/tests/test_markdown_output.py
+++ b/tests/test_markdown_output.py
@@ -1,0 +1,81 @@
+import pytest
+from unittest.mock import patch
+from pyqwk.core import _write_markdown, MessageHeader, ProcessedMessage
+
+def test_write_markdown_output():
+    header = MessageHeader(
+        status=' ',
+        msgnum=1,
+        msgdate='01-01-90',
+        msgtime='12:00',
+        msgto='User',
+        msgfrom='Sysop',
+        msgsubject='Welcome',
+        msgpassword='',
+        refnum=None,
+        numblocks=1,
+        msgflag='',
+        confnum=1,
+        lognum=1,
+        nettag=''
+    )
+    message = ProcessedMessage(
+        text='Hello World',
+        msgnum=1,
+        refnum=None,
+        confnum=1,
+        header=header,
+        depth=0,
+        thread_id='1',
+        parent_msgnum=None
+    )
+
+    with patch('pyqwk.core._write_text_output') as mock_write:
+        _write_markdown([message], None)
+
+        mock_write.assert_called_once()
+        content = mock_write.call_args[0][0]
+
+        assert "# QWK Messages" in content
+        assert "## Welcome" in content
+        assert "- **From:** Sysop" in content
+        assert "Hello World" in content
+        assert "---" in content
+
+def test_write_markdown_threaded():
+    header1 = MessageHeader(
+        status=' ', msgnum=1, msgdate='01-01-90', msgtime='12:00',
+        msgto='All', msgfrom='Sysop', msgsubject='Topic',
+        msgpassword='', refnum=None, numblocks=1, msgflag='',
+        confnum=1, lognum=1, nettag=''
+    )
+    header2 = MessageHeader(
+        status=' ', msgnum=2, msgdate='01-01-90', msgtime='12:05',
+        msgto='Sysop', msgfrom='User', msgsubject='Re: Topic',
+        msgpassword='', refnum=1, numblocks=1, msgflag='',
+        confnum=1, lognum=2, nettag=''
+    )
+
+    msg1 = ProcessedMessage(
+        text='Parent message', msgnum=1, refnum=None, confnum=1,
+        header=header1, depth=0, thread_id='1', parent_msgnum=None
+    )
+    msg2 = ProcessedMessage(
+        text='Child message', msgnum=2, refnum=1, confnum=1,
+        header=header2, depth=1, thread_id='1', parent_msgnum=1
+    )
+
+    with patch('pyqwk.core._write_text_output') as mock_write:
+        _write_markdown([msg1, msg2], None)
+
+        mock_write.assert_called_once()
+        content = mock_write.call_args[0][0]
+
+        # Check for child message with blockquote
+        assert "> ## Re: Topic" in content
+        assert "> - **From:** User" in content
+        assert "> Child message" in content
+        assert "> ---" in content
+
+        # Ensure parent is NOT blockquoted
+        assert "\n## Topic" in content


### PR DESCRIPTION
I have implemented Markdown export support in `pyqwk`. This feature allows users to convert QWK archives into Markdown format, which is highly useful for modern documentation and sharing.

The implementation includes:
- A new Markdown serializer and writer in `pyqwk/core.py`.
- Support for conversation threading using Markdown blockquotes.
- CLI updates to support the new format and auto-detect file extensions.
- Comprehensive tests ensuring the output is correctly formatted.
- Updated documentation in `README.md`.

---
*PR created automatically by Jules for task [9032166799242232501](https://jules.google.com/task/9032166799242232501) started by @RainRat*