### PR TITLE
[UI/UX] Improve search responsiveness with debouncing and Enter-key execution

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -36,7 +36,8 @@ class QwkGuiApp:
         self.threaded_var = tk.BooleanVar(value=False)
 
         self.search_var = tk.StringVar()
-        self.search_var.trace_add("write", lambda *args: self.reload_messages())
+        self.search_var.trace_add("write", self._on_search_changed)
+        self._search_timer: str | None = None
 
         self._build_menu()
         self._build_toolbar()
@@ -109,7 +110,7 @@ class QwkGuiApp:
             side=tk.LEFT
         )
 
-        self.search_entry.bind("<Return>", lambda e: self.message_list.focus_set())
+        self.search_entry.bind("<Return>", self._on_search_enter)
         self.search_entry.bind("<Escape>", self.clear_search)
         self.root.bind("<Control-f>", lambda e: self.search_entry.focus_set())
 
@@ -320,7 +321,22 @@ class QwkGuiApp:
         self.current_path = path
         self.load_messages(path)
 
+    def _on_search_changed(self, *args: object) -> None:
+        """Handle search term changes with debouncing to improve UI responsiveness."""
+        if self._search_timer is not None:
+            self.root.after_cancel(self._search_timer)
+        self._search_timer = self.root.after(250, self.reload_messages)
+
+    def _on_search_enter(self, _event: object) -> None:
+        """Execute search immediately when Enter is pressed."""
+        self.reload_messages()
+        self.message_list.focus_set()
+
     def reload_messages(self) -> None:
+        if self._search_timer is not None:
+            self.root.after_cancel(self._search_timer)
+            self._search_timer = None
+
         if self.current_path:
             self.load_messages(self.current_path)
 


### PR DESCRIPTION
This PR improves the usability and responsiveness of the PyQWK Reader GUI.

### Problem
In the previous implementation, the search field triggered a full reload and re-filtering of all messages on every single keystroke. For medium to large QWK archives, this caused significant UI stuttering and input lag, as the main thread was blocked by message processing and Treeview updates.

### Solution
I have implemented a **250ms debounce delay** for the search input. The archive is now only re-filtered after the user has stopped typing for a brief moment, ensuring a fluid typing experience even with thousands of messages.

To complement this, I've added **immediate execution on the Enter key**:
- Pressing `Enter` in the search box now triggers the search immediately (canceling any pending debounce timer).
- It also automatically moves focus to the message list, allowing users to start browsing results immediately without extra clicks.

### Changes
- **`pyqwk/gui.py`**:
    - Initialized `_search_timer` in `__init__`.
    - Redirected `search_var` trace to `_on_search_changed` (debounced).
    - Added `_on_search_enter` for immediate execution and focus management.
    - Updated `reload_messages` to ensure robust timer management for all reload triggers (search, checkboxes, and conferences).

---
*PR created automatically by Jules for task [5204189548274488272](https://jules.google.com/task/5204189548274488272) started by @RainRat*