### PR TITLE
[FEAT] Add --skip option for pagination and partial processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,13 @@ Search for keywords in the author, subject, and message body.
 qwk archive.qwk --search "BBS"
 ```
 
+**Pagination:**
+Skip a number of messages or limit the total results. This is useful for processing large archives in chunks.
+```bash
+# Skip the first 100 messages and process the next 50
+qwk archive.qwk --skip 100 --limit 50
+```
+
 **Filter by Date:**
 Find messages from a specific date range (use YYYY-MM-DD).
 ```bash
@@ -249,6 +256,7 @@ for msg in parse_messages(file_data, None):
 | `-v`, `--verbose` | Show more details like conference names and message numbers. |
 | `-q`, `--quiet` | Hide the progress bar and extra info. |
 | `-L, --limit [num]` | Stop after processing this many messages. |
+| `-K, --skip [num]` | Skip the first this many matching messages. |
 | `-I, --info` | Show a summary of the archive and exit. |
 | `--stats` | Show detailed statistics about the messages and exit. |
 

--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -265,6 +265,13 @@ def main() -> None:
         default=None,
     )
     filter_group.add_argument(
+        '-K',
+        '--skip',
+        help='Skip the first this many matching messages.',
+        type=int,
+        default=None,
+    )
+    filter_group.add_argument(
         '--before',
         help='Filter messages dated on or before this date (format: YYYY-MM-DD).',
         default=None,
@@ -393,6 +400,7 @@ def main() -> None:
         after=after_date,
         before=before_date,
         limit=args.limit,
+        skip=args.skip,
     )
 
     if args.info:

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -155,6 +155,7 @@ class ProcessingSettings:
     after: datetime.datetime | None = None
     before: datetime.datetime | None = None
     limit: int | None = None
+    skip: int | None = None
 
 
 @dataclass
