### PR TITLE
[TEST] Implement stateful base64 binary detection

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -31,6 +31,7 @@ RE_UUE_DATA_PATTERN = re.compile(r'^M[\x21-\x60]{60}$')
 RE_UUE_LOOSE_PATTERN = re.compile(r'[\x21-\x4c][\x21-\x60]{4,60}$')
 RE_BASE64_PATTERN = re.compile(r'^[A-Za-z0-9+/=]{60,}$')
 RE_YENC_PATTERN = re.compile(r'^=y(begin|part|end)')
+RE_BASE64_LOOSE_PATTERN = re.compile(r'^[A-Za-z0-9+/=]{4,}$')
 RE_EMAIL_PATTERN = re.compile(r'\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b')
 RE_PHONE_PATTERN = re.compile(
     r'(?<!\w)'
@@ -80,37 +81,43 @@ def _is_binary_line(
     previous_line: str | None,
     in_yenc_block: bool,
     in_uue_block: bool,
-) -> tuple[bool, bool, bool]:
+    in_base64_block: bool,
+) -> tuple[bool, bool, bool, bool]:
     """Detect whether a line is part of a binary payload.
 
-    Returns a tuple ``(should_skip, in_yenc_block, in_uue_block)`` indicating whether the
+    Returns a tuple ``(should_skip, in_yenc_block, in_uue_block, in_base64_block)`` indicating whether the
     caller should exclude the line from output and the updated binary block states.
     """
+    if in_base64_block:
+        if RE_BASE64_LOOSE_PATTERN.match(line):
+            return True, in_yenc_block, in_uue_block, True
+        in_base64_block = False
+
     is_yenc_marker = RE_YENC_PATTERN.match(line)
 
     if is_yenc_marker:
-        return True, not line.startswith('=yend'), in_uue_block
+        return True, not line.startswith('=yend'), in_uue_block, in_base64_block
 
     if in_yenc_block:
-        return True, True, in_uue_block
+        return True, True, in_uue_block, in_base64_block
 
     if in_uue_block:
         if line.strip() == 'end':
-            return True, in_yenc_block, False
-        return True, in_yenc_block, True
+            return True, in_yenc_block, False, in_base64_block
+        return True, in_yenc_block, True, in_base64_block
 
     if RE_BASE64_PATTERN.match(line):
-        return True, in_yenc_block, in_uue_block
+        return True, in_yenc_block, in_uue_block, True
     elif RE_UUE_DATA_PATTERN.match(line) or RE_UUE_PATTERN.match(line):
-        return True, in_yenc_block, True
+        return True, in_yenc_block, True, in_base64_block
     elif RE_UUE_LOOSE_PATTERN.match(line):
         if previous_line and (
             RE_UUE_DATA_PATTERN.match(previous_line)
             or RE_UUE_PATTERN.match(previous_line)
         ):
-            return True, in_yenc_block, True
+            return True, in_yenc_block, True, in_base64_block
 
-    return False, in_yenc_block, False
+    return False, in_yenc_block, False, in_base64_block
 
 
 class ProgressBar(Protocol):
