### PR TITLE
Fix missing EML format in auto-separator suppression logic

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -891,7 +891,7 @@ def process_merged_files(
     separator_mode = settings.separator
     if separator_mode == 'auto':
         if settings.individual_files or settings.format in (
-            'json', 'xml', 'html', 'csv', 'markdown', 'sqlite', 'mbox'
+            'json', 'xml', 'html', 'csv', 'markdown', 'sqlite', 'mbox', 'eml'
         ):
             separator_mode = 'none'
         else:


### PR DESCRIPTION
Added 'eml' to the whitelist of formats that suppress the automatic separator in `pyqwk/core.py`. Verified with a reproduction test and ensured no regressions with existing tests.

---
*PR created automatically by Jules for task [13057835295752717055](https://jules.google.com/task/13057835295752717055) started by @RainRat*