### PR TITLE
Fix redundant text separators in SQLite and MBOX exports

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -851,7 +851,9 @@ def process_merged_files(
 
     separator_mode = settings.separator
     if separator_mode == 'auto':
-        if settings.individual_files or settings.format in ('json', 'xml', 'html', 'csv', 'markdown'):
+        if settings.individual_files or settings.format in (
+            'json', 'xml', 'html', 'csv', 'markdown', 'sqlite', 'mbox'
+        ):
             separator_mode = 'none'
         else:
             separator_mode = 'dashes'

--- a/tests/test_fix_separators.py
+++ b/tests/test_fix_separators.py
@@ -1,0 +1,74 @@
+import logging
+import os
+import sqlite3
+import pytest
+from pathlib import Path
+from pyqwk.core import process_file, ProcessingSettings
+
+@pytest.fixture
+def logger():
+    logger = logging.getLogger("pyqwk.tests")
+    logger.addHandler(logging.NullHandler())
+    return logger
+
+def test_sqlite_no_separator_by_default(tmp_path, logger):
+    input_path = Path(__file__).resolve().parents[1] / "testdata" / "messages.dat"
+    db_path = tmp_path / "test.sqlite"
+
+    settings = ProcessingSettings(
+        verbose=False,
+        private=False,
+        no_header=False,
+        truncate_signatures=False,
+        cut_quoting=False,
+        individual_files=False,
+        threaded=False,
+        binaries_removal=False,
+        redact_pii=False,
+        format="sqlite",
+        separator="auto",
+        output_mode="file",
+        output_path=str(db_path),
+        encoding="latin1"
+    )
+
+    process_file(str(input_path), settings, logger)
+
+    conn = sqlite3.connect(str(db_path))
+    c = conn.cursor()
+    c.execute("SELECT text FROM messages LIMIT 1")
+    text = c.fetchone()[0]
+    conn.close()
+
+    assert not text.startswith("-" * 80)
+    # It should start with the header if no_header is False
+    assert text.startswith("Date:")
+
+def test_mbox_no_separator_by_default(tmp_path, logger):
+    input_path = Path(__file__).resolve().parents[1] / "testdata" / "messages.dat"
+    mbox_path = tmp_path / "test.mbox"
+
+    settings = ProcessingSettings(
+        verbose=False,
+        private=False,
+        no_header=False,
+        truncate_signatures=False,
+        cut_quoting=False,
+        individual_files=False,
+        threaded=False,
+        binaries_removal=False,
+        redact_pii=False,
+        format="mbox",
+        separator="auto",
+        output_mode="file",
+        output_path=str(mbox_path),
+        encoding="latin1"
+    )
+
+    process_file(str(input_path), settings, logger)
+
+    content = mbox_path.read_text(encoding='utf-8')
+    # In mbox, the separator should NOT be there.
+    # The body is separated from mbox headers by a blank line.
+    # The formatted header is at the start of the body.
+    assert ("-" * 80) not in content


### PR DESCRIPTION
**What:** Modified `pyqwk/core.py` to include `sqlite` and `mbox` in the list of formats that automatically disable the text separator (dashes) when `separator` is set to `auto`. Added a new test file `tests/test_fix_separators.py` to verify this behavior.
**Why:** Structured data formats like SQLite databases and MBOX files should not contain visual text separators between messages in their content fields, as they provide their own structure. This improves the quality and usability of the exported data. No breaking changes were introduced.

---
*PR created automatically by Jules for task [10484496347445899179](https://jules.google.com/task/10484496347445899179) started by @RainRat*