@@ -880,7 +881,8 @@ def process_merged_files(
     elif separator_mode == 'blank':
         separator_str = "\r\n"
 
-    count = 0
+    total_matching = 0
+    processed_count = 0
     for input_path in input_paths:
         file_data, board_dict = load_data(input_path, logger, settings.encoding)
         bbs_info = getattr(board_dict, 'bbs_info', None)
@@ -917,9 +919,13 @@ def process_merged_files(
                         continue
                     seen_ids.add(msg_id)
 
-                count += 1
-                if settings.limit is not None and count > settings.limit:
+                total_matching += 1
+                if settings.skip is not None and total_matching <= settings.skip:
+                    continue
+
+                if settings.limit is not None and processed_count >= settings.limit:
                     break
+                processed_count += 1
 
                 processed_buffer = process_message(
                     parsed_message.text,
@@ -992,7 +998,7 @@ def process_merged_files(
                         target_dir = os.path.join(output_dir, conf_dir)
                         os.makedirs(target_dir, exist_ok=True)
 
-                    filename = _generate_safe_filename(parsed_message, settings.format, count)
+                    filename = _generate_safe_filename(parsed_message, settings.format, processed_count)
                     full_path = os.path.join(target_dir, filename)
 
                     # Collision avoidance
@@ -1015,7 +1021,7 @@ def process_merged_files(
                             text=text_content,
                         )
                     )
-            if settings.limit is not None and count > settings.limit:
+            if settings.limit is not None and processed_count >= settings.limit:
                 break
 
     if not settings.individual_files:
@@ -1628,6 +1634,7 @@ def show_stats(input_paths: list[str], settings: ProcessingSettings, logger: log
             private_count = 0
             matching_count = 0
             total_count = 0
+            processed_count = 0
 
             desc = f"Analyzing {os.path.basename(input_path)}"
             # Use a progress bar for statistics gathering
@@ -1641,6 +1648,13 @@ def show_stats(input_paths: list[str], settings: ProcessingSettings, logger: log
                         continue
 
                     matching_count += 1
+
+                    if settings.skip is not None and matching_count <= settings.skip:
+                        continue
+
+                    if settings.limit is not None and processed_count >= settings.limit:
+                        break
+                    processed_count += 1
 
                     # Date/Time
                     dt = _parse_qwk_date(message.header.msgdate, message.header.msgtime)
@@ -1660,7 +1674,7 @@ def show_stats(input_paths: list[str], settings: ProcessingSettings, logger: log
                         private_count += 1
 
             stats_entry["total_messages"] = total_count
-            stats_entry["matching_messages"] = matching_count
+            stats_entry["matching_messages"] = processed_count
             stats_entry["private_count"] = private_count
 
             if earliest_dt:
@@ -1676,7 +1690,7 @@ def show_stats(input_paths: list[str], settings: ProcessingSettings, logger: log
 
             if settings.format != 'json':
                 print(f"Statistics for: {_colorize(input_path, CYAN)}")
-                print(f"  {_colorize('Messages:', BOLD)} {matching_count} matching / {total_count} total")
+                print(f"  {_colorize('Messages:', BOLD)} {processed_count} matching / {total_count} total")
 
                 if earliest_dt:
                     print(f"  {_colorize('Date Range:', BOLD)} {earliest_dt.strftime('%Y-%m-%d')} to {latest_dt.strftime('%Y-%m-%d')}")

--- a/tests/test_qwk.py
+++ b/tests/test_qwk.py
@@ -83,6 +83,7 @@ def _make_settings(**overrides) -> ProcessingSettings:
         after=None,
         before=None,
         limit=None,
+        skip=None,
     )
     defaults.update(overrides)
     return ProcessingSettings(**defaults)
@@ -121,6 +122,7 @@ def _make_cli_namespace(**overrides: object) -> argparse.Namespace:
         after=None,
         before=None,
         limit=None,
+        skip=None,
         info=False,
         stats=False,
     )

--- a/tests/test_skip.py
+++ b/tests/test_skip.py
@@ -1,0 +1,156 @@
+
+import pytest
+import logging
+from dataclasses import replace
+from pyqwk.core import process_file, ProcessingSettings, ParsedMessage, MessageHeader
+
+@pytest.fixture
+def mock_logger():
+    return logging.getLogger("test_skip")
+
+@pytest.fixture
+def mock_messages():
+    header_template = MessageHeader(
+        status=' ', msgnum=1, msgdate='01-01-23', msgtime='12:00', msgto='Everyone', msgfrom='Alice',
+        msgsubject='Subject', msgpassword='', refnum=None, numblocks=2,
+        msgflag=' ', confnum=1, lognum=1, nettag=''
+    )
+
+    msgs = []
+    for i in range(1, 11):
+        msgs.append(ParsedMessage(
+            text=f"Msg:{i:02d}",
+            msgnum=i, refnum=None, confnum=1,
+            header=replace(header_template, msgnum=i)
+        ))
+    return msgs
+
+def test_skip_ignores_first_n_messages(tmp_path, mock_messages, mock_logger, monkeypatch):
+    output_path = tmp_path / "output.txt"
+
+    def fake_load_data(*args, **kwargs):
+        return bytearray(), {1: "General"}
+
+    def fake_parse_messages(*args, **kwargs):
+        yield from mock_messages
+
+    monkeypatch.setattr("pyqwk.core.load_data", fake_load_data)
+    monkeypatch.setattr("pyqwk.core.parse_messages", fake_parse_messages)
+
+    skip = 5
+    settings = ProcessingSettings(
+        verbose=False, private=False, no_header=True, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False, binaries_removal=False,
+        redact_pii=False, format="text", separator="none", output_mode="file",
+        output_path=str(output_path), encoding="cp437", quiet=True,
+        skip=skip
+    )
+
+    process_file("dummy.qwk", settings, mock_logger)
+
+    content = output_path.read_text(encoding="latin1")
+    # Should NOT contain Message 1 to 5
+    assert "Msg:01" not in content
+    assert "Msg:05" not in content
+    # Should contain Message 6 to 10
+    assert "Msg:06" in content
+    assert "Msg:10" in content
+
+def test_skip_and_limit_together(tmp_path, mock_messages, mock_logger, monkeypatch):
+    output_path = tmp_path / "output.txt"
+
+    def fake_load_data(*args, **kwargs):
+        return bytearray(), {1: "General"}
+
+    def fake_parse_messages(*args, **kwargs):
+        yield from mock_messages
+
+    monkeypatch.setattr("pyqwk.core.load_data", fake_load_data)
+    monkeypatch.setattr("pyqwk.core.parse_messages", fake_parse_messages)
+
+    skip = 2
+    limit = 3
+    settings = ProcessingSettings(
+        verbose=False, private=False, no_header=True, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False, binaries_removal=False,
+        redact_pii=False, format="text", separator="none", output_mode="file",
+        output_path=str(output_path), encoding="cp437", quiet=True,
+        skip=skip,
+        limit=limit
+    )
+
+    process_file("dummy.qwk", settings, mock_logger)
+
+    content = output_path.read_text(encoding="latin1")
+    # Should skip 1, 2. Process 3, 4, 5. Stop before 6.
+    assert "Msg:01" not in content
+    assert "Msg:02" not in content
+    assert "Msg:03" in content
+    assert "Msg:04" in content
+    assert "Msg:05" in content
+    assert "Msg:06" not in content
+
+def test_skip_exceeds_total(tmp_path, mock_messages, mock_logger, monkeypatch):
+    output_path = tmp_path / "output.txt"
+
+    def fake_load_data(*args, **kwargs):
+        return bytearray(), {1: "General"}
+
+    def fake_parse_messages(*args, **kwargs):
+        yield from mock_messages
+
+    monkeypatch.setattr("pyqwk.core.load_data", fake_load_data)
+    monkeypatch.setattr("pyqwk.core.parse_messages", fake_parse_messages)
+
+    settings = ProcessingSettings(
+        verbose=False, private=False, no_header=True, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False, binaries_removal=False,
+        redact_pii=False, format="text", separator="none", output_mode="file",
+        output_path=str(output_path), encoding="cp437", quiet=True,
+        skip=20
+    )
+
+    process_file("dummy.qwk", settings, mock_logger)
+
+    content = output_path.read_text(encoding="latin1")
+    assert content == ""
+
+def test_skip_with_unique(tmp_path, mock_messages, mock_logger, monkeypatch):
+    output_path = tmp_path / "output.txt"
+
+    # Create duplicates: 1, 1, 2, 2, 3, 3...
+    duplicated_msgs = []
+    for m in mock_messages:
+        duplicated_msgs.append(m)
+        duplicated_msgs.append(m)
+
+    def fake_load_data(*args, **kwargs):
+        return bytearray(), {1: "General"}
+
+    def fake_parse_messages(*args, **kwargs):
+        yield from duplicated_msgs
+
+    monkeypatch.setattr("pyqwk.core.load_data", fake_load_data)
+    monkeypatch.setattr("pyqwk.core.parse_messages", fake_parse_messages)
+
+    # Unique should reduce to 1, 2, 3, 4, 5...
+    # Skip 2 should skip 1 and 2.
+    # Limit 2 should give 3 and 4.
+    settings = ProcessingSettings(
+        verbose=False, private=False, no_header=True, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False, binaries_removal=False,
+        redact_pii=False, format="text", separator="none", output_mode="file",
+        output_path=str(output_path), encoding="cp437", quiet=True,
+        unique=True,
+        skip=2,
+        limit=2
+    )
+
+    process_file("dummy.qwk", settings, mock_logger)
+
+    content = output_path.read_text(encoding="latin1")
+    assert "Msg:01" not in content
+    assert "Msg:02" not in content
+    assert "Msg:03" in content
+    assert "Msg:04" in content
+    assert "Msg:05" not in content

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -91,3 +91,56 @@ def test_show_stats_filter(capsys):
     assert "Messages: 1 matching / 2 total" in captured.out
     assert "Russ Beuker" in captured.out
     assert "Chris Exner" not in captured.out
+
+def test_show_stats_skip_limit(capsys):
+    input_path = "testdata/test2_qwk.zip"
+    # test2 has 2 messages.
+    # Skip 1 should leave 1.
+    # Limit 1 should leave 1.
+    # Skip 2 should leave 0.
+
+    logger = logging.getLogger("test")
+
+    settings_skip = ProcessingSettings(
+        verbose=False, private=False, no_header=False, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False, binaries_removal=False,
+        redact_pii=False, strip_ansi=False, format='text', separator='auto',
+        output_mode='stdout', output_path=None, encoding='cp437', quiet=True,
+        skip=1
+    )
+    show_stats([input_path], settings_skip, logger)
+    captured = capsys.readouterr()
+    assert "Messages: 1 matching / 2 total" in captured.out
+
+    settings_limit = ProcessingSettings(
+        verbose=False, private=False, no_header=False, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False, binaries_removal=False,
+        redact_pii=False, strip_ansi=False, format='text', separator='auto',
+        output_mode='stdout', output_path=None, encoding='cp437', quiet=True,
+        limit=1
+    )
+    show_stats([input_path], settings_limit, logger)
+    captured = capsys.readouterr()
+    assert "Messages: 1 matching / 2 total" in captured.out
+
+    settings_both = ProcessingSettings(
+        verbose=False, private=False, no_header=False, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False, binaries_removal=False,
+        redact_pii=False, strip_ansi=False, format='text', separator='auto',
+        output_mode='stdout', output_path=None, encoding='cp437', quiet=True,
+        skip=1, limit=1
+    )
+    show_stats([input_path], settings_both, logger)
+    captured = capsys.readouterr()
+    assert "Messages: 1 matching / 2 total" in captured.out
+
+    settings_skip_all = ProcessingSettings(
+        verbose=False, private=False, no_header=False, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False, binaries_removal=False,
+        redact_pii=False, strip_ansi=False, format='text', separator='auto',
+        output_mode='stdout', output_path=None, encoding='cp437', quiet=True,
+        skip=2
+    )
+    show_stats([input_path], settings_skip_all, logger)
+    captured = capsys.readouterr()
+    assert "Messages: 0 matching / 2 total" in captured.out


### PR DESCRIPTION
This pull request implements a new `--skip` (shorthand `-K`) feature for the `pyqwk` utility. 

### What:
- Added a `--skip` option to the CLI that allows bypassing a specified number of matching messages before starting processing or analysis.
- Updated the core processing loop and statistics generation to respect both `skip` and `limit` settings.
- Added a new test suite `tests/test_skip.py` and expanded `tests/test_stats.py` to ensure correctness.

### Why:
I identified a gap in the current filtering logic where users could limit the number of messages processed but could not skip a specific offset. Adding a skip/offset feature enables:
1. **Pagination:** Users can process large archives in manageable chunks (e.g., skip 1000, limit 500).
2. **Resumption:** If a long-running export is interrupted, it can be resumed from a known offset.
3. **Sampling:** Users can explore different parts of an archive by skipping the beginning.

This change is additive, non-breaking, and follows the existing design patterns of the codebase.

---
*PR created automatically by Jules for task [13999515327417364592](https://jules.google.com/task/13999515327417364592) started by @RainRat*