### PR TITLE
[UI/UX] Clickable Ref # links for easier conversation navigation

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -230,6 +230,13 @@ class QwkGuiApp:
         self.detail_text.tag_configure(
             "search_highlight", background="#ffff00", foreground="#000000"
         )
+        self.detail_text.tag_configure("link", foreground="blue", underline=True)
+        self.detail_text.tag_bind(
+            "link", "<Enter>", lambda e: self.detail_text.config(cursor="hand2")
+        )
+        self.detail_text.tag_bind(
+            "link", "<Leave>", lambda e: self.detail_text.config(cursor="")
+        )
 
     def _current_settings(self) -> ProcessingSettings:
         clean = self.clean_var.get()
@@ -296,7 +303,13 @@ class QwkGuiApp:
                 self.detail_text.insert(tk.END, f"{header.msgnum}\t", "header_value")
             if message.refnum:
                 self.detail_text.insert(tk.END, "Ref #: ", "header_label")
-                self.detail_text.insert(tk.END, f"{message.refnum}\t", "header_value")
+                self.detail_text.insert(tk.END, str(message.refnum), "link")
+                self.detail_text.insert(tk.END, "\t", "header_value")
+                self.detail_text.tag_bind(
+                    "link",
+                    "<Button-1>",
+                    lambda e, c=header.confnum, r=message.refnum: self.jump_to_message(c, r),
+                )
             self.detail_text.insert(tk.END, "\n")
 
         header_end = self.detail_text.index(tk.INSERT)
@@ -535,6 +548,22 @@ class QwkGuiApp:
         self.detail_text.delete("1.0", tk.END)
         self.detail_text.insert(tk.END, text)
         self.detail_text.config(state=tk.DISABLED)
+
+    def jump_to_message(self, confnum: int, msgnum: int) -> None:
+        """Find and select a message by conference and message number."""
+        for i, m in enumerate(self.messages):
+            if m.header.confnum == confnum and m.header.msgnum == msgnum:
+                iid = str(i)
+                if self.message_list.exists(iid):
+                    self.message_list.selection_set(iid)
+                    self.message_list.see(iid)
+                    self.message_list.focus(iid)
+                    self.on_message_selected()
+                    return
+        messagebox.showinfo(
+            "Not Found",
+            f"Referenced message #{msgnum} was not found in the current view.",
+        )
 
     def on_message_selected(self, _event: object | None = None) -> None:
         selected_items = self.message_list.selection()

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -408,3 +408,29 @@ class TestQwkGui:
         app.message_list.selection.return_value = ("not-an-int",)
         app.on_message_selected()
         app.detail_text.delete.assert_not_called()
+
+    def test_jump_to_message_found(self, mock_gui_deps):
+        app = get_app()
+        header1 = MessageHeader(' ', 1, "01-01-90", "12:00", "To", "From", "Sub", "", None, 1, " ", 1, 1, "")
+        header2 = MessageHeader(' ', 2, "01-01-90", "12:05", "To", "From", "Sub", "", 1, 1, " ", 1, 1, "")
+        app.messages = [
+            ParsedMessage("Msg 1", 1, None, 1, header1),
+            ParsedMessage("Msg 2", 2, 1, 1, header2)
+        ]
+        app.message_list.exists.return_value = True
+
+        with patch.object(app, "on_message_selected") as mock_on_selected:
+            app.jump_to_message(1, 1) # Jump to conf 1, msg 1
+            mock_on_selected.assert_called_once()
+
+        app.message_list.selection_set.assert_called_with("0")
+        app.message_list.see.assert_called_with("0")
+        app.message_list.focus.assert_called_with("0")
+
+    def test_jump_to_message_not_found(self, mock_gui_deps):
+        app = get_app()
+        app.messages = []
+        app.jump_to_message(1, 999)
+        mock_gui_deps["messagebox"].showinfo.assert_called_with(
+            "Not Found", "Referenced message #999 was not found in the current view."
+        )


### PR DESCRIPTION
Improved the usability of the QWK message reader by making message reference numbers clickable. This allows users to jump directly to parent messages in a conversation, significantly reducing friction when navigating archives. The implementation includes visual feedback (blue underline and hand cursor) and robust error handling if the referenced message is not in the current filtered view.

---
*PR created automatically by Jules for task [8755890148775941455](https://jules.google.com/task/8755890148775941455) started by @RainRat*