### PR TITLE
[TEST] Increase test coverage for sorting, stats, and output handling

### DIFF
--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -20,7 +20,8 @@ from pyqwk.core import (
     LogFormatter,
     _message_to_xml_element,
     parse_messages,
-    _order_messages_by_thread
+    _order_messages_by_thread,
+    _write_text_output
 )
 
 @pytest.fixture
@@ -232,3 +233,15 @@ def test_parse_messages_progress_bar():
 
 def test_order_messages_by_thread_empty():
     assert _order_messages_by_thread([]) == []
+
+def test_write_text_output_stdout_no_newline(capsys):
+    # Test that _write_text_output adds a newline if it's missing on stdout
+    _write_text_output("No newline", None)
+    captured = capsys.readouterr()
+    assert captured.out == "No newline\n"
+
+def test_write_text_output_stdout_with_newline(capsys):
+    # Test that _write_text_output does NOT add an extra newline if it's already there
+    _write_text_output("Has newline\n", None)
+    captured = capsys.readouterr()
+    assert captured.out == "Has newline\n"

--- a/tests/test_eml.py
+++ b/tests/test_eml.py
@@ -104,3 +104,23 @@ def test_eml_default_individual_files(tmp_path: Path, testdata_dir: Path, monkey
     files = list(output_dir.iterdir())
     assert len(files) == 1
     assert files[0].suffix == ".eml"
+
+def test_eml_aggregated_output(tmp_path: Path, testdata_dir: Path, capsys) -> None:
+    # Test that EML can be aggregated when individual_files=False
+    logger = logging.getLogger("pyqwk.tests")
+    input_file = testdata_dir / "messages.dat"
+
+    settings = _make_settings(
+        format="eml",
+        individual_files=False,
+        output_mode="stdout"
+    )
+
+    process_file(str(input_file), settings, logger)
+
+    captured = capsys.readouterr()
+    # messages.dat has one message. Aggregated EML should contain the content.
+    assert "From: GammaO #571 @0*1" in captured.out
+    assert "Subject: New User" in captured.out
+    # Check that it doesn't have the mbox "From " separator
+    assert not captured.out.startswith("From ")

--- a/tests/test_sorting.py
+++ b/tests/test_sorting.py
@@ -109,6 +109,18 @@ def test_sort_by_author(mock_messages, monkeypatch, capsys):
     lines = [line.strip() for line in captured.splitlines() if line.strip()]
     assert lines == ["Message 1", "Message 3", "Message 2"]
 
+def test_sort_by_to(mock_messages, monkeypatch, capsys):
+    monkeypatch.setattr(qwk, "load_data", lambda *args, **kwargs: (bytearray(b'Produced \0' + b'\0'*119), {1: "Conf 1", 2: "Conf 2"}))
+    monkeypatch.setattr(qwk, "parse_messages", lambda *args, **kwargs: iter(mock_messages))
+
+    settings = _make_settings(sort="to")
+    process_merged_files(["dummy.qwk"], settings, logging.getLogger("test"))
+
+    captured = capsys.readouterr().out
+    # Alice (2), Bob (1), Charlie (3)
+    lines = [line.strip() for line in captured.splitlines() if line.strip()]
+    assert lines == ["Message 2", "Message 1", "Message 3"]
+
 def test_sort_by_subject(mock_messages, monkeypatch, capsys):
     monkeypatch.setattr(qwk, "load_data", lambda *args, **kwargs: (bytearray(b'Produced \0' + b'\0'*119), {1: "Conf 1", 2: "Conf 2"}))
     monkeypatch.setattr(qwk, "parse_messages", lambda *args, **kwargs: iter(mock_messages))
@@ -144,6 +156,27 @@ def test_sort_by_conference(mock_messages, monkeypatch, capsys):
     # Conf 1 (1, 2), Conf 2 (3)
     lines = [line.strip() for line in captured.splitlines() if line.strip()]
     assert lines == ["Message 1", "Message 2", "Message 3"]
+
+def test_sort_by_num(mock_messages, monkeypatch, capsys):
+    # Add a message with None msgnum to test fallback
+    h_none = _make_header(None, "01-01-23", "08:00", "Dave", "Alice", "None Num", 1)
+    msg_none = ParsedMessage(text="Message None", msgnum=None, refnum=None, confnum=1, header=h_none)
+    extended_messages = mock_messages + [msg_none]
+
+    monkeypatch.setattr(qwk, "load_data", lambda *args, **kwargs: (bytearray(b'Produced \0' + b'\0'*119), {1: "Conf 1", 2: "Conf 2"}))
+    monkeypatch.setattr(qwk, "parse_messages", lambda *args, **kwargs: iter(extended_messages))
+
+    settings = _make_settings(sort="num")
+    process_merged_files(["dummy.qwk"], settings, logging.getLogger("test"))
+
+    captured = capsys.readouterr().out
+    # Order should be:
+    # 1. Message None (Conf 1, Num None -> 0)
+    # 2. Message 1 (Conf 1, Num 1)
+    # 3. Message 2 (Conf 1, Num 2)
+    # 4. Message 3 (Conf 2, Num 3)
+    lines = [line.strip() for line in captured.splitlines() if line.strip()]
+    assert lines == ["Message None", "Message 1", "Message 2", "Message 3"]
 
 def test_sort_with_limit(mock_messages, monkeypatch, capsys):
     monkeypatch.setattr(qwk, "load_data", lambda *args, **kwargs: (bytearray(b'Produced \0' + b'\0'*119), {1: "Conf 1", 2: "Conf 2"}))

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,7 +1,8 @@
 import pytest
 import logging
 import json
-from pyqwk.core import ProcessingSettings, show_stats
+import pyqwk.core as qwk
+from pyqwk.core import ProcessingSettings, show_stats, ParsedMessage, MessageHeader
 
 def test_show_stats_basic(capsys):
     input_path = "testdata/test1_qwk.zip"
@@ -144,3 +145,40 @@ def test_show_stats_skip_limit(capsys):
     show_stats([input_path], settings_skip_all, logger)
     captured = capsys.readouterr()
     assert "Messages: 0 matching / 2 total" in captured.out
+
+def test_show_stats_private_messages(monkeypatch, capsys):
+    # Mock messages including a private one
+    h1 = MessageHeader(
+        status=" ", msgnum=1, msgdate="01-01-23", msgtime="12:00",
+        msgto="All", msgfrom="User1", msgsubject="Subj1",
+        msgpassword="", refnum=None, numblocks=2, msgflag=" ",
+        confnum=1, lognum=1, nettag="",
+    )
+    h2 = MessageHeader(
+        status="*", msgnum=2, msgdate="01-01-23", msgtime="13:00",
+        msgto="User1", msgfrom="User2", msgsubject="Private",
+        msgpassword="", refnum=None, numblocks=2, msgflag=" ",
+        confnum=1, lognum=1, nettag="",
+    )
+
+    msgs = [
+        ParsedMessage(text="Msg 1", msgnum=1, refnum=None, confnum=1, header=h1),
+        ParsedMessage(text="Msg 2", msgnum=2, refnum=None, confnum=1, header=h2),
+    ]
+
+    monkeypatch.setattr(qwk, "load_data", lambda *args, **kwargs: (bytearray(b'Produced \0' + b'\0'*119), {1: "General"}))
+    monkeypatch.setattr(qwk, "parse_messages", lambda *args, **kwargs: iter(msgs))
+
+    settings = ProcessingSettings(
+        verbose=False, private=True, no_header=False, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False, binaries_removal=False,
+        redact_pii=False, strip_ansi=False, format='text', separator='auto',
+        output_mode='stdout', output_path=None, encoding='cp437', quiet=True
+    )
+    logger = logging.getLogger("test")
+
+    show_stats(["dummy.qwk"], settings, logger)
+
+    captured = capsys.readouterr().out
+    assert "Messages: 2 matching / 2 total" in captured
+    assert "Private:    1 messages" in captured


### PR DESCRIPTION
**Type:** New Coverage
**What:** Increased test coverage for several core logic branches in `pyqwk/core.py`, specifically:
- Message sorting by recipient (`to`) and message number (`num`), including fallback for missing numbers.
- Statistics reporting for private messages.
- Aggregated EML output (when not using individual files).
- Automatic trailing newline addition for standard output.

**Why:** These areas were previously untested or under-tested, leaving gaps in the verification of core processing logic. Increasing coverage ensures these features remain reliable and handle edge cases (like missing metadata) correctly.

---
*PR created automatically by Jules for task [8202586343034292295](https://jules.google.com/task/8202586343034292295) started by @RainRat*