### PR TITLE
[FEAT] Message Deduplication for Merged Archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,9 @@ qwk my_archives/ -o output_folder/
 ```
 *Tip: The output folder will be created automatically if it does not exist.*
 
-**Merge multiple archives into one file:**
+**Merge multiple archives into one file (removing any duplicate messages):**
 ```bash
-qwk archive1.qwk archive2.qwk --merge -o combined.mbox
+qwk archive1.qwk archive2.qwk --merge --unique -o combined.mbox
 ```
 
 **Clean up messages (removes signatures, quotes, and binaries):**
@@ -195,6 +195,7 @@ for msg in parse_messages(file_data, None):
 | `-F, --format [type]` | Choose format: `text`, `html`, `json`, `xml`, `markdown`, `csv`, `mbox`, `sqlite`. |
 | `-T`, `--threaded` | Group replies together into conversations. |
 | `-m`, `--merge` | Combine multiple inputs into a single output file. |
+| `-u`, `--unique` | Only include unique messages (removes duplicates when merging archives). |
 | `-S`, `--search [term]` | Search for a keyword in author, subject, and message text. |
 | `-C`, `--conference [id]` | Only show messages from this conference name or number. |
 | `--clean` | Automatically remove signatures, quotes, binary data, and color codes. |

--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -269,6 +269,12 @@ def main() -> None:
         type=int,
         default=None,
     )
+    filter_group.add_argument(
+        '-u',
+        '--unique',
+        help='Only include unique messages (removes duplicates when merging archives).',
+        action='store_true',
+    )
 
     parser.add_argument(
         '-I',
@@ -356,6 +362,7 @@ def main() -> None:
         strip_ansi=args.stripansi or args.clean,
         quiet=args.quiet,
         headers_only=args.headers_only,
+        unique=args.unique,
         format=output_format,
         separator=args.separator,
         output_mode=output_mode,

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -145,6 +145,7 @@ class ProcessingSettings:
     quiet: bool = False
     headers_only: bool = False
     merge: bool = False
+    unique: bool = False
     conferences: list[str] | None = None
     authors: list[str] | None = None
     recipients: list[str] | None = None
@@ -848,6 +849,7 @@ def process_merged_files(
         os.makedirs(output_dir, exist_ok=True)
 
     collected_messages: list[ParsedMessage] = []
+    seen_ids: set[tuple[str, int, int | str]] = set()
 
     separator_mode = settings.separator
     if separator_mode == 'auto':
@@ -864,6 +866,9 @@ def process_merged_files(
     count = 0
     for input_path in input_paths:
         file_data, board_dict = load_data(input_path, logger, settings.encoding)
+        bbs_info = getattr(board_dict, 'bbs_info', None)
+        bbs_key = f"{bbs_info.name}|{bbs_info.bbs_id}" if bbs_info else ""
+
         allowed_conferences = get_allowed_conferences(settings.conferences, board_dict)
 
         desc = f"Processing {os.path.basename(input_path)}"
@@ -880,6 +885,20 @@ def process_merged_files(
                 )
                 if not matches_filters(parsed_message, settings, allowed_conferences):
                     continue
+
+                if settings.unique:
+                    msg_id: tuple[str, int, int | str]
+                    if parsed_message.msgnum is not None:
+                        msg_id = (bbs_key, parsed_message.confnum, parsed_message.msgnum)
+                    else:
+                        content_hash = hashlib.sha1(
+                            parsed_message.text.encode(settings.encoding, errors='replace')
+                        ).hexdigest()
+                        msg_id = (bbs_key, parsed_message.confnum, content_hash)
+
+                    if msg_id in seen_ids:
+                        continue
+                    seen_ids.add(msg_id)
 
                 count += 1
                 if settings.limit is not None and count > settings.limit:

--- a/tests/test_deduplication.py
+++ b/tests/test_deduplication.py
@@ -1,0 +1,125 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from pyqwk.core import process_merged_files, ProcessingSettings, ParsedMessage, MessageHeader
+import hashlib
+
+def test_deduplication_by_msgnum(tmp_path):
+    output_path = tmp_path / "output.txt"
+    settings = ProcessingSettings(
+        verbose=False, private=True, no_header=True, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False, merge=True,
+        binaries_removal=False, redact_pii=False, format='text', separator='none',
+        output_mode='file', output_path=str(output_path), encoding='cp437',
+        unique=True, strip_ansi=False, quiet=True, headers_only=False
+    )
+
+    # Message 1
+    h1 = MagicMock(spec=MessageHeader)
+    h1.is_private = False
+    h1.is_password = False
+    h1.msgfrom = "User1"
+    h1.msgdate = "01-01-23"
+    h1.msgtime = "12:00"
+    h1.msgsubject = "Subj1"
+    h1.msgnum = 1
+    h1.confnum = 100
+    h1.format_text.return_value = ""
+
+    msg1 = ParsedMessage(text="Message 1", msgnum=1, refnum=None, confnum=100, header=h1)
+
+    # Message 2 (Duplicate of 1 by msgnum)
+    h2 = MagicMock(spec=MessageHeader)
+    h2.is_private = False
+    h2.is_password = False
+    h2.msgfrom = "User1"
+    h2.msgdate = "01-01-23"
+    h2.msgtime = "12:00"
+    h2.msgsubject = "Subj1"
+    h2.msgnum = 1
+    h2.confnum = 100
+    h2.format_text.return_value = ""
+
+    msg2 = ParsedMessage(text="Message 1 Duplicate", msgnum=1, refnum=None, confnum=100, header=h2)
+
+    # Message 3 (Different msgnum)
+    h3 = MagicMock(spec=MessageHeader)
+    h3.is_private = False
+    h3.is_password = False
+    h3.msgfrom = "User1"
+    h3.msgdate = "01-01-23"
+    h3.msgtime = "12:05"
+    h3.msgsubject = "Subj2"
+    h3.msgnum = 2
+    h3.confnum = 100
+    h3.format_text.return_value = ""
+
+    msg3 = ParsedMessage(text="Message 2", msgnum=2, refnum=None, confnum=100, header=h3)
+
+    mock_logger = MagicMock()
+
+    with patch('pyqwk.core.load_data') as mock_load:
+        mock_load.return_value = (bytearray(b'Produced '), {})
+        with patch('pyqwk.core.parse_messages') as mock_parse:
+            mock_parse.side_effect = [[msg1, msg2, msg3]]
+
+            process_merged_files(['archive.qwk'], settings, mock_logger)
+
+    content = output_path.read_text()
+    assert "Message 1" in content
+    assert "Message 2" in content
+    assert "Message 1 Duplicate" not in content
+    # Should only have two messages
+    assert content.count("\n") == 2
+
+def test_deduplication_by_content_hash(tmp_path):
+    output_path = tmp_path / "output.txt"
+    settings = ProcessingSettings(
+        verbose=False, private=True, no_header=True, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False, merge=True,
+        binaries_removal=False, redact_pii=False, format='text', separator='none',
+        output_mode='file', output_path=str(output_path), encoding='cp437',
+        unique=True, strip_ansi=False, quiet=True, headers_only=False
+    )
+
+    # Message 1 (No msgnum)
+    h1 = MagicMock(spec=MessageHeader)
+    h1.is_private = False
+    h1.is_password = False
+    h1.msgnum = None
+    h1.confnum = 100
+    h1.format_text.return_value = ""
+
+    msg1 = ParsedMessage(text="Message Content", msgnum=None, refnum=None, confnum=100, header=h1)
+
+    # Message 2 (Same content, no msgnum)
+    h2 = MagicMock(spec=MessageHeader)
+    h2.is_private = False
+    h2.is_password = False
+    h2.msgnum = None
+    h2.confnum = 100
+    h2.format_text.return_value = ""
+
+    msg2 = ParsedMessage(text="Message Content", msgnum=None, refnum=None, confnum=100, header=h2)
+
+    # Message 3 (Different content)
+    h3 = MagicMock(spec=MessageHeader)
+    h3.is_private = False
+    h3.is_password = False
+    h3.msgnum = None
+    h3.confnum = 100
+    h3.format_text.return_value = ""
+
+    msg3 = ParsedMessage(text="Different Content", msgnum=None, refnum=None, confnum=100, header=h3)
+
+    mock_logger = MagicMock()
+
+    with patch('pyqwk.core.load_data') as mock_load:
+        mock_load.return_value = (bytearray(b'Produced '), {})
+        with patch('pyqwk.core.parse_messages') as mock_parse:
+            mock_parse.side_effect = [[msg1, msg2, msg3]]
+
+            process_merged_files(['archive.qwk'], settings, mock_logger)
+
+    content = output_path.read_text()
+    assert content.count("Message Content") == 1
+    assert "Different Content" in content

--- a/tests/test_qwk.py
+++ b/tests/test_qwk.py
@@ -101,6 +101,7 @@ def _make_cli_namespace(**overrides: object) -> argparse.Namespace:
         individualfiles=False,
         threaded=False,
         merge=False,
+        unique=False,
         binariesremoval=False,
         redactpii=False,
         stripansi=False,


### PR DESCRIPTION
Identified that merging multiple QWK archives (especially from the same BBS) often results in duplicate messages. Implemented a deduplication feature that uses BBS metadata and message numbers to ensure only unique messages are exported. This adds significant value for users archiving historical BBS data.

---
*PR created automatically by Jules for task [11687709836673180206](https://jules.google.com/task/11687709836673180206) started by @RainRat*