### PR TITLE
Remove redundant assignment in _serialize_message_mbox

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -1345,13 +1345,12 @@ def _serialize_message_mbox(message: ProcessedMessage) -> str:
     from_line_date = dt.ctime()
     rfc_date = email.utils.format_datetime(dt)
 
-    sender_addr = "user@example.com"
     if "@" in header.msgfrom:
-         sender_addr = header.msgfrom
+        sender_addr = header.msgfrom
     else:
-         # Create a safe address from the name
-         safe_name = re.sub(r'[^A-Za-z0-9]', '.', header.msgfrom).strip('.')
-         sender_addr = f"{safe_name}@example.com"
+        # Create a safe address from the name
+        safe_name = re.sub(r'[^A-Za-z0-9]', '.', header.msgfrom).strip('.')
+        sender_addr = f"{safe_name}@example.com"
 
     # Escape "From " lines in body
     body_lines = []


### PR DESCRIPTION
The `_serialize_message_mbox` function in `pyqwk/core.py` contained a redundant initialization of the `sender_addr` variable. This PR removes that initialization and cleans up the indentation of the associated conditional logic to improve code hygiene. No changes to external behavior were introduced, and all existing tests pass.

---
*PR created automatically by Jules for task [3067423175869722365](https://jules.google.com/task/3067423175869722365) started by @RainRat*