### PR TITLE
[DOCS] Improve CLI documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,8 @@ for msg in parse_messages(file_data, None):
 | `-m`, `--merge` | Combine multiple inputs into a single output file. |
 | `-u`, `--unique` | Only include unique messages (removes duplicates when merging archives). |
 | `-S`, `--search [term]` | Search for a keyword in author, subject, and message text. |
-| `-C`, `--conference [id]` | Only show messages from this conference name or number. |
+| `--regex` | Use regular expressions for searching and filtering. |
+| `-C, --conference [id]` | Only show messages from this conference name or number (can be used multiple times). |
 | `--clean` | Automatically remove signatures, quotes, attachments, and color codes. |
 | `-t, --truncate-signatures` | Stop reading a message when a signature is found. |
 | `-c, --cut-quoting` | Remove text quoted from earlier messages. |
@@ -260,9 +261,9 @@ for msg in parse_messages(file_data, None):
 | `-H, --headers-only` | Show only message headers and skip the message text. |
 | `-E, --encoding [name]` | Set the text character set (default is `cp437`). |
 | `-p`, `--private` | Include private messages in the output. |
-| `-f, --from [name]` | Only show messages from this author. |
-| `--to [name]` | Only show messages to this recipient. |
-| `-s, --subject [text]` | Only show messages with this word in the subject. |
+| `-f, --from [name]` | Only show messages from this author (can be used multiple times). |
+| `--to [name]` | Only show messages to this recipient (can be used multiple times). |
+| `-s, --subject [text]` | Only show messages with this word in the subject (can be used multiple times). |
 | `--after [date]` | Only show messages from this date or later (YYYY-MM-DD). |
 | `--before [date]` | Only show messages from this date or earlier (YYYY-MM-DD). |
 | `-n, --noheader` | Do not include the message header information in the text. |
@@ -270,13 +271,13 @@ for msg in parse_messages(file_data, None):
 | `--separator [type]` | How to separate messages (`auto`, `none`, `dashes`, `blank`). |
 | `-v`, `--verbose` | Show more details like conference names and message numbers. |
 | `-q`, `--quiet` | Hide the progress bar and extra information. |
-| `--loglevel [level]` | Set how much detail to show in logs (DEBUG, INFO, WARNING, ERROR). |
+| `-l, --loglevel [level]` | Set how much detail to show in logs (DEBUG, INFO, WARNING, ERROR, CRITICAL). |
 | `-L, --limit [num]` | Stop after processing this many messages. |
 | `-K, --skip [num]` | Skip the first this many matching messages. |
 | `--sort [field]` | Sort results by: `date`, `author`, `to`, `subject`, `num`, or `conference`. |
 | `--reverse` | Reverse the order of the output. |
-| `-I, --info` | Show a summary of the archive and exit. |
-| `--stats` | Show detailed statistics about the messages and exit. |
+| `-I, --info` | Show a summary of the archive and exit. Use `--format json` for JSON output. |
+| `--stats` | Show detailed statistics about the messages and exit. Use `--format json` for JSON output. |
 | `-V, --version` | Show the version number and exit. |
 
 Run `qwk --help` to see all available options.


### PR DESCRIPTION
This PR improves the CLI documentation in the `README.md` file by making it more comprehensive and accurate. 

Key changes include:
- Documenting the previously missing `--regex` flag.
- Updating the `--loglevel` entry to include its `-l` short flag and the `CRITICAL` log level.
- Adding information about JSON output support for the `--info` and `--stats` commands.
- Clarifying that filtering flags such as `--conference`, `--from`, `--to`, and `--subject` can be used multiple times. 

These changes make the tool's capabilities more visible and understandable for users.

---
*PR created automatically by Jules for task [14695990120738463187](https://jules.google.com/task/14695990120738463187) started by @RainRat*