### PR TITLE
Fix logic bug in filename collision avoidance

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -1038,7 +1038,8 @@ def process_merged_files(
             # Collision avoidance
             if os.path.exists(full_path):
                 short_hash = hashlib.sha1(encoded_buffer).hexdigest()[:8]
-                filename = filename.replace(".", f"-{short_hash}.")
+                base, ext = os.path.splitext(filename)
+                filename = f"{base}-{short_hash}{ext}"
                 full_path = os.path.join(target_dir, filename)
 
             estimated_bytes += len(encoded_buffer)


### PR DESCRIPTION
The current implementation of filename collision avoidance uses `filename.replace(".", f"-{short_hash}.")`, which replaces all occurrences of a dot in the filename. This leads to incorrect filenames when the base name contains dots (e.g., `archive.tar.gz` becomes `archive-hash.tar-hash.gz`).

I replaced this with a more robust implementation using `os.path.splitext(filename)`, which correctly splits the filename into base and extension, allowing us to append the hash only to the base part.

This is a non-breaking change as it only affects how collisions are handled, resulting in more predictable and standard filenames.

---
*PR created automatically by Jules for task [13167815070625311039](https://jules.google.com/task/13167815070625311039) started by @RainRat*