### PR TITLE
[FEAT] Add ANSI escape sequence stripping

### DIFF
--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -110,7 +110,7 @@ def main() -> None:
     content_group = parser.add_argument_group('Content Processing')
     content_group.add_argument(
         '--clean',
-        help='Clean the message by removing signatures, old quotes, and binary data.',
+        help='Clean the message by removing signatures, old quotes, binary data, and ANSI colors.',
         action='store_true',
     )
     content_group.add_argument(
@@ -139,6 +139,13 @@ def main() -> None:
         '--redact-pii',
         dest='redactpii',
         help='Hide personal info like email addresses and phone numbers.',
+        action='store_true',
+    )
+    content_group.add_argument(
+        '-A',
+        '--strip-ansi',
+        dest='stripansi',
+        help='Remove ANSI escape sequences (colors) from the message text.',
         action='store_true',
     )
     content_group.add_argument(
@@ -340,6 +347,7 @@ def main() -> None:
         merge=args.merge,
         binaries_removal=args.binariesremoval or args.clean,
         redact_pii=args.redactpii,
+        strip_ansi=args.stripansi or args.clean,
         quiet=args.quiet,
         headers_only=args.headers_only,
         format=output_format,

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -50,6 +50,8 @@ RE_SUBJECT_PREFIX_PATTERN = re.compile(
     r'^\s*(?:re|fw|fwd)(?:\[\d+\])?[:\s-]+\s*', re.IGNORECASE
 )
 
+RE_ANSI_ESCAPE_PATTERN = re.compile(r'\x1b\[[0-?]*[ -/]*[@-~]')
+
 SIGNATURE_PATTERNS_EXACT = {
     "---",
     "___",
@@ -132,6 +134,7 @@ class ProcessingSettings:
     output_mode: str
     output_path: str | None
     encoding: str
+    strip_ansi: bool = False
     quiet: bool = False
     headers_only: bool = False
     merge: bool = False
@@ -635,6 +638,7 @@ def process_message(
     cut_quoting: bool,
     binaries_removal: bool,
     redact_pii: bool,
+    strip_ansi: bool = False,
 ) -> str:
     """Transform a raw message body according to processing settings.
 
@@ -644,6 +648,7 @@ def process_message(
         cut_quoting: Whether to remove quoted text and quote headers.
         binaries_removal: Whether to strip uuencoded, Base64, and yEnc payloads.
         redact_pii: Whether to redact email addresses and phone numbers.
+        strip_ansi: Whether to remove ANSI escape sequences from the text.
 
     Returns:
         The processed message text with transformations applied.
@@ -679,6 +684,8 @@ def process_message(
         if redact_pii:
             line = RE_EMAIL_PATTERN.sub('[EMAIL]', line)
             line = RE_PHONE_PATTERN.sub('[PHONE]', line)
+        if strip_ansi:
+            line = RE_ANSI_ESCAPE_PATTERN.sub('', line)
         new_lines.append(line)
         previous_line = line
 
@@ -872,6 +879,7 @@ def process_merged_files(
                     settings.cut_quoting,
                     settings.binaries_removal,
                     settings.redact_pii,
+                    settings.strip_ansi,
                 )
                 if not settings.no_header and settings.format not in ('html', 'markdown'):
                     leading_newlines = 0

--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -32,6 +32,7 @@ class QwkGuiApp:
         self.clean_var = tk.BooleanVar(value=False)
         self.private_var = tk.BooleanVar(value=False)
         self.redact_var = tk.BooleanVar(value=False)
+        self.ansi_var = tk.BooleanVar(value=False)
         self.threaded_var = tk.BooleanVar(value=False)
 
         self.search_var = tk.StringVar()
@@ -111,6 +112,7 @@ class QwkGuiApp:
             ("Clean", self.clean_var),
             ("Include Private", self.private_var),
             ("Redact PII", self.redact_var),
+            ("Strip ANSI", self.ansi_var),
             ("Threaded", self.threaded_var),
         ]:
             ttk.Checkbutton(
@@ -210,6 +212,7 @@ class QwkGuiApp:
             threaded=self.threaded_var.get(),
             binaries_removal=clean,
             redact_pii=self.redact_var.get(),
+            strip_ansi=clean or self.ansi_var.get(),
             format='text',
             separator='none',
             output_mode='stdout',
@@ -320,6 +323,7 @@ class QwkGuiApp:
                     settings.cut_quoting,
                     settings.binaries_removal,
                     settings.redact_pii,
+                    settings.strip_ansi,
                 )
                 messages.append(replace(parsed_message, text=processed_buffer))
 

--- a/tests/test_content_processing.py
+++ b/tests/test_content_processing.py
@@ -205,3 +205,30 @@ def test_process_message_removes_consecutive_loose_uue_lines() -> None:
         redact_pii=False,
     )
     assert processed == "Intro\r\nOutro\r\n"
+
+
+def test_process_message_strips_ansi_escapes() -> None:
+    # ESC [ 31 m (Red) Body ESC [ 0 m (Reset)
+    message = "Intro\r\n\x1b[31mRed Text\x1b[0m\r\nOutro\r\n"
+
+    # Test with stripping ENABLED
+    processed_enabled = process_message(
+        message,
+        truncate_signatures=False,
+        cut_quoting=False,
+        binaries_removal=False,
+        redact_pii=False,
+        strip_ansi=True,
+    )
+    assert processed_enabled == "Intro\r\nRed Text\r\nOutro\r\n"
+
+    # Test with stripping DISABLED
+    processed_disabled = process_message(
+        message,
+        truncate_signatures=False,
+        cut_quoting=False,
+        binaries_removal=False,
+        redact_pii=False,
+        strip_ansi=False,
+    )
+    assert processed_disabled == "Intro\r\n\x1b[31mRed Text\x1b[0m\r\nOutro\r\n"

--- a/tests/test_qwk.py
+++ b/tests/test_qwk.py
@@ -103,6 +103,7 @@ def _make_cli_namespace(**overrides: object) -> argparse.Namespace:
         merge=False,
         binariesremoval=False,
         redactpii=False,
+        stripansi=False,
         clean=False,
         quiet=False,
         headers_only=False,


### PR DESCRIPTION
This PR adds a new feature to strip ANSI escape sequences from QWK message content. This is a common requirement for processing BBS-era archives, as they often contain color codes that can clutter modern text-based exports or break simple text readers like Tkinter.

Key changes:
- `pyqwk/core.py`: Implementation of the stripping logic using regex in the message processing loop.
- `pyqwk/cli.py`: New `--strip-ansi` flag and updated `--clean` flag.
- `pyqwk/gui.py`: Added a standalone "Strip ANSI" toggle and updated the "Clean" option to include ANSI stripping.
- `tests/test_content_processing.py`: Added tests to verify correct stripping.
- `tests/test_qwk.py`: Updated test mocks for compatibility.

---
*PR created automatically by Jules for task [12029725328550861183](https://jules.google.com/task/12029725328550861183) started by @RainRat*