### PR TITLE
Refactor duplicate header logic in process_merged_files

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -937,7 +937,12 @@ def process_merged_files(
                     settings.redact_pii,
                     settings.strip_ansi,
                 )
-                if not settings.no_header and settings.format not in ('html', 'markdown'):
+
+                # Logic for prepending headers and separators
+                include_header = (
+                    not settings.no_header and settings.format not in ('html', 'markdown')
+                )
+                if include_header:
                     leading_newlines = 0
                     text_prefix = parsed_message.text
                     while text_prefix.startswith('\r\n'):
@@ -953,7 +958,7 @@ def process_merged_files(
                     processed_buffer = header_text + processed_buffer
 
                 # Add separator for text format, or if headers are enabled (legacy behavior for non-text formats)
-                if settings.format == 'text' or (not settings.no_header and settings.format not in ('html', 'markdown')):
+                if settings.format == 'text' or include_header:
                     processed_buffer = separator_str + processed_buffer
 
                 if settings.individual_files:


### PR DESCRIPTION
This PR addresses a duplication issue in `pyqwk/core.py`. 

In the `process_merged_files` function, the condition for determining whether to prepend headers and separators to the message buffer was repeated twice. This refactor extracts that condition into a local variable `include_header`, making the logic clearer and reducing redundant evaluations.

Technical changes:
- Created `include_header` variable to store the result of the header inclusion check.
- Used `include_header` to guard the header formatting block.
- Used `include_header` in the separator prepending condition.

This is an atomic, non-breaking refactor that preserves all existing behavior and passes the full test suite.

---
*PR created automatically by Jules for task [17881694599722827189](https://jules.google.com/task/17881694599722827189) started by @RainRat*