### PR TITLE
Refactor pyqwk/core.py for code hygiene and redundancy cleanup

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -19,6 +19,8 @@ from typing import Any, Callable, Protocol
 import datetime
 import email.utils
 import sqlite3
+import binascii
+import base64
 
 __version__ = "0.1.0"
 
@@ -140,9 +142,6 @@ def extract_binaries(text: str) -> list[tuple[str, bytes]]:
     Returns:
         A list of (filename, data) tuples.
     """
-    import binascii
-    import base64
-
     lines = text.splitlines()
     binaries: list[tuple[str, bytes]] = []
 
@@ -201,7 +200,7 @@ def extract_binaries(text: str) -> list[tuple[str, bytes]]:
                 current_data.append(line)  # Use original line for UUE as spaces matter
 
         elif in_base64:
-            if not RE_BASE64_LOOSE_PATTERN.match(clean_line) or not clean_line:
+            if not RE_BASE64_LOOSE_PATTERN.match(clean_line):
                 try:
                     decoded = base64.b64decode("".join(current_data))
                     if decoded:
@@ -239,7 +238,6 @@ def extract_binaries(text: str) -> list[tuple[str, bytes]]:
     # Handle unterminated blocks at end of text
     if in_base64 and current_data:
         try:
-            import base64
             decoded = base64.b64decode("".join(current_data))
             if decoded:
                 binaries.append((current_filename, decoded))
@@ -1752,7 +1750,7 @@ def _parse_qwk_date(msgdate: str, msgtime: str) -> datetime.datetime:
                 year += 1900
 
         return datetime.datetime(year, month, day, hour, minute)
-    except (ValueError, IndexError):
+    except ValueError:
         # Fallback for invalid dates
         return datetime.datetime(1970, 1, 1, 0, 0)
 


### PR DESCRIPTION
Improved code quality in `pyqwk/core.py` by removing redundant imports and validations.

1.  **Code Hygiene**: Moved `binascii` and `base64` imports to the top of the file to follow PEP 8 and avoid redundant imports inside the `extract_binaries` function.
2.  **Redundant Validation**: Removed a redundant `or not clean_line` check in the Base64 block termination logic of `extract_binaries`, as the Base64 loose regex does not match empty strings.
3.  **Redundant Validation**: Updated `_parse_qwk_date` to only catch `ValueError` during date/time unpacking, as `IndexError` is not raised in that context.

All 366 tests passed successfully.

---
*PR created automatically by Jules for task [7561982236369516550](https://jules.google.com/task/7561982236369516550) started by @RainRat*