### PR TITLE
[UI/UX] Add sort direction indicators to GUI message list

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -30,6 +30,14 @@ class QwkGuiApp:
         self._cache = {}
         self.conf_mapping = {}
 
+        self.column_labels = {
+            "#0": "Subject",
+            "Num": "Num",
+            "From": "From",
+            "Date": "Date",
+            "Conference": "Conference",
+        }
+
         self.clean_var = tk.BooleanVar(value=False)
         self.private_var = tk.BooleanVar(value=False)
         self.redact_var = tk.BooleanVar(value=False)
@@ -170,36 +178,14 @@ class QwkGuiApp:
             columns=("Num", "From", "Date", "Conference"),
             selectmode="browse",
         )
-        self.message_list.heading(
-            "#0",
-            text="Subject",
-            anchor=tk.W,
-            command=lambda: self.sort_column("#0", False),
-        )
-        self.message_list.heading(
-            "Num",
-            text="Num",
-            anchor=tk.W,
-            command=lambda: self.sort_column("Num", False),
-        )
-        self.message_list.heading(
-            "From",
-            text="From",
-            anchor=tk.W,
-            command=lambda: self.sort_column("From", False),
-        )
-        self.message_list.heading(
-            "Date",
-            text="Date",
-            anchor=tk.W,
-            command=lambda: self.sort_column("Date", False),
-        )
-        self.message_list.heading(
-            "Conference",
-            text="Conference",
-            anchor=tk.W,
-            command=lambda: self.sort_column("Conference", False),
-        )
+
+        for col, label in self.column_labels.items():
+            self.message_list.heading(
+                col,
+                text=label,
+                anchor=tk.W,
+                command=lambda c=col: self.sort_column(c, False),
+            )
 
         self.message_list.column("#0", minwidth=200, width=300)
         self.message_list.column("Num", minwidth=50, width=60, anchor=tk.E)
@@ -366,11 +352,23 @@ class QwkGuiApp:
         if self.current_path:
             self.load_messages(self.current_path)
 
+    def _reset_column_headers(self) -> None:
+        """Reset all column headers to their original labels without sort indicators."""
+        for col, label in self.column_labels.items():
+            self.message_list.heading(
+                col,
+                text=label,
+                command=lambda c=col: self.sort_column(c, False)
+            )
+
     def load_messages(self, path: str) -> None:
         try:
             self.status_label.config(text="Loading...")
             self.root.update_idletasks()
             settings = self._current_settings()
+
+            # Reset headers to remove any previous sort indicators
+            self._reset_column_headers()
 
             # Cache file data to improve responsiveness during filtering
             if self._cache.get('path') != path:
@@ -521,10 +519,22 @@ class QwkGuiApp:
         for index, (_, k) in enumerate(l):
             self.message_list.move(k, "", index)
 
-        # Update heading to toggle reverse flag
-        self.message_list.heading(
-            col, command=lambda: self.sort_column(col, not reverse)
-        )
+        # Update all headings to show indicators and set correct toggle commands
+        for c in self.column_labels:
+            label = self.column_labels[c]
+            if c == col:
+                label += " ▼" if reverse else " ▲"
+                # If we just sorted this column, the next click should reverse it
+                next_reverse = not reverse
+            else:
+                # If we click a different column, it should start as ascending
+                next_reverse = False
+
+            self.message_list.heading(
+                c,
+                text=label,
+                command=lambda _c=c, _r=next_reverse: self.sort_column(_c, _r)
+            )
 
 
 def main() -> None:

--- a/tests/test_gui_sort_indicators.py
+++ b/tests/test_gui_sort_indicators.py
@@ -1,0 +1,77 @@
+import sys
+from unittest.mock import MagicMock, patch, call, ANY
+import pytest
+
+# Mock tkinter before any pyqwk.gui imports
+mock_tk = MagicMock()
+mock_ttk = MagicMock()
+sys.modules["tkinter"] = mock_tk
+sys.modules["tkinter.filedialog"] = MagicMock()
+sys.modules["tkinter.messagebox"] = MagicMock()
+sys.modules["tkinter.ttk"] = mock_ttk
+
+from pyqwk.gui import QwkGuiApp
+
+@pytest.fixture
+def mock_gui_deps():
+    with patch("pyqwk.gui.tk") as mock_tk, \
+         patch("pyqwk.gui.ttk") as mock_ttk:
+
+        # Configure Variable mocks
+        def make_var(value=None):
+            m = MagicMock()
+            m.get.return_value = value
+            return m
+        mock_tk.BooleanVar.side_effect = lambda value=False, **kwargs: make_var(value)
+        mock_tk.StringVar.side_effect = lambda value="", **kwargs: make_var(value)
+
+        yield {
+            "tk": mock_tk,
+            "ttk": mock_ttk,
+        }
+
+def test_sort_indicators_update(mock_gui_deps):
+    root = MagicMock()
+    app = QwkGuiApp(root)
+
+    # Mock message_list behavior
+    app.message_list.get_children.return_value = ["item1", "item2"]
+    app.message_list.set.side_effect = lambda k, col: "Value2" if k == "item1" else "Value1"
+    app.threaded_var.get.return_value = False
+
+    # 1. Initial sort by "From" (ascending)
+    app.sort_column("From", False)
+
+    # Check that "From" header has ascending arrow
+    app.message_list.heading.assert_any_call("From", text="From ▲", command=ANY)
+    # Check that other headers have no arrow
+    app.message_list.heading.assert_any_call("Num", text="Num", command=ANY)
+
+    # 2. Sort same column "From" (descending)
+    app.message_list.heading.reset_mock()
+    app.sort_column("From", True)
+    app.message_list.heading.assert_any_call("From", text="From ▼", command=ANY)
+
+    # 3. Sort different column "Num" (ascending)
+    app.message_list.heading.reset_mock()
+    app.sort_column("Num", False)
+    app.message_list.heading.assert_any_call("Num", text="Num ▲", command=ANY)
+    app.message_list.heading.assert_any_call("From", text="From", command=ANY)
+
+def test_load_messages_resets_indicators(mock_gui_deps):
+    root = MagicMock()
+    app = QwkGuiApp(root)
+
+    with patch("pyqwk.gui.load_data") as mock_load_data, \
+         patch("pyqwk.gui.parse_messages") as mock_parse_messages:
+
+        mock_load_data.return_value = (bytearray(b"Produced "), {})
+        mock_parse_messages.return_value = []
+
+        # Manually set an indicator
+        app.message_list.heading("From", text="From ▲")
+
+        app.load_messages("test.qwk")
+
+        # Check that headers were reset
+        app.message_list.heading.assert_any_call("From", text="From", command=ANY)


### PR DESCRIPTION
This PR improves the usability of the `pyqwk` GUI by adding visual sort direction indicators (up/down arrows) to the message list headers.

### Problem:
The user could not easily see which column the message list was sorted by, nor in what direction. This was a friction point when navigating large archives.

### Solution:
- **Visual Feedback:** Added Unicode arrows (▲ for ascending, ▼ for descending) to the active sort column header.
- **Consistency:** Clicking a different column now always starts with ascending order, while clicking the same column toggles the direction.
- **Robustness:** Indicators are cleared when a new QWK archive is opened.
- **Code Quality:** Refactored header initialization into a clean loop using a configuration mapping.

### Changes:
- Modified `pyqwk/gui.py` to support dynamic header updates.
- Added `tests/test_gui_sort_indicators.py` to verify the logic.
- Verified with full test suite (319/319 passed).

---
*PR created automatically by Jules for task [2412816578817045422](https://jules.google.com/task/2412816578817045422) started by @RainRat*