### PR TITLE
[FEAT] Enhanced Mbox Threading and Metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ qwk archive.qwk --format html -o messages.html
 ```bash
 qwk archive.qwk --format mbox -o messages.mbox
 ```
+*Tip: Use `--threaded` to include standard email threading headers for better organization in your mail app.*
 
 **Convert to JSON for your own scripts:**
 ```bash

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -183,6 +183,7 @@ class ParsedMessage:
     depth: int = 0
     thread_id: str | None = None
     parent_msgnum: int | None = None
+    confname: str | None = None
 
 
 
@@ -866,6 +867,10 @@ def process_merged_files(
                 settings.encoding,
                 settings.headers_only,
             ):
+                parsed_message = replace(
+                    parsed_message,
+                    confname=board_dict.get(parsed_message.confnum)
+                )
                 if not matches_filters(parsed_message, settings, allowed_conferences):
                     continue
 
@@ -1214,7 +1219,11 @@ def _parse_qwk_date(msgdate: str, msgtime: str) -> datetime.datetime:
 
 
 def _serialize_message_mbox(message: ProcessedMessage) -> str:
-    """Serialize a message to mbox format."""
+    """Serialize a message to mbox format with threading and metadata.
+
+    Includes standard email headers for threading (Message-ID, In-Reply-To, References)
+    and custom X-QWK headers for conference names, message numbers, and statuses.
+    """
     header = message.header
 
     # Parse date
@@ -1256,7 +1265,26 @@ def _serialize_message_mbox(message: ProcessedMessage) -> str:
     # <confnum.msgnum@qwk>
     msg_id = f"<{header.confnum}.{header.msgnum if header.msgnum is not None else 'x'}@qwk>"
     parts.append(f"Message-ID: {msg_id}")
+
+    # Threading headers
+    if message.parent_msgnum is not None:
+        parent_id = f"<{header.confnum}.{message.parent_msgnum}@qwk>"
+        parts.append(f"In-Reply-To: {parent_id}")
+        parts.append(f"References: {parent_id}")
+
+    # QWK Metadata headers
     parts.append(f"X-QWK-Conference: {header.confnum}")
+    if message.confname:
+        parts.append(f"X-QWK-Conference-Name: {message.confname}")
+    if header.msgnum is not None:
+        parts.append(f"X-QWK-Message-Number: {header.msgnum}")
+    if header.status.strip():
+        parts.append(f"X-QWK-Status: {header.status}")
+    if header.msgflag.strip():
+        parts.append(f"X-QWK-Flags: {header.msgflag}")
+
+    parts.append("Content-Type: text/plain; charset=utf-8")
+    parts.append("Content-Transfer-Encoding: 8bit")
 
     parts.append("")  # Separator before body
     parts.append(body)

--- a/tests/test_mbox_output.py
+++ b/tests/test_mbox_output.py
@@ -60,6 +60,25 @@ def test_serialize_message_mbox_format(sample_message):
     # Check Body
     assert "This is the body." in mbox_content
 
+def test_serialize_message_mbox_with_metadata(sample_message):
+    sample_message.confname = "Main Board"
+    sample_message.header.status = "*"
+    sample_message.header.msgflag = " "
+
+    mbox_content = _serialize_message_mbox(sample_message)
+
+    assert "X-QWK-Conference-Name: Main Board" in mbox_content
+    assert "X-QWK-Message-Number: 123" in mbox_content
+    assert "X-QWK-Status: *" in mbox_content
+    assert "Content-Type: text/plain; charset=utf-8" in mbox_content
+
+def test_serialize_message_mbox_threading(sample_message):
+    sample_message.parent_msgnum = 100
+    mbox_content = _serialize_message_mbox(sample_message)
+
+    assert "In-Reply-To: <1.100@qwk>" in mbox_content
+    assert "References: <1.100@qwk>" in mbox_content
+
 def test_write_mbox_multiple(tmp_path, sample_message):
     output_file = tmp_path / "output.mbox"
 


### PR DESCRIPTION
Enhanced the mbox export format by adding standard email threading headers (In-Reply-To, References) and various QWK-specific metadata headers (X-QWK-Conference-Name, X-QWK-Message-Number, X-QWK-Status, X-QWK-Flags). This allows modern mail clients to properly thread conversations and preserves valuable archive metadata. Updated ParsedMessage to include a confname field and updated the processing loop to populate it. Verified with new test cases and ran the full test suite.

---
*PR created automatically by Jules for task [15301290609240439352](https://jules.google.com/task/15301290609240439352) started by @RainRat*