### PR TITLE
Strip conference names and add encoding fallback in CONTROL.DAT

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -533,8 +533,7 @@ def _parse_control_dat(
                 conf_number_raw,
             )
             continue
-        conf_name = conf_name_raw.decode(encoding)
-        board_dict[conf_number] = conf_name
+        board_dict[conf_number] = dec(conf_name_raw)
 
     return board_dict
 


### PR DESCRIPTION
Improved data quality by stripping trailing spaces from conference names parsed from CONTROL.DAT. This also ensures consistent encoding fallback for these names, matching other BBS metadata fields. Added a reproduction script to verify the issue and ensured all tests pass.

---
*PR created automatically by Jules for task [9739159239230312901](https://jules.google.com/task/9739159239230312901) started by @RainRat*