@@ -659,6 +666,7 @@ def process_message(
     new_lines = []
     in_yenc_block = False
     in_uue_block = False
+    in_base64_block = False
     previous_line: str | None = None
     for j, line in enumerate(lines):
         if truncate_signatures and (
@@ -674,8 +682,8 @@ def process_message(
                 and RE_QUOTE_PATTERN.match(lines[j + 1]):
                 continue
         if binaries_removal:
-            should_skip, in_yenc_block, in_uue_block = _is_binary_line(
-                line, previous_line, in_yenc_block, in_uue_block
+            should_skip, in_yenc_block, in_uue_block, in_base64_block = _is_binary_line(
+                line, previous_line, in_yenc_block, in_uue_block, in_base64_block
             )
             if should_skip:
                 previous_line = line

--- a/tests/repro_uue_bug.py
+++ b/tests/repro_uue_bug.py
@@ -3,25 +3,25 @@ from pyqwk.core import _is_binary_line
 def test_uue_backtick_line():
     # Start UUE block
     line1 = "begin 644 test.txt"
-    skip1, in_yenc1, in_uue1 = _is_binary_line(line1, None, False, False)
+    skip1, in_yenc1, in_uue1, in_b64_1 = _is_binary_line(line1, None, False, False, False)
     assert skip1 is True
     assert in_uue1 is True
 
     # Data line
     line2 = "M" + ("A" * 60)
-    skip2, in_yenc2, in_uue2 = _is_binary_line(line2, line1, False, in_uue1)
+    skip2, in_yenc2, in_uue2, in_b64_2 = _is_binary_line(line2, line1, False, in_uue1, False)
     assert skip2 is True
     assert in_uue2 is True
 
     # Backtick line (common in UUE before 'end')
     line3 = "`"
-    skip3, in_yenc3, in_uue3 = _is_binary_line(line3, line2, False, in_uue2)
+    skip3, in_yenc3, in_uue3, in_b64_3 = _is_binary_line(line3, line2, False, in_uue2, False)
 
     print(f"Backtick line: skip={skip3}, in_uue={in_uue3}")
 
     # End line
     line4 = "end"
-    skip4, in_yenc4, in_uue4 = _is_binary_line(line4, line3, False, in_uue3)
+    skip4, in_yenc4, in_uue4, in_b64_4 = _is_binary_line(line4, line3, False, in_uue3, False)
     print(f"End line: skip={skip4}, in_uue={in_uue4}")
 
 if __name__ == "__main__":

--- a/tests/test_binary_detection.py
+++ b/tests/test_binary_detection.py
@@ -12,18 +12,53 @@ class TestBinaryDetection:
 
     def test_detects_yenc_start(self):
         line = "=ybegin line=128 size=12345 name=test.zip"
-        skip, in_yenc, in_uue = _is_binary_line(
-            line, previous_line=None, in_yenc_block=False, in_uue_block=False
+        skip, in_yenc, in_uue, in_b64 = _is_binary_line(
+            line, previous_line=None, in_yenc_block=False, in_uue_block=False, in_base64_block=False
         )
         assert skip is True
         assert in_yenc is True
         assert in_uue is False
 
+    def test_detects_multi_line_base64_block(self):
+        # Test that multiple lines of base64 are skipped, including a short trailing one
+        line1 = "A" * 65 # Strict
+        line2 = "B" * 65 # Strict
+        line3 = "C" * 20 # Loose
+        line4 = "Normal Text"
+
+        # Line 1: Strict -> Enter block
+        skip1, in_yenc1, in_uue1, in_b64_1 = _is_binary_line(
+            line1, None, False, False, False
+        )
+        assert skip1 is True
+        assert in_b64_1 is True
+
+        # Line 2: Strict while in block -> Stay in block
+        skip2, in_yenc2, in_uue2, in_b64_2 = _is_binary_line(
+            line2, line1, in_yenc1, in_uue1, in_b64_1
+        )
+        assert skip2 is True
+        assert in_b64_2 is True
+
+        # Line 3: Loose while in block -> Stay in block/Skip
+        skip3, in_yenc3, in_uue3, in_b64_3 = _is_binary_line(
+            line3, line2, in_yenc2, in_uue2, in_b64_2
+        )
+        assert skip3 is True
+        assert in_b64_3 is True
+
+        # Line 4: Normal text -> Exit block/Keep
+        skip4, in_yenc4, in_uue4, in_b64_4 = _is_binary_line(
+            line4, line3, in_yenc3, in_uue3, in_b64_3
+        )
+        assert skip4 is False
+        assert in_b64_4 is False
+
     def test_uue_backtick_inside_block(self):
         # Backtick is a valid UUE line (zero length) but often doesn't match data patterns
         line = "`"
-        skip, in_yenc, in_uue = _is_binary_line(
-            line, previous_line=None, in_yenc_block=False, in_uue_block=True
+        skip, in_yenc, in_uue, in_b64 = _is_binary_line(
+            line, previous_line=None, in_yenc_block=False, in_uue_block=True, in_base64_block=False
         )
         assert skip is True
         assert in_uue is True
@@ -31,16 +66,16 @@ class TestBinaryDetection:
     def test_uue_skips_until_end(self):
         # Any garbage inside a UUE block should be skipped until 'end'
         line = "This is not UUE data"
-        skip, in_yenc, in_uue = _is_binary_line(
-            line, previous_line=None, in_yenc_block=False, in_uue_block=True
+        skip, in_yenc, in_uue, in_b64 = _is_binary_line(
+            line, previous_line=None, in_yenc_block=False, in_uue_block=True, in_base64_block=False
         )
         assert skip is True
         assert in_uue is True
 
     def test_detects_yenc_body(self):
         line = "random_yenc_data"
-        skip, in_yenc, in_uue = _is_binary_line(
-            line, previous_line=None, in_yenc_block=True, in_uue_block=False
+        skip, in_yenc, in_uue, in_b64 = _is_binary_line(
+            line, previous_line=None, in_yenc_block=True, in_uue_block=False, in_base64_block=False
         )
         assert skip is True
         assert in_yenc is True
@@ -48,8 +83,8 @@ class TestBinaryDetection:
 
     def test_detects_yenc_end(self):
         line = "=yend size=12345 crc32=12345678"
-        skip, in_yenc, in_uue = _is_binary_line(
-            line, previous_line=None, in_yenc_block=True, in_uue_block=False
+        skip, in_yenc, in_uue, in_b64 = _is_binary_line(
+            line, previous_line=None, in_yenc_block=True, in_uue_block=False, in_base64_block=False
         )
         assert skip is True
         assert in_yenc is False
@@ -57,8 +92,8 @@ class TestBinaryDetection:
 
     def test_detects_uue_start(self):
         line = "begin 644 test.txt"
-        skip, in_yenc, in_uue = _is_binary_line(
-            line, previous_line=None, in_yenc_block=False, in_uue_block=False
+        skip, in_yenc, in_uue, in_b64 = _is_binary_line(
+            line, previous_line=None, in_yenc_block=False, in_uue_block=False, in_base64_block=False
         )
         assert skip is True
         assert in_yenc is False
@@ -67,8 +102,8 @@ class TestBinaryDetection:
     def test_detects_uue_data_strict(self):
         # Strict UUE line starts with 'M' and is 61 chars long (M + 60 chars)
         line = "M" + ("A" * 60)
-        skip, in_yenc, in_uue = _is_binary_line(
-            line, previous_line=None, in_yenc_block=False, in_uue_block=True
+        skip, in_yenc, in_uue, in_b64 = _is_binary_line(
+            line, previous_line=None, in_yenc_block=False, in_uue_block=True, in_base64_block=False
         )
         assert skip is True
         assert in_yenc is False
@@ -77,8 +112,8 @@ class TestBinaryDetection:
     def test_detects_uue_loose_inside_block(self):
         # Loose pattern allows other start chars and lengths
         line = "L" + ("A" * 50)
-        skip, in_yenc, in_uue = _is_binary_line(
-            line, previous_line=None, in_yenc_block=False, in_uue_block=True
+        skip, in_yenc, in_uue, in_b64 = _is_binary_line(
+            line, previous_line=None, in_yenc_block=False, in_uue_block=True, in_base64_block=False
         )
         assert skip is True
         assert in_yenc is False
@@ -88,8 +123,8 @@ class TestBinaryDetection:
         # If we are NOT in a block, but previous line was UUE, we should enter block/skip
         line = "L" + ("A" * 50)
         previous = "M" + ("A" * 60)
-        skip, in_yenc, in_uue = _is_binary_line(
-            line, previous_line=previous, in_yenc_block=False, in_uue_block=False
+        skip, in_yenc, in_uue, in_b64 = _is_binary_line(
+            line, previous_line=previous, in_yenc_block=False, in_uue_block=False, in_base64_block=False
         )
         assert skip is True
         assert in_yenc is False
@@ -99,8 +134,8 @@ class TestBinaryDetection:
         # Loose pattern on its own should not trigger UUE if not already in block or following UUE
         line = "L" + ("A" * 50)
         previous = "Normal line"
-        skip, in_yenc, in_uue = _is_binary_line(
-            line, previous_line=previous, in_yenc_block=False, in_uue_block=False
+        skip, in_yenc, in_uue, in_b64 = _is_binary_line(
+            line, previous_line=previous, in_yenc_block=False, in_uue_block=False, in_base64_block=False
         )
         assert skip is False
         assert in_yenc is False
@@ -108,8 +143,8 @@ class TestBinaryDetection:
 
     def test_detects_uue_end(self):
         line = "end"
-        skip, in_yenc, in_uue = _is_binary_line(
-            line, previous_line=None, in_yenc_block=False, in_uue_block=True
+        skip, in_yenc, in_uue, in_b64 = _is_binary_line(
+            line, previous_line=None, in_yenc_block=False, in_uue_block=True, in_base64_block=False
         )
         assert skip is True
         assert in_yenc is False
@@ -117,8 +152,8 @@ class TestBinaryDetection:
 
     def test_stays_in_uue_on_invalid_line(self):
         line = "Not a uue line"
-        skip, in_yenc, in_uue = _is_binary_line(
-            line, previous_line=None, in_yenc_block=False, in_uue_block=True
+        skip, in_yenc, in_uue, in_b64 = _is_binary_line(
+            line, previous_line=None, in_yenc_block=False, in_uue_block=True, in_base64_block=False
         )
         # We should stay in UUE block and skip the line
         assert skip is True
@@ -129,19 +164,19 @@ class TestBinaryDetection:
         line = "VGhpcyBpcyBhIHRlc3QgbWVzc2FnZQ==" # Base64 for "This is a test message"
         # It needs to be at least 60 chars according to RE_BASE64_PATTERN in qwk.py
         line = "A" * 65
-        skip, in_yenc, in_uue = _is_binary_line(
-            line, previous_line=None, in_yenc_block=False, in_uue_block=False
+        skip, in_yenc, in_uue, in_b64 = _is_binary_line(
+            line, previous_line=None, in_yenc_block=False, in_uue_block=False, in_base64_block=False
         )
         assert skip is True
-        # Base64 doesn't set a state in this implementation, it just skips
+        assert in_b64 is True
         assert in_yenc is False
         assert in_uue is False
 
     def test_base64_preserves_state(self):
         # If we happen to see base64 inside a yenc block (unlikely but possible), state should be preserved
         line = "A" * 65
-        skip, in_yenc, in_uue = _is_binary_line(
-            line, previous_line=None, in_yenc_block=True, in_uue_block=False
+        skip, in_yenc, in_uue, in_b64 = _is_binary_line(
+            line, previous_line=None, in_yenc_block=True, in_uue_block=False, in_base64_block=False
         )
         assert skip is True
         assert in_yenc is True


### PR DESCRIPTION
Improved base64 binary removal by implementing stateful tracking of base64 blocks, ensuring short trailing lines are correctly identified and skipped. Added supporting tests and updated existing ones to match the new internal API.

---
*PR created automatically by Jules for task [12939436245457036113](https://jules.google.com/task/12939436245457036113) started by @RainRat*