### PR TITLE
Implement conference discovery in GUI reader

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -394,6 +394,23 @@ class QwkGuiApp:
             # Cache file data to improve responsiveness during filtering
             if self._cache.get('path') != path:
                 file_data, board_dict = load_data(path, self.logger, settings.encoding)
+
+                # Ensure all conferences present in the data are in the dropdown,
+                # even if CONTROL.DAT is missing or incomplete.
+                try:
+                    found_confs = set()
+                    for parsed_message in parse_messages(
+                        file_data, None, settings.encoding, headers_only=True
+                    ):
+                        found_confs.add(parsed_message.confnum)
+
+                    for cid in sorted(found_confs):
+                        if cid not in board_dict:
+                            board_dict[cid] = f"Conference {cid}"
+                except Exception:
+                    # If discovery fails, we proceed with whatever load_data found
+                    pass
+
                 self._cache = {
                     'path': path,
                     'file_data': file_data,


### PR DESCRIPTION
This PR improves the GUI reader by ensuring that the conference filter dropdown is populated even when opening a standalone `messages.dat` file. It implements a discovery phase that scans message headers for unique conference IDs and adds them to the UI mapping with generic names if no descriptive name is available from a `CONTROL.DAT` file.

---
*PR created automatically by Jules for task [16810471193095297492](https://jules.google.com/task/16810471193095297492) started by @RainRat*