### PR TITLE
[UI/UX] Add short aliases for common CLI flags to improve efficiency

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,18 +151,18 @@ for msg in parse_messages(file_data, None):
 | :--- | :--- |
 | `-o`, `--output [path]` | Where to save the output. Prints to terminal by default. |
 | `-i`, `--individual-files` | Save each message as a separate file. |
-| `--format [type]` | Choose format: `text`, `html`, `json`, `xml`, `markdown`, `csv`, `mbox`, `sqlite`. |
+| `-F, --format [type]` | Choose format: `text`, `html`, `json`, `xml`, `markdown`, `csv`, `mbox`, `sqlite`. |
 | `-T`, `--threaded` | Group replies together into conversations. |
 | `--clean` | Remove signatures, quotes, and binary data automatically. |
-| `--redact-pii` | Hide personal info like email addresses and phone numbers. |
-| `--headers-only` | Extract only message headers and skip the message body. |
-| `--encoding [name]` | Set the input text encoding (default is `cp437`). |
+| `-r, --redact-pii` | Hide personal info like email addresses and phone numbers. |
+| `-H, --headers-only` | Extract only message headers and skip the message body. |
+| `-E, --encoding [name]` | Set the input text encoding (default is `cp437`). |
 | `-p`, `--private` | Include private messages in the output. |
 | `-n`, `--noheader` | Do not include the message header info in the text. |
 | `-v`, `--verbose` | Show more details like conference names and message numbers. |
 | `-q`, `--quiet` | Hide the progress bar and extra info. |
-| `--limit [num]` | Stop after processing this many messages. |
-| `--info` | Show a summary of the archive and exit. |
+| `-L, --limit [num]` | Stop after processing this many messages. |
+| `-I, --info` | Show a summary of the archive and exit. |
 
 Run `qwk --help` to see all available options.
 

--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -100,6 +100,7 @@ def main() -> None:
         action='store_true',
     )
     io_group.add_argument(
+        '-E',
         '--encoding',
         help='Character encoding of the input file (default: cp437)',
         default='cp437',
@@ -146,6 +147,7 @@ def main() -> None:
         action='store_true',
     )
     content_group.add_argument(
+        '-H',
         '--headers-only',
         help='Extract only message headers, skipping body text (faster for metadata/stats).',
         action='store_true',
@@ -153,6 +155,7 @@ def main() -> None:
 
     format_group = parser.add_argument_group('Formatting & Structure')
     format_group.add_argument(
+        '-F',
         '--format',
         help=(
             'Choose the output format: text, json, xml, html, markdown, csv, mbox, or sqlite. '
@@ -209,6 +212,7 @@ def main() -> None:
         help='Filter messages by conference name or number (can be used multiple times).',
     )
     filter_group.add_argument(
+        '-f',
         '--from',
         dest='authors',
         action='append',
@@ -221,12 +225,14 @@ def main() -> None:
         help='Filter messages by recipient name (case-insensitive substring match).',
     )
     filter_group.add_argument(
+        '-s',
         '--subject',
         dest='subjects',
         action='append',
         help='Filter messages by subject line (case-insensitive substring match).',
     )
     filter_group.add_argument(
+        '-S',
         '--search',
         dest='search_term',
         help='Search for a keyword in author, subject, and message body.',
@@ -242,6 +248,7 @@ def main() -> None:
         default=None,
     )
     filter_group.add_argument(
+        '-L',
         '--limit',
         help='Limit the number of messages processed.',
         type=int,
@@ -249,11 +256,13 @@ def main() -> None:
     )
 
     parser.add_argument(
+        '-I',
         '--info',
         action='store_true',
         help='Show a summary of the QWK packet (BBS info, conferences, message counts) and exit. (Respects --format json)',
     )
     parser.add_argument(
+        '-V',
         '--version',
         action='version',
         version=f"%(prog)s {__version__}",


### PR DESCRIPTION
This improvement focuses on **Friction Reduction** and **Efficiency** for CLI power users. By adding standard short-form aliases for common flags, the tool becomes much faster to use for routine tasks like searching, filtering, and inspecting archive metadata.

### Changes:
1.  **pyqwk/cli.py**: Added short aliases for the following arguments:
    - `-I` for `--info`
    - `-V` for `--version`
    - `-H` for `--headers-only`
    - `-f` for `--from`
    - `-s` for `--subject`
    - `-S` for `--search`
    - `-L` for `--limit`
    - `-F` for `--format`
    - `-E` for `--encoding`
2.  **README.md**: Updated the "Common Options" table to include the newly added short flags, ensuring documentation is consistent with the code.

All existing tests (242) passed after these changes.

---
*PR created automatically by Jules for task [12186926014489596568](https://jules.google.com/task/12186926014489596568) started by @RainRat*