### PR TITLE
[TEST] Add coverage for CLI merge mode error handling

### DIFF
--- a/tests/test_cli_coverage_extra.py
+++ b/tests/test_cli_coverage_extra.py
@@ -130,3 +130,17 @@ def test_individual_files_mode_setup(monkeypatch, testdata_dir, tmp_path):
     with monkeypatch.context() as m:
         m.setattr(cli, "process_file", lambda *args: None)
         main()
+
+def test_merge_mode_error(monkeypatch, testdata_dir, caplog):
+    from unittest.mock import MagicMock
+    input_file = testdata_dir / "messages.dat"
+    monkeypatch.setattr(sys, "argv", ["qwk", str(input_file), "--merge"])
+
+    import pyqwk.cli as cli
+    with monkeypatch.context() as m:
+        m.setattr(cli, "process_merged_files", MagicMock(side_effect=OSError("Merge failure")))
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(SystemExit) as exc:
+                main()
+            assert exc.value.code == 1
+            assert "Merge failure" in caplog.text


### PR DESCRIPTION
This PR adds a specific test case to cover the error handling logic in the CLI's merge mode. Previously, the `except PROCESSING_EXCEPTIONS` block in the merge path was untested. The new test mocks `process_merged_files` to raise an `OSError` and verifies that the error is appropriately logged and that the program exits with a status of 1.

---
*PR created automatically by Jules for task [11268508121671292097](https://jules.google.com/task/11268508121671292097) started by @RainRat*