### PR TITLE
[UI/UX] Add Conference filter clear button and improve toolbar consistency

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -75,6 +75,12 @@ class QwkGuiApp:
         self.search_var.set("")
         self.message_list.focus_set()
 
+    def clear_conf_filter(self, _event: object | None = None) -> None:
+        """Reset the conference filter to show all conferences."""
+        self.conf_combo.set("All Conferences")
+        self.reload_messages()
+        self.message_list.focus_set()
+
     def quit_app(self, _event: object | None = None) -> None:
         self.root.quit()
 
@@ -121,8 +127,13 @@ class QwkGuiApp:
         filters_frame.pack(side=tk.LEFT)
         ttk.Label(filters_frame, text="Conf:").pack(side=tk.LEFT)
         self.conf_combo = ttk.Combobox(filters_frame, state="readonly", width=25)
-        self.conf_combo.pack(side=tk.LEFT, padx=(5, 0))
+        self.conf_combo.pack(side=tk.LEFT, padx=(5, 2))
+        ttk.Button(filters_frame, text="×", width=2, command=self.clear_conf_filter).pack(
+            side=tk.LEFT
+        )
+
         self.conf_combo.bind("<<ComboboxSelected>>", lambda e: self.reload_messages())
+        self.conf_combo.bind("<Escape>", lambda e: self.clear_conf_filter())
 
         ttk.Separator(toolbar, orient=tk.VERTICAL).pack(side=tk.LEFT, fill=tk.Y, padx=10)
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -88,6 +88,15 @@ class TestQwkGui:
             app.load_messages("bad.qwk")
             mock_gui_deps["messagebox"].showerror.assert_called_with("Failed to load QWK", "Load failed")
 
+    def test_clear_conf_filter(self, mock_gui_deps):
+        app = get_app()
+        app.conf_combo.set("1: General")
+        with patch.object(app, 'reload_messages') as mock_reload:
+            app.clear_conf_filter()
+            app.conf_combo.set.assert_called_with("All Conferences")
+            mock_reload.assert_called_once()
+            app.message_list.focus_set.assert_called_once()
+
     def test_on_message_selected(self, mock_gui_deps):
         app = get_app()
         header = MessageHeader(


### PR DESCRIPTION
The PyQWK GUI now features a more consistent and efficient filtering experience. A new 'Clear' button (×) has been added to the conference filter, matching the existing search bar functionality. Additionally, the 'Escape' key now resets the conference filter when focused, and the toolbar layout has been polished by standardizing padding between elements. These changes reduce friction and improve the overall visual hierarchy of the application.

---
*PR created automatically by Jules for task [8108849267246122094](https://jules.google.com/task/8108849267246122094) started by @RainRat*