### PR TITLE
[DOCS] Improve accessibility and remove jargon from CLI and API documentation

### DIFF
--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -83,7 +83,7 @@ def _parse_cli_date(date_str: str | None, end_of_day: bool = False) -> datetime.
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Convert old QWK mail archives from the BBS era into modern formats like Text, HTML, JSON, and more."
+        description="A tool to read and convert old Bulletin Board System (BBS) message packets (QWK format) into modern formats like Text, HTML, or JSON."
     )
     parser.add_argument(
         'input_paths',
@@ -102,7 +102,7 @@ def main() -> None:
         '-i',
         '--individual-files',
         dest='individualfiles',
-        help='Save each message as a separate file with a human-readable name. For HTML and Markdown formats, an index file (index.html or README.md) is automatically generated for easier browsing. This cannot be used with the --threaded option.',
+        help='Save each message as its own file. HTML and Markdown exports will also get a clickable index file. You cannot use this with --threaded.',
         action='store_true',
     )
     io_group.add_argument(
@@ -113,7 +113,7 @@ def main() -> None:
     io_group.add_argument(
         '-E',
         '--encoding',
-        help='Text character set of the input file (default: cp437).',
+        help='The text format of the input file (default is cp437).',
         default='cp437',
     )
 
@@ -127,7 +127,7 @@ def main() -> None:
         '-t',
         '--truncate-signatures',
         dest='truncatesignatures',
-        help="Stop showing the message once a signature (like '---') is found.",
+        help="Stop reading a message when a signature (like '---') is found.",
         action='store_true',
     )
     content_group.add_argument(
@@ -161,7 +161,7 @@ def main() -> None:
     content_group.add_argument(
         '-p',
         '--private',
-        help="Include messages marked as 'Private'.",
+        help="Include private messages.",
         action='store_true',
     )
     content_group.add_argument(
@@ -176,8 +176,8 @@ def main() -> None:
         '-F',
         '--format',
         help=(
-            'Choose the output format (text, json, xml, html, markdown, csv, mbox, eml, or sqlite). '
-            'If you do not choose one, it is guessed from the output filename.'
+            'Choose the output format (text, html, json, etc.). '
+            'If you leave this out, it is determined by the file extension of the output path.'
         ),
         default=None,
         choices=['text', 'json', 'xml', 'html', 'markdown', 'csv', 'mbox', 'eml', 'sqlite'],
@@ -209,7 +209,7 @@ def main() -> None:
     format_group.add_argument(
         '-m',
         '--merge',
-        help='Merge multiple input archives into a single output. This allows conversations to span across different archives.',
+        help='Combine multiple archives into one file. This helps you follow conversations across different files.',
         action='store_true',
     )
 
@@ -279,25 +279,27 @@ def main() -> None:
     )
     filter_group.add_argument(
         '--after',
-        help='Filter messages dated on or after this date (format: YYYY-MM-DD).',
+        help='Only show messages from this date or later (YYYY-MM-DD).',
         default=None,
     )
     filter_group.add_argument(
         '-K',
         '--skip',
-        help='Skip the first [number] matching messages.',
+        metavar='NUM',
+        help='Skip this many matching messages.',
         type=int,
         default=None,
     )
     filter_group.add_argument(
         '--before',
-        help='Filter messages dated on or before this date (format: YYYY-MM-DD).',
+        help='Only show messages from this date or earlier (YYYY-MM-DD).',
         default=None,
     )
     filter_group.add_argument(
         '-L',
         '--limit',
-        help='Process only the first [number] matching messages.',
+        metavar='NUM',
+        help='Process only this many matching messages.',
         type=int,
         default=None,
     )

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -95,7 +95,7 @@ def _is_binary_line(
     in_uue_block: bool,
     in_base64_block: bool,
 ) -> tuple[bool, bool, bool, bool]:
-    """Detect whether a line is part of a binary payload.
+    """Detect whether a line is part of an attachment.
 
     Returns a tuple ``(should_skip, in_yenc_block, in_uue_block, in_base64_block)`` indicating whether the
     caller should exclude the line from output and the updated binary block states.
@@ -177,7 +177,7 @@ class ProcessingSettings:
 
 @dataclass
 class BBSInfo:
-    """Metadata about the BBS that generated the QWK packet."""
+    """Information about the BBS that generated the QWK packet."""
     name: str = ""
     location: str = ""
     phone: str = ""
@@ -191,7 +191,7 @@ class BBSInfo:
 
 
 class ConferenceMap(dict):
-    """A dictionary mapping conference numbers to names, with optional BBS metadata."""
+    """A dictionary mapping conference numbers to names, with optional BBS information."""
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.bbs_info: BBSInfo | None = None
@@ -343,7 +343,7 @@ class MessageHeader:
 
         Args:
             board_dict: Mapping of conference numbers to human-readable names.
-            verbose: Whether to include extra metadata such as message numbers and reference numbers.
+            verbose: Whether to include extra information such as message numbers and reference numbers.
             include_separator: Whether to prepend the message separator line.
             use_colors: Whether to use ANSI colors for terminal output.
             highlight_term: Optional term to highlight in the header values.
@@ -458,20 +458,18 @@ class LogFormatter(logging.Formatter):
 def load_data(
     input_path: str, logger: logging.Logger, encoding: str = 'cp437'
 ) -> tuple[bytearray, dict[int, str]]:
-    """Load message and conference metadata from a QWK packet or raw file.
+    """Load message and conference information from a QWK packet or raw file.
 
     Args:
-        input_path: Path to either a ``messages.dat`` file or a QWK archive containing
-            that file (and optionally ``CONTROL.DAT``).
-        logger: Logger used to report warnings when optional metadata is missing.
-        encoding: Character encoding to use when decoding metadata.
+        input_path: Path to either a ``messages.dat`` file or a QWK archive.
+        logger: Logger used to report warnings when optional information is missing.
+        encoding: The text format to use when reading information.
 
     Returns:
-        A tuple ``(file_data, board_dict)`` where ``file_data`` is a mutable
-        ``bytearray`` containing the full contents of ``messages.dat`` and
-        ``board_dict`` maps conference numbers to their names parsed from
-        ``CONTROL.DAT``. If ``CONTROL.DAT`` is not present, the mapping will be empty
-        and conference identifiers will remain numeric.
+        A tuple ``(file_data, board_dict)`` where ``file_data`` contains the
+        contents of ``messages.dat`` and ``board_dict`` maps conference numbers
+        to their names. If conference names are not found, the names will just
+        be the conference numbers.
     """
     board_dict: dict[int, str] = {}
     if zipfile.is_zipfile(input_path):
@@ -581,19 +579,19 @@ def parse_messages(
     encoding: str = 'cp437',
     headers_only: bool = False,
 ) -> Iterator[ParsedMessage]:
-    """Parse a QWK messages.dat payload into message objects.
+    """Convert the raw data from a QWK message file into a list of messages.
 
     Args:
         file_data: Raw bytes from a messages.dat file.
-        progress_bar: Optional tqdm-compatible progress reporter to update as blocks are read.
-        encoding: Character encoding to use when decoding messages.
+        progress_bar: Optional progress reporter to update as blocks are read.
+        encoding: The text format to use when reading messages.
         headers_only: If True, skips reading the message body content.
 
     Yields:
-        ParsedMessage instances containing the message body, header, and metadata flags.
+        ParsedMessage instances containing the message body, header, and information flags.
 
     Raises:
-        MessagesDatFormatError: If the payload does not start with a valid messages.dat header.
+        MessagesDatFormatError: If the data does not start with a valid messages.dat header.
         InvalidMessageTypeError: If a message header encodes an unknown message type.
     """
     blocks_remaining = 0
@@ -677,18 +675,18 @@ def process_message(
     redact_pii: bool,
     strip_ansi: bool = False,
 ) -> str:
-    """Transform a raw message body according to processing settings.
+    """Clean up and format a raw message body.
 
     Args:
-        message_buffer: The original message text with DOS-style newlines.
-        truncate_signatures: Whether to stop output at common signature separators.
-        cut_quoting: Whether to remove quoted text and quote headers.
-        binaries_removal: Whether to remove attachments (like images or programs) encoded in the text.
-        redact_pii: Whether to hide personal information like email addresses and phone numbers.
-        strip_ansi: Whether to remove color codes and other formatting symbols from the text.
+        message_buffer: The original message text.
+        truncate_signatures: If True, stop reading when a signature is found.
+        cut_quoting: If True, remove quoted text from earlier messages.
+        binaries_removal: If True, remove attachments (like images) from the text.
+        redact_pii: If True, hide personal information like email addresses.
+        strip_ansi: If True, remove color codes and other symbols from the text.
 
     Returns:
-        The processed message text with transformations applied.
+        The cleaned message text.
     """
     message_buffer = message_buffer.lstrip('\r\n').rstrip()
     lines = message_buffer.splitlines()
@@ -1503,7 +1501,7 @@ def _parse_qwk_date(msgdate: str, msgtime: str) -> datetime.datetime:
         msgtime: Time string in 'HH:MM' format.
 
     Returns:
-        A datetime object. Defaults to epoch if parsing fails.
+        A datetime object. Defaults to 1970-01-01 if the date is invalid.
     """
     try:
         # Normalize date separators
@@ -1527,7 +1525,7 @@ def _parse_qwk_date(msgdate: str, msgtime: str) -> datetime.datetime:
 
 
 def _serialize_message_mbox(message: ProcessedMessage) -> str:
-    """Serialize a message to mbox format with threading and metadata.
+    """Serialize a message to mbox format with threading and extra headers.
 
     Includes standard email headers for threading (Message-ID, In-Reply-To, References)
     and custom X-QWK headers for conference names, message numbers, and statuses.
@@ -1579,7 +1577,7 @@ def _serialize_message_mbox(message: ProcessedMessage) -> str:
         parts.append(f"In-Reply-To: {parent_id}")
         parts.append(f"References: {parent_id}")
 
-    # QWK Metadata headers
+    # QWK Information headers
     parts.append(f"X-QWK-Conference: {header.confnum}")
     if message.confname:
         parts.append(f"X-QWK-Conference-Name: {message.confname}")


### PR DESCRIPTION
This submission improves the accessibility of the `pyqwk` tool by simplifying user-facing and developer-facing documentation. Following the Plain English guidelines, I have removed technical jargon and obscure terms from the CLI help text and core API docstrings. These changes ensure that the tool is easier to understand for a global audience, including non-native English speakers and casual users, while maintaining professional clarity for developers. No functional logic was altered, and all 348 tests passed successfully.

---
*PR created automatically by Jules for task [9956606439690248793](https://jules.google.com/task/9956606439690248793) started by @RainRat*