### PR TITLE
Remove redundant assignments in parse_messages

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -581,7 +581,6 @@ def parse_messages(
                     "Invalid message header at offset %s; skipping block.",
                     i,
                 )
-                blocks_remaining = 0
                 continue
 
             current_msgnum = header.msgnum
@@ -595,7 +594,6 @@ def parse_messages(
                     getattr(header, '_numblocks_raw', header.numblocks),
                     i,
                 )
-                blocks_remaining = 0
                 continue
 
             blocks_remaining = header.numblocks - 1


### PR DESCRIPTION
This PR removes redundant assignments in `pyqwk/core.py` within the `parse_messages` function. These assignments occurred in error-handling paths that are only reachable when the variable is already set to zero. This change improves code clarity and follows "Senior Maintenance" principles by removing low-hanging fruit redundancy.

---
*PR created automatically by Jules for task [8226768066623089751](https://jules.google.com/task/8226768066623089751) started by @RainRat*