### PR TITLE
[DOCS] Improve CLI help text for --format option

### DIFF
--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -177,7 +177,7 @@ def main() -> None:
         '--format',
         help=(
             'Choose the output format (text, json, xml, html, markdown, csv, mbox, eml, or sqlite). '
-            'If you do not choose one, it is guessed from the output filename.'
+            'If not specified, it is determined by the output filename extension.'
         ),
         default=None,
         choices=['text', 'json', 'xml', 'html', 'markdown', 'csv', 'mbox', 'eml', 'sqlite'],


### PR DESCRIPTION
This PR improves the CLI documentation by refining the help text for the `--format` option. It replaces unprofessional jargon ("guessed") with a more precise term ("determined") and simplifies the sentence structure to follow Plain English guidelines.

**Type:** Internal Help
**What:** `pyqwk/cli.py` (CLI help string for `--format`)
**Why:** Improves professional tone and clarity for users.

---
*PR created automatically by Jules for task [4513830950849230960](https://jules.google.com/task/4513830950849230960) started by @RainRat*