### PR TITLE
[FEAT] Add Dry Run mode to preview conversion results

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ pyqwk is a tool to convert old `.QWK` mail archives (from the BBS era) into mode
 - **Content Cleaning:** Automatically remove signatures, old quotes, and attachments like images.
 - **Privacy:** Hide personal information and handle private messages.
 - **Batch Processing:** Convert many archives at once or merge them into a single file.
+- **Dry Run Mode:** Preview the results of a conversion without writing any files to disk.
 - **Built-in Reader:** A simple graphical interface to read messages without converting them. It includes search and filtering tools.
 
 ## Prerequisites
@@ -204,6 +205,12 @@ Find messages from a specific date range (use YYYY-MM-DD).
 qwk archive.qwk --after 2023-01-01 --before 2023-12-31
 ```
 
+**Dry Run:**
+Preview exactly how many messages match your filters and how many files will be created without actually making any changes.
+```bash
+qwk archives/ --search "BBS" --dry-run
+```
+
 ## Library Usage
 
 You can use `pyqwk` in your own Python projects:
@@ -270,6 +277,7 @@ for msg in parse_messages(file_data, None):
 | `--separator [type]` | How to separate messages (`auto`, `none`, `dashes`, `blank`). |
 | `-v`, `--verbose` | Show more details like conference names and message numbers. |
 | `-q`, `--quiet` | Hide the progress bar and extra information. |
+| `--dry-run` | Preview actions without writing files to disk. |
 | `--loglevel [level]` | Set how much detail to show in logs (DEBUG, INFO, WARNING, ERROR). |
 | `-L, --limit [num]` | Stop after processing this many messages. |
 | `-K, --skip [num]` | Skip the first this many matching messages. |

--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -221,6 +221,11 @@ def main() -> None:
         action='store_true',
     )
     control_group.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='Do everything except actually writing files. Useful for testing filters.',
+    )
+    control_group.add_argument(
         '-l',
         '--loglevel',
         help='Choose how much detail to show in logs (DEBUG, INFO, WARNING, ERROR).',
@@ -422,6 +427,7 @@ def main() -> None:
         skip=args.skip,
         sort=args.sort,
         reverse=args.reverse,
+        dry_run=args.dry_run,
     )
 
     if args.info:

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -154,6 +154,7 @@ class ProcessingSettings:
     output_path: str | None
     encoding: str
     regex: bool = False
+    dry_run: bool = False
     strip_ansi: bool = False
     quiet: bool = False
     headers_only: bool = False
@@ -899,12 +900,14 @@ def process_merged_files(
 
     total_matching = 0
     processed_count = 0
+    estimated_bytes = 0
+    potential_files = 0
     use_streaming = not (settings.sort or settings.reverse)
     sort_buffer: list[tuple[ParsedMessage, dict[int, str]]] = []
 
     def handle_output(parsed_message: ParsedMessage, board_dict: dict[int, str]) -> bool:
         """Process and output a single message. Returns True if processing should stop."""
-        nonlocal total_matching, processed_count
+        nonlocal total_matching, processed_count, estimated_bytes, potential_files
 
         total_matching += 1
         if settings.skip is not None and total_matching <= settings.skip:
@@ -995,20 +998,25 @@ def process_merged_files(
                 filename = filename.replace(".", f"-{short_hash}.")
                 full_path = os.path.join(target_dir, filename)
 
-            with open(full_path, 'wb') as f:
-                f.write(encoded_buffer)
+            estimated_bytes += len(encoded_buffer)
+            potential_files += 1
+            if not settings.dry_run:
+                with open(full_path, 'wb') as f:
+                    f.write(encoded_buffer)
         else:
-            text_content = processed_buffer
-            if settings.headers_only:
-                if settings.format in ('json', 'xml', 'csv', 'sqlite', 'mbox'):
-                    text_content = ""
+            estimated_bytes += len(processed_buffer.encode('utf-8'))
+            if not settings.dry_run:
+                text_content = processed_buffer
+                if settings.headers_only:
+                    if settings.format in ('json', 'xml', 'csv', 'sqlite', 'mbox'):
+                        text_content = ""
 
-            collected_messages.append(
-                replace(
-                    parsed_message,
-                    text=text_content,
+                collected_messages.append(
+                    replace(
+                        parsed_message,
+                        text=text_content,
+                    )
                 )
-            )
         return False
 
     for input_path in input_paths:
@@ -1080,29 +1088,47 @@ def process_merged_files(
                 break
 
     if not settings.individual_files:
-        ordered_messages = (
-            _order_messages_by_thread(collected_messages)
-            if settings.threaded
-            else collected_messages
-        )
+        if not settings.dry_run:
+            ordered_messages = (
+                _order_messages_by_thread(collected_messages)
+                if settings.threaded
+                else collected_messages
+            )
 
-        writers: dict[str, Callable[[list[ProcessedMessage], str | None, str], None]] = {
-            'json': _write_json,
-            'xml': _write_xml,
-            'html': _write_html,
-            'markdown': _write_markdown,
-            'text': _write_text,
-            'csv': _write_csv,
-            'mbox': _write_mbox,
-            'eml': _write_eml,
-            'sqlite': _write_sqlite,
-        }
+            writers: dict[str, Callable[[list[ProcessedMessage], str | None, str], None]] = {
+                'json': _write_json,
+                'xml': _write_xml,
+                'html': _write_html,
+                'markdown': _write_markdown,
+                'text': _write_text,
+                'csv': _write_csv,
+                'mbox': _write_mbox,
+                'eml': _write_eml,
+                'sqlite': _write_sqlite,
+            }
 
-        writer = writers.get(settings.format, _write_text)
-        output_encoding = 'utf-8'
-        if settings.format == 'text':
-            output_encoding = settings.encoding
-        writer(ordered_messages, resolved_output_path, output_encoding)
+            writer = writers.get(settings.format, _write_text)
+            output_encoding = 'utf-8'
+            if settings.format == 'text':
+                output_encoding = settings.encoding
+            writer(ordered_messages, resolved_output_path, output_encoding)
+        else:
+            potential_files = 1
+
+    if settings.dry_run:
+        CYAN = "36"
+        BOLD = "1"
+        print(f"\n{_colorize('--- Dry Run Summary ---', BOLD, CYAN)}")
+        print(f"Archives processed: {len(input_paths)}")
+        print(f"Matching messages:  {processed_count}")
+        if settings.individual_files:
+            print(f"Files to create:    {potential_files}")
+        else:
+            print(f"Files to create:    1 (merged)")
+
+        size_str = f"{estimated_bytes / 1024:.1f} KB" if estimated_bytes < 1024 * 1024 else f"{estimated_bytes / (1024 * 1024):.1f} MB"
+        print(f"Estimated size:     {size_str}")
+        print(f"{_colorize('No changes were made to the disk.', BOLD)}")
 
 
 def process_file(

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1,0 +1,89 @@
+import pytest
+import sys
+from pathlib import Path
+from pyqwk.core import process_file, ProcessingSettings, load_data, parse_messages
+from pyqwk.cli import main
+import logging
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+@pytest.fixture
+def baseline_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "testdata" / "messages.dat"
+
+@pytest.fixture
+def logger() -> logging.Logger:
+    logger = logging.getLogger("pyqwk.tests")
+    logger.addHandler(logging.NullHandler())
+    return logger
+
+def test_process_file_dry_run_no_files_created(tmp_path, baseline_path, logger):
+    output_dir = tmp_path / "output"
+    output_dir.mkdir()
+
+    settings = ProcessingSettings(
+        verbose=False,
+        private=False,
+        no_header=False,
+        truncate_signatures=False,
+        cut_quoting=False,
+        individual_files=True,
+        threaded=False,
+        binaries_removal=False,
+        redact_pii=False,
+        format="text",
+        separator="auto",
+        output_mode="file",
+        output_path=str(output_dir),
+        encoding="latin1",
+        dry_run=True
+    )
+
+    process_file(str(baseline_path), settings, logger)
+
+    # Check that no files were created in the output directory
+    assert len(list(output_dir.iterdir())) == 0
+
+def test_process_file_dry_run_summary_printed(capsys, baseline_path, logger):
+    settings = ProcessingSettings(
+        verbose=False,
+        private=False,
+        no_header=False,
+        truncate_signatures=False,
+        cut_quoting=False,
+        individual_files=False,
+        threaded=False,
+        binaries_removal=False,
+        redact_pii=False,
+        format="text",
+        separator="auto",
+        output_mode="stdout",
+        output_path=None,
+        encoding="latin1",
+        dry_run=True,
+        quiet=True
+    )
+
+    process_file(str(baseline_path), settings, logger)
+
+    captured = capsys.readouterr()
+    assert "--- Dry Run Summary ---" in captured.out
+    assert "Archives processed: 1" in captured.out
+    assert "Matching messages:  1" in captured.out
+    assert "No changes were made to the disk." in captured.out
+    # Should not print the actual message
+    assert "Subject:" not in captured.out
+
+def test_cli_dry_run_flag_works(monkeypatch, baseline_path, capsys):
+    monkeypatch.setattr(sys, "argv", ["qwk", str(baseline_path), "--dry-run"])
+
+    # Run main and catch potential SystemExit
+    try:
+        main()
+    except SystemExit as e:
+        assert e.code == 0
+
+    captured = capsys.readouterr()
+    assert "--- Dry Run Summary ---" in captured.out
+    assert "No changes were made to the disk." in captured.out

--- a/tests/test_qwk.py
+++ b/tests/test_qwk.py
@@ -85,6 +85,7 @@ def _make_settings(**overrides) -> ProcessingSettings:
         before=None,
         limit=None,
         skip=None,
+        dry_run=False,
     )
     defaults.update(overrides)
     return ProcessingSettings(**defaults)
@@ -129,6 +130,7 @@ def _make_cli_namespace(**overrides: object) -> argparse.Namespace:
         regex=False,
         info=False,
         stats=False,
+        dry_run=False,
     )
     base.update(overrides)
     return argparse.Namespace(**base)


### PR DESCRIPTION
Implemented a new "Dry Run" mode for the `pyqwk` utility. This feature enables users to preview exactly what would happen during a conversion (how many messages match their filters, how many files will be created, and the estimated total disk space required) without actually performing any disk writes. This is particularly useful for testing complex filtering and cleaning options on large archives.

Key additions:
- `--dry-run` CLI flag.
- Detailed summary report printed at the conclusion of a dry run.
- Comprehensive unit tests covering both core logic and CLI integration.
- Updated documentation in README.md.

---
*PR created automatically by Jules for task [6159499777395102517](https://jules.google.com/task/6159499777395102517) started by @RainRat*