### PR TITLE
[UI/UX] Improve message navigation and metadata clarity

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -400,9 +400,9 @@ class MessageHeader:
         else:
             header_parts.append(fmt_line("Date:", self.msgdate + " " + self.msgtime))
 
-        header_parts.append(fmt_line("From:", self.msgfrom))
-        header_parts.append(fmt_line("To:", self.msgto))
-        header_parts.append(fmt_line("Subject:", self.msgsubject))
+        header_parts.append(fmt_line("From:", self.msgfrom.strip()))
+        header_parts.append(fmt_line("To:", self.msgto.strip()))
+        header_parts.append(fmt_line("Subject:", self.msgsubject.strip()))
 
         if verbose:
             reference_number = str(self.refnum) if self.refnum is not None else ""

--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -81,6 +81,53 @@ class QwkGuiApp:
         self.root.bind("<Control-o>", self.open_file)
         self.root.bind("<Control-q>", self.quit_app)
         self.root.bind("<Escape>", self.clear_search)
+        self.root.bind("j", lambda e: self._select_relative_message(1))
+        self.root.bind("n", lambda e: self._select_relative_message(1))
+        self.root.bind("k", lambda e: self._select_relative_message(-1))
+        self.root.bind("p", lambda e: self._select_relative_message(-1))
+
+    def _get_all_tree_items(self) -> list[str]:
+        """Return a flattened list of all item IDs currently visible in the treeview."""
+        items = []
+
+        def traverse(item_id):
+            items.append(item_id)
+            for child in self.message_list.get_children(item_id):
+                traverse(child)
+
+        for root_item in self.message_list.get_children(""):
+            traverse(root_item)
+        return items
+
+    def _select_relative_message(self, delta: int) -> None:
+        """Move the selection up or down in the treeview display order."""
+        if not self.messages:
+            return
+
+        # If the search entry has focus, don't hijack keyboard navigation
+        if self.root.focus_get() == self.search_entry:
+            return
+
+        all_items = self._get_all_tree_items()
+        if not all_items:
+            return
+
+        current_selection = self.message_list.selection()
+        if not current_selection:
+            new_item = all_items[0]
+        else:
+            current_iid = current_selection[0]
+            try:
+                current_idx = all_items.index(current_iid)
+                new_idx = max(0, min(len(all_items) - 1, current_idx + delta))
+                new_item = all_items[new_idx]
+            except ValueError:
+                new_item = all_items[0]
+
+        self.message_list.selection_set(new_item)
+        self.message_list.see(new_item)
+        self.message_list.focus(new_item)
+        self.on_message_selected()
 
     def clear_search(self, _event: object | None = None) -> None:
         self.search_var.set("")
@@ -294,7 +341,7 @@ class QwkGuiApp:
 
         def insert_field(label: str, value: str, last_in_row: bool = False) -> None:
             self.detail_text.insert(tk.END, f"{label}: ", "header_label")
-            self.detail_text.insert(tk.END, f"{value}\t", "header_value")
+            self.detail_text.insert(tk.END, f"{value.strip()}\t", "header_value")
             if last_in_row:
                 self.detail_text.insert(tk.END, "\n")
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -499,3 +499,55 @@ class TestQwkGui:
         app.message_list.selection.return_value = ("99",)
         with patch("pyqwk.gui.load_data", return_value=(bytearray(), {})):
             app.load_messages("test.qwk")
+
+    def test_navigation_shortcuts(self, mock_gui_deps):
+        app = get_app()
+        header = MessageHeader(' ', 1, "01-01-90", "12:00", "To", "From", "Sub", "", None, 1, " ", 1, 1, "")
+        app.messages = [
+            ParsedMessage("Msg 1", 1, None, 1, header),
+            ParsedMessage("Msg 2", 2, None, 1, header),
+            ParsedMessage("Msg 3", 3, None, 1, header),
+        ]
+        app.message_list.get_children.side_effect = lambda parent="": ["0", "1", "2"] if parent == "" else []
+
+        # No selection initially -> select first
+        app.message_list.selection.return_value = ()
+        with patch.object(app, "on_message_selected") as mock_on_selected:
+            app._select_relative_message(1)
+            app.message_list.selection_set.assert_called_with("0")
+            mock_on_selected.assert_called_once()
+
+        # Selection at index 0 -> move to index 1
+        app.message_list.selection.return_value = ("0",)
+        app._select_relative_message(1)
+        app.message_list.selection_set.assert_called_with("1")
+
+        # Selection at index 2 -> move to next (stay at 2)
+        app.message_list.selection.return_value = ("2",)
+        app._select_relative_message(1)
+        app.message_list.selection_set.assert_called_with("2")
+
+        # Move back
+        app.message_list.selection.return_value = ("1",)
+        app._select_relative_message(-1)
+        app.message_list.selection_set.assert_called_with("0")
+
+    def test_render_message_stripping(self, mock_gui_deps):
+        app = get_app()
+        header = MessageHeader(
+            status=' ', msgnum=1, msgdate='01-01-90', msgtime='12:00',
+            msgto='All             ', msgfrom='User            ', msgsubject='Subject         ',
+            msgpassword='', refnum=None, numblocks=1, msgflag=' ',
+            confnum=1, lognum=1, nettag=''
+        )
+        app.messages = [ParsedMessage(text="Body", msgnum=1, refnum=None, confnum=1, header=header)]
+        app.board_dict = {1: "General"}
+
+        app._render_message(0)
+
+        # Verify that stripped values were inserted
+        # Subject is inserted first
+        app.detail_text.insert.assert_any_call(mock_gui_deps["tk"].END, "Subject\n\n", "header_subject")
+        # Then From and To via insert_field
+        app.detail_text.insert.assert_any_call(mock_gui_deps["tk"].END, "User\t", "header_value")
+        app.detail_text.insert.assert_any_call(mock_gui_deps["tk"].END, "All\t", "header_value")


### PR DESCRIPTION
This PR introduces several UI/UX improvements focused on friction reduction and visual hierarchy.

1. **Friction Reduction:** Added standard navigation shortcuts (`j`/`k`, `n`/`p`) to the GUI, allowing users to move through messages quickly without using the mouse. The navigation logic respects the current Treeview state, including sorting and threading.
2. **Visual Hierarchy & Consistency:** QWK files use fixed-width fields padded with spaces. This PR ensures that these fields ('From', 'To', 'Subject') are stripped of trailing whitespace during human-readable rendering in both the CLI and the GUI detail view. This results in cleaner alignment and less visual clutter.

Tests have been added to `tests/test_gui.py` to verify these changes, and the full test suite (357 tests) passes.

---
*PR created automatically by Jules for task [16805296895059321509](https://jules.google.com/task/16805296895059321509) started by @RainRat*