### PR TITLE
[UI/UX] Improve status bar feedback with message counts

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -366,8 +366,10 @@ class QwkGuiApp:
             board_dict = self._cache['board_dict']
 
             messages = []
+            total_count = 0
             allowed_conferences = get_allowed_conferences(settings.conferences, board_dict)
             for parsed_message in parse_messages(file_data, None, settings.encoding):
+                total_count += 1
                 if not matches_filters(parsed_message, settings, allowed_conferences):
                     continue
 
@@ -424,7 +426,7 @@ class QwkGuiApp:
                 source_display = os.path.basename(path)
 
             self.status_label.config(
-                text=f"Loaded {source_display} - {len(self.messages)} messages"
+                text=f"Showing {len(self.messages)} of {total_count} messages from {source_display}"
             )
             if self.messages:
                 first_item = self.message_list.get_children()[0]

--- a/tests/test_gui_status_counts.py
+++ b/tests/test_gui_status_counts.py
@@ -1,0 +1,96 @@
+import sys
+from unittest.mock import MagicMock, patch
+import pytest
+import os
+
+# Mock tkinter before any pyqwk.gui imports
+mock_tk = MagicMock()
+mock_ttk = MagicMock()
+sys.modules["tkinter"] = mock_tk
+sys.modules["tkinter.filedialog"] = MagicMock()
+sys.modules["tkinter.messagebox"] = MagicMock()
+sys.modules["tkinter.ttk"] = mock_ttk
+
+from pyqwk.core import ParsedMessage, MessageHeader, ProcessingSettings
+
+@pytest.fixture
+def mock_gui_deps():
+    with patch("pyqwk.gui.tk") as mock_tk, \
+         patch("pyqwk.gui.ttk") as mock_ttk:
+
+        def make_var(value=None):
+            m = MagicMock()
+            m.get.return_value = value
+            return m
+        mock_tk.BooleanVar.side_effect = lambda value=False, **kwargs: make_var(value)
+        mock_tk.StringVar.side_effect = lambda value="", **kwargs: make_var(value)
+
+        mock_tk.END = "end"
+        mock_tk.HORIZONTAL = "horizontal"
+        mock_tk.VERTICAL = "vertical"
+        mock_tk.BOTH = "both"
+        mock_tk.X = "x"
+        mock_tk.Y = "y"
+        mock_tk.LEFT = "left"
+        mock_tk.RIGHT = "right"
+        mock_tk.TOP = "top"
+        mock_tk.BOTTOM = "bottom"
+        mock_tk.SUNKEN = "sunken"
+        mock_tk.W = "w"
+        mock_tk.E = "e"
+        mock_tk.WORD = "word"
+        mock_tk.DISABLED = "disabled"
+        mock_tk.NORMAL = "normal"
+
+        yield {
+            "tk": mock_tk,
+            "ttk": mock_ttk,
+        }
+
+def test_status_bar_counts(mock_gui_deps):
+    with patch("pyqwk.gui.load_data") as mock_load_data, \
+         patch("pyqwk.gui.parse_messages") as mock_parse_messages, \
+         patch("pyqwk.gui.matches_filters") as mock_matches_filters, \
+         patch("pyqwk.gui.process_message") as mock_process_message, \
+         patch("pyqwk.gui.get_allowed_conferences") as mock_get_allowed_conferences:
+
+        from pyqwk.gui import QwkGuiApp
+        root = MagicMock()
+        app = QwkGuiApp(root)
+
+        # Setup mocks
+        mock_load_data.return_value = (bytearray(), {1: "General"})
+
+        header = MessageHeader(
+            status=' ', msgnum=1, msgdate='01-01-90', msgtime='12:00',
+            msgto='All', msgfrom='User', msgsubject='Subject',
+            msgpassword='', refnum=None, numblocks=1, msgflag=' ',
+            confnum=1, lognum=1, nettag=''
+        )
+        # Create 5 messages
+        mock_msgs = [
+            ParsedMessage(text="Msg 1", msgnum=1, refnum=None, confnum=1, header=header),
+            ParsedMessage(text="Msg 2", msgnum=2, refnum=None, confnum=1, header=header),
+            ParsedMessage(text="Msg 3", msgnum=3, refnum=None, confnum=1, header=header),
+            ParsedMessage(text="Msg 4", msgnum=4, refnum=None, confnum=1, header=header),
+            ParsedMessage(text="Msg 5", msgnum=5, refnum=None, confnum=1, header=header),
+        ]
+        mock_parse_messages.return_value = iter(mock_msgs)
+
+        # matches_filters returns True for only 2 of them
+        mock_matches_filters.side_effect = [True, False, True, False, False]
+        mock_process_message.side_effect = lambda text, *args: text
+        mock_get_allowed_conferences.return_value = {1}
+
+        # Trigger load_messages
+        app.load_messages("test.qwk")
+
+        # Expected status: "Showing 2 of 5 messages from test.qwk"
+        # status_label.config is called with text="Loading..." first, then the result
+        calls = app.status_label.config.call_args_list
+        last_call_text = None
+        for call in calls:
+            if 'text' in call.kwargs:
+                last_call_text = call.kwargs['text']
+
+        assert last_call_text == "Showing 2 of 5 messages from test.qwk"


### PR DESCRIPTION
Improved the GUI status bar to show "Showing X of Y messages" when filtering, providing better feedback to the user about how many messages are being hidden by the current search or conference filter. This change is atomic and follows "Invisible Design" principles by improving clarity without adding unnecessary decoration.

---
*PR created automatically by Jules for task [17270756638614839565](https://jules.google.com/task/17270756638614839565) started by @RainRat*