### PR TITLE
[TEST] Increase test coverage for CLI helpers and output formats

### DIFF
--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -1,0 +1,40 @@
+import pytest
+import datetime
+from pyqwk.cli import _parse_cli_date, _resolve_output_format
+
+def test_parse_cli_date_valid():
+    assert _parse_cli_date("2023-01-01") == datetime.datetime(2023, 1, 1)
+
+def test_parse_cli_date_end_of_day():
+    dt = _parse_cli_date("2023-01-01", end_of_day=True)
+    assert dt == datetime.datetime(2023, 1, 1, 23, 59, 59, 999999)
+
+def test_parse_cli_date_none():
+    assert _parse_cli_date(None) is None
+    assert _parse_cli_date("") is None
+
+def test_parse_cli_date_invalid():
+    with pytest.raises(ValueError, match="Invalid date format"):
+        _parse_cli_date("01-01-2023")
+    with pytest.raises(ValueError, match="Invalid date format"):
+        _parse_cli_date("2023-13-01")
+
+def test_resolve_output_format_explicit():
+    assert _resolve_output_format("json", "out.txt", "file") == "json"
+    assert _resolve_output_format("text", None, "stdout") == "text"
+
+def test_resolve_output_format_auto_detect():
+    assert _resolve_output_format(None, "out.json", "file") == "json"
+    assert _resolve_output_format(None, "out.xml", "file") == "xml"
+    assert _resolve_output_format(None, "out.html", "file") == "html"
+    assert _resolve_output_format(None, "out.csv", "file") == "csv"
+    assert _resolve_output_format(None, "out.mbox", "file") == "mbox"
+    assert _resolve_output_format(None, "out.md", "file") == "markdown"
+    assert _resolve_output_format(None, "out.markdown", "file") == "markdown"
+    assert _resolve_output_format(None, "out.sqlite", "file") == "sqlite"
+    assert _resolve_output_format(None, "out.db", "file") == "sqlite"
+
+def test_resolve_output_format_default():
+    assert _resolve_output_format(None, "out.foo", "file") == "text"
+    assert _resolve_output_format(None, None, "stdout") == "text"
+    assert _resolve_output_format(None, "somefile", "stdout") == "text"

--- a/tests/test_individual_files_formats.py
+++ b/tests/test_individual_files_formats.py
@@ -124,3 +124,45 @@ def test_individual_files_html_format(tmp_path: Path, baseline_path: Path, logge
         content = f.read()
         assert "<!DOCTYPE html>" in content or "<html>" in content
         assert '<div class="message">' in content
+
+def test_individual_files_markdown_format(tmp_path: Path, baseline_path: Path, logger: logging.Logger):
+    output_dir = tmp_path / "md_out"
+
+    process_file(
+        str(baseline_path),
+        _make_settings(
+            individual_files=True,
+            format="markdown",
+            output_mode="file",
+            output_path=str(output_dir),
+        ),
+        logger=logger,
+    )
+
+    files = list(output_dir.iterdir())
+    assert len(files) > 0
+    with files[0].open("r", encoding="utf-8") as f:
+        content = f.read()
+        assert "# QWK Message" in content
+        assert "## " in content
+
+def test_individual_files_mbox_format(tmp_path: Path, baseline_path: Path, logger: logging.Logger):
+    output_dir = tmp_path / "mbox_out"
+
+    process_file(
+        str(baseline_path),
+        _make_settings(
+            individual_files=True,
+            format="mbox",
+            output_mode="file",
+            output_path=str(output_dir),
+        ),
+        logger=logger,
+    )
+
+    files = list(output_dir.iterdir())
+    assert len(files) > 0
+    with files[0].open("r", encoding="utf-8") as f:
+        content = f.read()
+        assert content.startswith("From ")
+        assert "Subject: " in content

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -134,3 +134,26 @@ def test_show_info_json_format(capsys, mock_logger, default_settings):
     assert data[0]["bbs_info"]["sysop"] == "Ken Read"
     assert len(data[0]["conferences"]) == 1
     assert data[0]["conferences"][0]["number"] == 4
+
+def test_show_info_truncated_messages_dat(capsys, mock_logger, default_settings):
+    """Test handling of truncated messages.dat in show_info."""
+    import struct
+    with patch('pyqwk.core.load_data') as mock_load:
+        # First block: Produced header
+        # Second block: Valid message header that claims to have 5 blocks, but no body blocks follow
+        header = struct.pack(
+            '<c7s8s5s25s25s25s12s8s6scHHc',
+            b' ', b"1".ljust(7, b' '), b"01-01-90", b"12:00",
+            b"To".ljust(25, b' '), b"From".ljust(25, b' '), b"Subj".ljust(25, b' '),
+            b"".ljust(12, b' '), b"0".ljust(8, b' '),
+            b"5".ljust(6, b' '), # Claims 5 blocks
+            b' ', 1, 1, b' '
+        )
+        bad_data = bytearray(b'Produced ' + b'X' * (128 - 9) + header)
+        mock_load.return_value = (bad_data, {})
+
+        show_info(['truncated.zip'], default_settings, mock_logger)
+
+        captured = capsys.readouterr()
+        # Should not crash and should print the file path
+        assert "File: truncated.zip" in captured.out

--- a/tests/test_parser_edge_cases.py
+++ b/tests/test_parser_edge_cases.py
@@ -122,3 +122,11 @@ class TestParserEdgeCases:
             list(parse_messages(data, progress_bar=None))
 
         assert "Input too short" in str(exc.value)
+
+    def test_parse_messages_invalid_produced_header(self):
+        """
+        Verify that data that doesn't start with 'Produced ' raises MessagesDatFormatError.
+        """
+        data = bytearray(b"X" * 128)
+        with pytest.raises(MessagesDatFormatError, match="Input does not start with 'Produced '"):
+            list(parse_messages(data, progress_bar=None))


### PR DESCRIPTION
Identified and filled several coverage gaps in the test suite:
- Added tests/test_cli_helpers.py to cover date parsing and output format auto-detection in cli.py.
- Expanded tests/test_individual_files_formats.py to verify Markdown and Mbox formats in individual files mode.
- Added edge case tests for truncated files and invalid headers in tests/test_info.py and tests/test_parser_edge_cases.py.

Total coverage improved from 93% to 95%.
- pyqwk/cli.py: 81% -> 90%
- pyqwk/core.py: 95% -> 97%

---
*PR created automatically by Jules for task [15024414079946736423](https://jules.google.com/task/15024414079946736423) started by @RainRat*