### PR TITLE
Optimize message threading and sync date parsing tests

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -1539,6 +1539,7 @@ def _order_messages_by_thread(messages: list[ProcessedMessage]) -> list[Processe
     logger = logging.getLogger(__name__)
     index_by_key: dict[tuple[int, int], int] = {}
     index_by_subject: dict[tuple[int, str], list[int]] = defaultdict(list)
+    normalized_subjects: list[str] = []
     children: dict[int, list[int]] = defaultdict(list)
     roots: list[int] = []
 
@@ -1548,6 +1549,7 @@ def _order_messages_by_thread(messages: list[ProcessedMessage]) -> list[Processe
             index_by_key[(message.confnum, message.msgnum)] = index
 
         subj = _normalize_subject(message.header.msgsubject)
+        normalized_subjects.append(subj)
         if subj:
             index_by_subject[(message.confnum, subj)].append(index)
 
@@ -1571,7 +1573,7 @@ def _order_messages_by_thread(messages: list[ProcessedMessage]) -> list[Processe
 
         # Fallback: Subject matching
         if parent_index is None:
-            subj = _normalize_subject(message.header.msgsubject)
+            subj = normalized_subjects[index]
             if subj:
                 candidates = index_by_subject.get((message.confnum, subj), [])
                 # Prefer candidates that appear before this message

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -14,9 +14,9 @@ def test_parse_cli_date_none():
     assert _parse_cli_date("") is None
 
 def test_parse_cli_date_invalid():
-    with pytest.raises(ValueError, match="Invalid date format"):
+    with pytest.raises(ValueError, match="is invalid. Please use YYYY-MM-DD"):
         _parse_cli_date("01-01-2023")
-    with pytest.raises(ValueError, match="Invalid date format"):
+    with pytest.raises(ValueError, match="is invalid. Please use YYYY-MM-DD"):
         _parse_cli_date("2023-13-01")
 
 def test_resolve_output_format_explicit():


### PR DESCRIPTION
This PR addresses two primary improvements:
1. **Performance Optimization (Duplication)**: In the `_order_messages_by_thread` function, subject normalization was previously performed twice for every message. By caching the normalized subject strings in a local list during the first indexing pass, we eliminate redundant calls to `_normalize_subject` (and its underlying regex operations) in the second pass.
2. **Test Synchronization (Logic Bug/Consistency)**: The CLI date parsing test was failing because its expected error message did not match the descriptive message produced by the code. This PR updates the test to align with the current implementation.

Verified with `pytest`, all 254 tests now pass.

---
*PR created automatically by Jules for task [7868141163366554592](https://jules.google.com/task/7868141163366554592) started by @RainRat*