### PR TITLE
Improve error reporting in info and stats commands

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -1956,8 +1956,8 @@ def show_info(input_paths: list[str], settings: ProcessingSettings, logger: logg
                 ):
                     total_messages += 1
                     conference_counts[message.confnum] += 1
-            except MessagesDatFormatError:
-                pass
+            except MessagesDatFormatError as e:
+                logger.warning(f"File {input_path} appears truncated or malformed: {e}")
 
             info_entry["total_messages"] = total_messages
             if bbs_info:
@@ -1997,7 +1997,7 @@ def show_info(input_paths: list[str], settings: ProcessingSettings, logger: logg
 
             all_info.append(info_entry)
 
-        except Exception as e:
+        except PROCESSING_EXCEPTIONS as e:
             logger.error(f"Error reading info for {input_path}: {e}")
 
     if settings.format == 'json':
@@ -2144,7 +2144,7 @@ def show_stats(input_paths: list[str], settings: ProcessingSettings, logger: log
 
             all_stats.append(stats_entry)
 
-        except Exception as e:
+        except PROCESSING_EXCEPTIONS as e:
             logger.error(f"Error calculating stats for {input_path}: {e}")
 
     if settings.format == 'json':

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -96,7 +96,7 @@ def test_process_multiple_files_error_handling(tmp_path, logger, default_setting
 
 def test_show_info_error_handling(logger, default_settings):
     with patch('pyqwk.core.load_data') as mock_load:
-        mock_load.side_effect = Exception("Mocked Error")
+        mock_load.side_effect = IOError("Mocked Error")
 
         with patch.object(logger, 'error') as mock_log_error:
             show_info(['fake.zip'], default_settings, logger)
@@ -106,7 +106,7 @@ def test_show_info_error_handling(logger, default_settings):
 
 def test_show_stats_error_handling(logger, default_settings):
     with patch('pyqwk.core.load_data') as mock_load:
-        mock_load.side_effect = Exception("Mocked Error")
+        mock_load.side_effect = IOError("Mocked Error")
 
         with patch.object(logger, 'error') as mock_log_error:
             show_stats(['fake.zip'], default_settings, logger)


### PR DESCRIPTION
This PR improves code quality by addressing "Error Handling Noise" in the `show_info` and `show_stats` functions.

Key changes:
1.  **More Specific Exception Catching:** Replaced generic `except Exception` blocks with the targeted `PROCESSING_EXCEPTIONS` tuple. This ensures that only expected processing errors are caught while allowing unexpected logic bugs to surface during development and maintenance.
2.  **Improved Observability in `show_info`:** Removed a silent `pass` block that was hiding `MessagesDatFormatError` during the initial metadata scan. The function now logs a warning if a file appears truncated, providing better feedback to the user while still attempting a "best effort" report of the valid data found.
3.  **Test Alignment:** Updated `tests/test_coverage_gaps.py` to use `IOError` instead of generic `Exception` for error handling mocks, ensuring tests remain compatible with the narrowed exception scope.

These changes are non-breaking and improve the robustness and maintainability of the codebase without altering core behavior.

---
*PR created automatically by Jules for task [17869205662655672660](https://jules.google.com/task/17869205662655672660) started by @RainRat*