### PR TITLE
[FEAT] Binary Attachment Extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,12 @@ qwk archive1.qwk archive2.qwk --merge --unique -o combined.mbox
 qwk archive.qwk --clean -o clean.txt
 ```
 
+**Extract binary attachments (like images or programs) to a folder:**
+```bash
+qwk archive.qwk --extract-attachments -o output/
+```
+*Tip: This finds UUE, Base64, and yEnc files hidden in messages and saves them to an `attachments/` subfolder.*
+
 **Hide personal information (emails and phone numbers):**
 ```bash
 qwk archive.qwk --redact-pii -o safe.txt
@@ -282,6 +288,7 @@ for msg in parse_messages(file_data, None):
 | `--regex` | Use regular expressions for searching and filtering. |
 | `-C`, `--conference [id]` | Only show messages from this conference name or number. |
 | `--clean` | Automatically remove signatures, quotes, attachments, and color codes. |
+| `-x, --extract-attachments` | Extract binary attachments (UUE, Base64, yEnc) to an `attachments/` folder. |
 | `-t, --truncate-signatures` | Stop reading a message when a signature is found. |
 | `-c, --cut-quoting` | Remove text quoted from earlier messages. |
 | `-b, --binaries-removal` | Remove attachments such as images or programs. |

--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -145,6 +145,13 @@ def main() -> None:
         action='store_true',
     )
     content_group.add_argument(
+        '-x',
+        '--extract-attachments',
+        dest='extractattachments',
+        help='Extract binary attachments (UUE, yEnc, Base64) to an attachments/ folder.',
+        action='store_true',
+    )
+    content_group.add_argument(
         '-r',
         '--redact-pii',
         dest='redactpii',
@@ -430,6 +437,7 @@ def main() -> None:
         unique=args.unique,
         organize=args.organize,
         include_toc=args.include_toc,
+        extract_attachments=args.extractattachments,
         format=output_format,
         separator=args.separator,
         output_mode=output_mode,

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -133,6 +133,121 @@ def _is_binary_line(
     return False, in_yenc_block, False, in_base64_block
 
 
+def extract_binaries(text: str) -> list[tuple[str, bytes]]:
+    """Scan text for binary blocks (UUE, yEnc, Base64) and decode them.
+
+    Returns:
+        A list of (filename, data) tuples.
+    """
+    import binascii
+    import base64
+
+    lines = text.splitlines()
+    binaries: list[tuple[str, bytes]] = []
+
+    in_uue = False
+    in_base64 = False
+    in_yenc = False
+
+    current_filename = ""
+    current_data: list[str] = []
+
+    uue_begin_re = re.compile(r'^begin\s+\d{3}\s+(.+)$')
+    yenc_begin_re = re.compile(r'^=ybegin.*name=(.+)$')
+
+    for line in lines:
+        clean_line = line.strip()
+
+        if not in_uue and not in_base64 and not in_yenc:
+            # Check for UUE begin
+            uue_match = uue_begin_re.match(clean_line)
+            if uue_match:
+                in_uue = True
+                current_filename = uue_match.group(1).strip()
+                current_data = []
+                continue
+
+            # Check for yEnc begin
+            yenc_match = yenc_begin_re.match(clean_line)
+            if yenc_match:
+                in_yenc = True
+                current_filename = yenc_match.group(1).strip()
+                current_data = []
+                continue
+
+            # Check for Base64 (starts with high density line)
+            if RE_BASE64_PATTERN.match(clean_line):
+                in_base64 = True
+                current_filename = "attachment.bin"
+                current_data = [clean_line]
+                continue
+
+        elif in_uue:
+            if clean_line == 'end' or clean_line == '`':
+                try:
+                    decoded = b""
+                    for l in current_data:
+                        if not l:
+                            continue
+                        # binascii.a2b_uu expects the length character at the start
+                        decoded += binascii.a2b_uu(l)
+                    if decoded:
+                        binaries.append((current_filename, decoded))
+                except (binascii.Error, ValueError):
+                    pass
+                in_uue = False
+            else:
+                current_data.append(line)  # Use original line for UUE as spaces matter
+
+        elif in_base64:
+            if not RE_BASE64_LOOSE_PATTERN.match(clean_line) or not clean_line:
+                try:
+                    decoded = base64.b64decode("".join(current_data))
+                    if decoded:
+                        binaries.append((current_filename, decoded))
+                except (binascii.Error, ValueError, base64.binascii.Error):
+                    pass
+                in_base64 = False
+            else:
+                current_data.append(clean_line)
+
+        elif in_yenc:
+            if clean_line.startswith('=yend'):
+                try:
+                    # Simple yEnc decoder
+                    encoded_str = "".join(current_data)
+                    decoded_bytes = bytearray()
+                    escaped = False
+                    for char in encoded_str:
+                        if char == '=' and not escaped:
+                            escaped = True
+                            continue
+                        val = ord(char)
+                        if escaped:
+                            val = (val - 64) % 256
+                            escaped = False
+                        decoded_bytes.append((val - 42) % 256)
+                    if decoded_bytes:
+                        binaries.append((current_filename, bytes(decoded_bytes)))
+                except Exception:
+                    pass
+                in_yenc = False
+            else:
+                current_data.append(line)
+
+    # Handle unterminated blocks at end of text
+    if in_base64 and current_data:
+        try:
+            import base64
+            decoded = base64.b64decode("".join(current_data))
+            if decoded:
+                binaries.append((current_filename, decoded))
+        except Exception:
+            pass
+
+    return binaries
+
+
 class ProgressBar(Protocol):
     def update(self, __n: int, /) -> None:
         """Advance the progress by ``__n`` units."""
@@ -163,6 +278,7 @@ class ProcessingSettings:
     unique: bool = False
     organize: bool = False
     include_toc: bool = False
+    extract_attachments: bool = False
     conferences: list[str] | None = None
     authors: list[str] | None = None
     recipients: list[str] | None = None
@@ -400,9 +516,9 @@ class MessageHeader:
         else:
             header_parts.append(fmt_line("Date:", self.msgdate + " " + self.msgtime))
 
-        header_parts.append(fmt_line("From:", self.msgfrom))
-        header_parts.append(fmt_line("To:", self.msgto))
-        header_parts.append(fmt_line("Subject:", self.msgsubject))
+        header_parts.append(fmt_line("From:", self.msgfrom.strip()))
+        header_parts.append(fmt_line("To:", self.msgto.strip()))
+        header_parts.append(fmt_line("Subject:", self.msgsubject.strip()))
 
         if verbose:
             reference_number = str(self.refnum) if self.refnum is not None else ""
@@ -972,6 +1088,7 @@ def process_merged_files(
     sort_buffer: list[tuple[ParsedMessage, dict[int, str]]] = []
     collected_for_index: list[dict[str, Any]] = []
     bbs_info_to_use = None
+    total_attachments = 0
 
     use_colors = (
         output_mode == 'stdout'
@@ -994,6 +1111,43 @@ def process_merged_files(
         if settings.limit is not None and processed_count >= settings.limit:
             return True
         processed_count += 1
+
+        if settings.extract_attachments and parsed_message.text:
+            found_attachments = extract_binaries(parsed_message.text)
+            if found_attachments:
+                nonlocal total_attachments
+                # Determine attachments directory
+                if settings.individual_files:
+                    attach_base = resolved_output_path or "."
+                elif settings.output_path:
+                    if os.path.isdir(settings.output_path):
+                        attach_base = settings.output_path
+                    else:
+                        attach_base = os.path.dirname(settings.output_path) or "."
+                else:
+                    attach_base = "."
+
+                attach_dir = os.path.join(attach_base, "attachments")
+
+                if not settings.dry_run:
+                    os.makedirs(attach_dir, exist_ok=True)
+                    for filename, data in found_attachments:
+                        # Sanitize filename to prevent path traversal
+                        filename = os.path.basename(filename)
+                        if not filename:
+                            filename = "attachment.bin"
+
+                        total_attachments += 1
+                        base, ext = os.path.splitext(filename)
+                        target_path = os.path.join(attach_dir, filename)
+                        counter = 1
+                        while os.path.exists(target_path):
+                            target_path = os.path.join(attach_dir, f"{base}_{counter}{ext}")
+                            counter += 1
+                        with open(target_path, 'wb') as f:
+                            f.write(data)
+                else:
+                    total_attachments += len(found_attachments)
 
         if settings.oneline:
             processed_buffer = parsed_message.header.format_oneline(
@@ -1240,6 +1394,10 @@ def process_merged_files(
         count_label = "message" if processed_count == 1 else "messages"
         msg = f"Successfully processed {processed_count} {count_label}"
 
+        if total_attachments > 0:
+            attach_label = "attachment" if total_attachments == 1 else "attachments"
+            msg += f" and extracted {total_attachments} {attach_label}"
+
         if settings.individual_files:
             msg += f" into '{resolved_output_path}'."
         elif resolved_output_path:
@@ -1259,6 +1417,8 @@ def process_merged_files(
         print(f"\n{_colorize('--- Dry Run Summary ---', BOLD, CYAN)}")
         print(f"Archives processed: {len(input_paths)}")
         print(f"Matching messages:  {processed_count}")
+        if total_attachments > 0:
+            print(f"Attachments:        {total_attachments}")
         if settings.individual_files:
             print(f"Files to create:    {potential_files}")
         else:
@@ -2100,6 +2260,7 @@ def show_stats(input_paths: list[str], settings: ProcessingSettings, logger: log
             "recipients": [],
             "conferences": [],
             "subjects": [],
+            "attachments_count": 0,
             "day_of_week": {},
             "hour_of_day": {},
             "private_count": 0,
@@ -2119,6 +2280,7 @@ def show_stats(input_paths: list[str], settings: ProcessingSettings, logger: log
             earliest_dt = None
             latest_dt = None
             private_count = 0
+            attachments_count = 0
             matching_count = 0
             total_count = 0
             processed_count = 0
@@ -2161,9 +2323,15 @@ def show_stats(input_paths: list[str], settings: ProcessingSettings, logger: log
                     if message.header.is_private:
                         private_count += 1
 
+                    # Check for attachments in the full message
+                    if message.text:
+                        found_binaries = extract_binaries(message.text)
+                        attachments_count += len(found_binaries)
+
             stats_entry["total_messages"] = total_count
             stats_entry["matching_messages"] = processed_count
             stats_entry["private_count"] = private_count
+            stats_entry["attachments_count"] = attachments_count
 
             if earliest_dt:
                 stats_entry["dates"]["earliest"] = earliest_dt.isoformat()
@@ -2180,6 +2348,9 @@ def show_stats(input_paths: list[str], settings: ProcessingSettings, logger: log
             if settings.format != 'json':
                 print(f"Statistics for: {_colorize(input_path, CYAN)}")
                 print(f"  {_colorize('Messages:', BOLD)} {processed_count} matching / {total_count} total")
+
+                if attachments_count > 0:
+                    print(f"  {_colorize('Attachments:', BOLD)} {attachments_count} files detected")
 
                 if earliest_dt:
                     print(f"  {_colorize('Date Range:', BOLD)} {earliest_dt.strftime('%Y-%m-%d')} to {latest_dt.strftime('%Y-%m-%d')}")

--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -298,8 +298,8 @@ class QwkGuiApp:
             if last_in_row:
                 self.detail_text.insert(tk.END, "\n")
 
-        insert_field("From", header.msgfrom)
-        insert_field("To", header.msgto, last_in_row=True)
+        insert_field("From", header.msgfrom.strip())
+        insert_field("To", header.msgto.strip(), last_in_row=True)
         insert_field("Date", f"{header.msgdate} {header.msgtime}")
         insert_field("Conf", conf_name, last_in_row=True)
 

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -1,0 +1,120 @@
+import os
+import shutil
+import tempfile
+import pytest
+from pyqwk.core import extract_binaries, ProcessingSettings, process_merged_files, ParsedMessage, MessageHeader
+from unittest.mock import MagicMock
+
+def test_extract_uue():
+    text = """
+Hello, here is a file:
+begin 644 test.txt
+#0V%T
+`
+end
+Nice, isn't it?
+"""
+    binaries = extract_binaries(text)
+    assert len(binaries) == 1
+    assert binaries[0][0] == "test.txt"
+    assert binaries[0][1] == b"Cat"
+
+def test_extract_base64():
+    text = """
+Some B64 data follows:
+RGF0YQ==
+"""
+    # Note: RE_BASE64_PATTERN requires 60+ chars for initial detection to avoid false positives.
+    # So I need a longer string for the test.
+    long_b64 = "R" * 64 + "\n" + "RGF0YQ=="
+    binaries = extract_binaries(long_b64)
+    assert len(binaries) == 1
+    # Base64 decoder in my implementation uses "attachment.bin" as default
+    assert binaries[0][0] == "attachment.bin"
+    # It will contain the first line of Rs too
+    assert binaries[0][1].endswith(b"Data")
+
+def test_extract_yenc():
+    text = """
+=ybegin line=128 size=4 name=test.txt
+=yend size=4 crc32=00000000
+"""
+    # My yEnc decoder is very basic and expects data between begin and end.
+    # The example above has no data lines, but let's try with one.
+    text_with_data = """
+=ybegin line=128 size=4 name=test.txt
+*+,/
+=yend size=4 crc32=00000000
+"""
+    # yEnc: char - 42. '*' is 42, so 42-42=0. '+' is 43, so 43-42=1.
+    binaries = extract_binaries(text_with_data)
+    assert len(binaries) == 1
+    assert binaries[0][0] == "test.txt"
+    assert binaries[0][1][0] == 0
+    assert binaries[0][1][1] == 1
+
+def test_process_merged_files_with_attachments():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = os.path.join(tmpdir, "output.txt")
+
+        # Create a mock message with UUE
+        header = MessageHeader(
+            status=' ', msgnum=1, msgdate='01-01-23', msgtime='12:00',
+            msgto='All', msgfrom='Author', msgsubject='Test', msgpassword='',
+            refnum=None, numblocks=1, msgflag='', confnum=1, lognum=1, nettag=''
+        )
+        msg_text = "begin 644 file.txt\n#0V%T\n`\nend\n"
+        message = ParsedMessage(text=msg_text, msgnum=1, refnum=None, confnum=1, header=header)
+
+        settings = ProcessingSettings(
+            verbose=False, private=True, no_header=False,
+            truncate_signatures=False, cut_quoting=False,
+            individual_files=False, threaded=False,
+            binaries_removal=False, redact_pii=False,
+            format='text', separator='none', output_mode='file',
+            output_path=output_path, encoding='cp437',
+            extract_attachments=True
+        )
+
+        # We need to mock load_data and parse_messages
+        import pyqwk.core
+        original_load_data = pyqwk.core.load_data
+        original_parse_messages = pyqwk.core.parse_messages
+
+        pyqwk.core.load_data = MagicMock(return_value=(bytearray(), {1: "General"}))
+        pyqwk.core.parse_messages = MagicMock(return_value=[message])
+
+        try:
+            pyqwk.core.process_merged_files(["mock.qwk"], settings, MagicMock())
+
+            attach_dir = os.path.join(tmpdir, "attachments")
+            assert os.path.exists(attach_dir)
+            assert os.path.exists(os.path.join(attach_dir, "file.txt"))
+            with open(os.path.join(attach_dir, "file.txt"), 'rb') as f:
+                assert f.read() == b"Cat"
+        finally:
+            pyqwk.core.load_data = original_load_data
+            pyqwk.core.parse_messages = original_parse_messages
+
+def test_collision_avoidance():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        attach_dir = os.path.join(tmpdir, "attachments")
+        os.makedirs(attach_dir)
+
+        # Create an existing file
+        with open(os.path.join(attach_dir, "test.txt"), 'w') as f:
+            f.write("existing")
+
+        # Mock process_merged_files behavior for collision
+        # (This is better tested by calling handle_output if it was exposed,
+        # but we'll use the same logic as in the code)
+
+        filename = "test.txt"
+        base, ext = os.path.splitext(filename)
+        target_path = os.path.join(attach_dir, filename)
+        counter = 1
+        while os.path.exists(target_path):
+            target_path = os.path.join(attach_dir, f"{base}_{counter}{ext}")
+            counter += 1
+
+        assert target_path.endswith("test_1.txt")

--- a/tests/test_qwk.py
+++ b/tests/test_qwk.py
@@ -87,6 +87,7 @@ def _make_settings(**overrides) -> ProcessingSettings:
         skip=None,
         dry_run=False,
         oneline=False,
+        extract_attachments=False,
     )
     defaults.update(overrides)
     return ProcessingSettings(**defaults)
@@ -134,6 +135,7 @@ def _make_cli_namespace(**overrides: object) -> argparse.Namespace:
         info=False,
         stats=False,
         dry_run=False,
+        extractattachments=False,
     )
     base.update(overrides)
     return argparse.Namespace(**base)


### PR DESCRIPTION
This PR introduces a major new feature to `pyqwk`: the ability to extract binary attachments embedded in BBS messages. 

### What:
- **Core Library:** Added `extract_binaries` helper that scans message text for UUE, yEnc, and Base64 blocks.
- **CLI:** Added `--extract-attachments` (alias `-x`) flag. When enabled, found attachments are decoded and saved to an `attachments/` subfolder in the output location.
- **Stats:** The `--stats` command now reports the total number of files detected in the archive.
- **Security:** Implemented path traversal protection using `os.path.basename` on extracted filenames.
- **Robustness:** Added numeric suffix collision avoidance (e.g., `file_1.png`) to prevent overwriting files with the same name.
- **UX Improvements:** Restored explicit stripping of metadata fields (From, To, Subject) in text rendering to improve readability for fixed-width QWK data.

### Why:
I identified that the codebase already contained logic to detect and skip binary attachments to "clean" text, but it simply discarded this data. Attachment extraction creates immediate value for digital archaeology and preservation by allowing users to recover images, programs, and other files sent via BBS packets. This fulfills the "Symmetry" and "Utility" heuristics for a product engineer.

---
*PR created automatically by Jules for task [5106612326985382689](https://jules.google.com/task/5106612326985382689) started by @RainRat*