### PR TITLE
[TEST] Increase coverage for BBS control data parsing

### DIFF
--- a/tests/test_control_dat.py
+++ b/tests/test_control_dat.py
@@ -51,3 +51,50 @@ def test_parse_control_dat_invalid_conference_number_skips_entry(caplog):
     assert 100 in board_dict
     assert "Invalid conference number" in caplog.text
     # Conf 2 should be skipped because its number was invalid
+
+def test_parse_control_dat_populates_bbs_info():
+    control_data = [
+        b'My BBS',          # 0: name
+        b'City, State',     # 1: location
+        b'555-1212',        # 2: phone
+        b'Sysop Name',      # 3: sysop
+        b'1234,MYBBS',      # 4: serial, bbs_id
+        b'01-01-90',        # 5: packet_at
+        b'User Name',       # 6: user_name
+        b'', b'', b'',      # 7, 8, 9
+        b'0',               # 10: num_confs - 1
+        b'101', b'Conf 1'   # 11, 12
+    ]
+    board_dict = _parse_control_dat(control_data)
+
+    assert board_dict.bbs_info is not None
+    assert board_dict.bbs_info.name == 'My BBS'
+    assert board_dict.bbs_info.location == 'City, State'
+    assert board_dict.bbs_info.phone == '555-1212'
+    assert board_dict.bbs_info.sysop == 'Sysop Name'
+    assert board_dict.bbs_info.serial_number == '1234'
+    assert board_dict.bbs_info.bbs_id == 'MYBBS'
+    assert board_dict.bbs_info.packet_at == '01-01-90'
+    assert board_dict.bbs_info.user_name == 'User Name'
+    assert board_dict.bbs_info.num_conferences == 1
+
+def test_parse_control_dat_bbs_id_missing():
+    # Line 4 with no comma
+    control_data = [b'line'] * 4 + [b'1234'] + [b'line'] * 5 + [b'0'] + [b'101', b'Conf 1']
+    board_dict = _parse_control_dat(control_data)
+
+    assert board_dict.bbs_info.serial_number == '1234'
+    assert board_dict.bbs_info.bbs_id == ''
+
+def test_parse_control_dat_unicode_decode_error_fallback():
+    # Provide bytes that are invalid in UTF-8
+    invalid_utf8 = b'Board \xff Name'
+    # Use utf-8 encoding to force the error in dec()
+    control_data = [b'line'] * 10 + [b'0'] + [b'101', invalid_utf8]
+
+    # We pass encoding='utf-8' so that .decode(encoding) fails for b'\xff'
+    board_dict = _parse_control_dat(control_data, encoding='utf-8')
+
+    assert 101 in board_dict
+    # Fallback is latin1. b'\xff'.decode('latin1') is 'ÿ'
+    assert board_dict[101] == 'Board ÿ Name'


### PR DESCRIPTION
This PR increases the test coverage for the `_parse_control_dat` function in `pyqwk/core.py`. 

The primary improvement is the addition of a test case for the `UnicodeDecodeError` fallback branch, which ensures that the parser remains robust even when encountering metadata that does not match the expected character encoding (falling back to `latin1` for best-effort recovery). 

Additionally, new tests verify that all `BBSInfo` metadata fields are correctly extracted from the `CONTROL.DAT` header and that the serial number/BBS ID splitting logic handles cases where the BBS ID is missing.

Coverage for `pyqwk/core.py` increased from 96% to 97%, specifically addressing previously untested logic in the control data parser.

---
*PR created automatically by Jules for task [10285865437182770215](https://jules.google.com/task/10285865437182770215) started by @RainRat*