### PR TITLE
[FEAT] Add --organize flag to group individual files by conference

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ qwk archive.qwk --format markdown -o messages.md
 qwk archive.qwk --individual-files -o output_folder/
 ```
 
+**Save each message as a separate file organized by conference:**
+```bash
+qwk archive.qwk --individual-files --organize -o output_folder/
+```
+*Tip: This creates subfolders for each conference (e.g., `001-general_chat/`) to keep the output tidy.*
+
 **Show detailed archive statistics:**
 ```bash
 qwk archive.qwk --stats
@@ -225,6 +231,7 @@ for msg in parse_messages(file_data, None):
 | :--- | :--- |
 | `-o`, `--output [path]` | Where to save the output. Prints to terminal by default. |
 | `-i`, `--individual-files` | Save each message as a separate file. |
+| `--organize` | Organize individual files into subfolders by conference. |
 | `-F, --format [type]` | Choose format: `text`, `html`, `json`, `xml`, `markdown`, `csv`, `mbox`, `eml`, `sqlite`. |
 | `-T`, `--threaded` | Group replies together into conversations. |
 | `-m`, `--merge` | Combine multiple inputs into a single output file. |

--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -104,6 +104,11 @@ def main() -> None:
         action='store_true',
     )
     io_group.add_argument(
+        '--organize',
+        help='Organize individual files into subfolders by conference.',
+        action='store_true',
+    )
+    io_group.add_argument(
         '-E',
         '--encoding',
         help='Character encoding of the input file (default: cp437)',
@@ -374,6 +379,7 @@ def main() -> None:
         quiet=args.quiet,
         headers_only=args.headers_only,
         unique=args.unique,
+        organize=args.organize,
         format=output_format,
         separator=args.separator,
         output_mode=output_mode,

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -146,6 +146,7 @@ class ProcessingSettings:
     headers_only: bool = False
     merge: bool = False
     unique: bool = False
+    organize: bool = False
     conferences: list[str] | None = None
     authors: list[str] | None = None
     recipients: list[str] | None = None
@@ -983,14 +984,25 @@ def process_merged_files(
                         encoded_buffer = processed_buffer.encode(target_encoding)
 
                     assert output_dir is not None
+
+                    target_dir = output_dir
+                    if settings.organize:
+                        conf_name = parsed_message.confname or "unknown"
+                        conf_slug = re.sub(r'[^a-zA-Z0-9]+', '_', conf_name).strip('_').lower()[:30]
+                        if not conf_slug:
+                            conf_slug = "conference"
+                        conf_dir = f"{parsed_message.confnum:03d}-{conf_slug}"
+                        target_dir = os.path.join(output_dir, conf_dir)
+                        os.makedirs(target_dir, exist_ok=True)
+
                     filename = _generate_safe_filename(parsed_message, settings.format, count)
-                    full_path = os.path.join(output_dir, filename)
+                    full_path = os.path.join(target_dir, filename)
 
                     # Collision avoidance
                     if os.path.exists(full_path):
                         short_hash = hashlib.sha1(encoded_buffer).hexdigest()[:8]
                         filename = filename.replace(".", f"-{short_hash}.")
-                        full_path = os.path.join(output_dir, filename)
+                        full_path = os.path.join(target_dir, filename)
 
                     with open(full_path, 'wb') as f:
                         f.write(encoded_buffer)

--- a/tests/test_organize.py
+++ b/tests/test_organize.py
@@ -1,0 +1,98 @@
+import os
+from unittest.mock import MagicMock, patch
+import pytest
+from pyqwk.core import (
+    ProcessingSettings,
+    ParsedMessage,
+    MessageHeader,
+    process_merged_files,
+)
+
+def test_organize_subfolders(tmp_path):
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    # Mocking data
+    header1 = MessageHeader(
+        status=' ', msgnum=1, msgdate='01-01-23', msgtime='12:00',
+        msgto='Alice', msgfrom='Bob', msgsubject='Hello',
+        msgpassword='', refnum=None, numblocks=2, msgflag='',
+        confnum=1, lognum=0, nettag=''
+    )
+    msg1 = ParsedMessage(text="Hello world", msgnum=1, refnum=None, confnum=1, header=header1)
+
+    header2 = MessageHeader(
+        status=' ', msgnum=2, msgdate='01-01-23', msgtime='12:05',
+        msgto='Bob', msgfrom='Alice', msgsubject='Re: Hello',
+        msgpassword='', refnum=1, numblocks=2, msgflag='',
+        confnum=2, lognum=0, nettag=''
+    )
+    msg2 = ParsedMessage(text="Reply here", msgnum=2, refnum=1, confnum=2, header=header2)
+
+    board_dict = {1: "General Chat", 2: "Tech Talk"}
+
+    settings = ProcessingSettings(
+        verbose=False, private=False, no_header=False,
+        truncate_signatures=False, cut_quoting=False,
+        individual_files=True, threaded=False, merge=False,
+        binaries_removal=False, redact_pii=False, strip_ansi=False,
+        format='text', separator='none', output_mode='file',
+        output_path=str(output_dir), encoding='cp437',
+        organize=True
+    )
+
+    logger = MagicMock()
+
+    with patch('pyqwk.core.load_data', return_value=(bytearray(), board_dict)), \
+         patch('pyqwk.core.parse_messages', return_value=[msg1, msg2]):
+        process_merged_files(['dummy.qwk'], settings, logger)
+
+    # Check if subfolders were created
+    conf1_dir = output_dir / "001-general_chat"
+    conf2_dir = output_dir / "002-tech_talk"
+
+    assert conf1_dir.is_dir()
+    assert conf2_dir.is_dir()
+
+    # Check if files are in subfolders
+    files1 = list(conf1_dir.glob("*.txt"))
+    files2 = list(conf2_dir.glob("*.txt"))
+
+    assert len(files1) == 1
+    assert len(files2) == 1
+    assert "001-00001-hello.txt" in files1[0].name
+    assert "002-00002-re_hello.txt" in files2[0].name
+
+def test_organize_unknown_conference(tmp_path):
+    output_dir = tmp_path / "output_unknown"
+    output_dir.mkdir()
+
+    header = MessageHeader(
+        status=' ', msgnum=10, msgdate='01-01-23', msgtime='12:00',
+        msgto='Alice', msgfrom='Bob', msgsubject='Secret',
+        msgpassword='', refnum=None, numblocks=2, msgflag='',
+        confnum=999, lognum=0, nettag=''
+    )
+    msg = ParsedMessage(text="Hello", msgnum=10, refnum=None, confnum=999, header=header)
+
+    board_dict = {} # No conference names
+
+    settings = ProcessingSettings(
+        verbose=False, private=False, no_header=False,
+        truncate_signatures=False, cut_quoting=False,
+        individual_files=True, threaded=False, merge=False,
+        binaries_removal=False, redact_pii=False, strip_ansi=False,
+        format='text', separator='none', output_mode='file',
+        output_path=str(output_dir), encoding='cp437',
+        organize=True
+    )
+
+    logger = MagicMock()
+
+    with patch('pyqwk.core.load_data', return_value=(bytearray(), board_dict)), \
+         patch('pyqwk.core.parse_messages', return_value=[msg]):
+        process_merged_files(['dummy.qwk'], settings, logger)
+
+    conf_dir = output_dir / "999-unknown"
+    assert conf_dir.is_dir()
+    assert (conf_dir / "999-00010-secret.txt").exists()

--- a/tests/test_qwk.py
+++ b/tests/test_qwk.py
@@ -102,6 +102,7 @@ def _make_cli_namespace(**overrides: object) -> argparse.Namespace:
         threaded=False,
         merge=False,
         unique=False,
+        organize=False,
         binariesremoval=False,
         redactpii=False,
         stripansi=False,


### PR DESCRIPTION
Added a new `--organize` CLI flag to allow users to group individual message exports into conference-specific subfolders. This improves the organization of the output directory for large archives.

---
*PR created automatically by Jules for task [2011661016423752916](https://jules.google.com/task/2011661016423752916) started by @RainRat*