### PR TITLE
[UI/UX] Support command-line arguments and dynamic title in GUI

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -1,3 +1,4 @@
+import argparse
 import logging
 import os
 import tkinter as tk
@@ -17,7 +18,7 @@ from pyqwk.core import (
 
 
 class QwkGuiApp:
-    def __init__(self, root: tk.Tk) -> None:
+    def __init__(self, root: tk.Tk, initial_path: str | None = None) -> None:
         self.root = root
         self.root.title("PyQWK Reader")
         self.root.geometry("1100x650")
@@ -54,6 +55,10 @@ class QwkGuiApp:
         self._build_toolbar()
         self._build_status_bar()
         self._build_layout()
+
+        if initial_path:
+            self.current_path = initial_path
+            self.root.after(100, lambda: self.load_messages(initial_path))
 
     def _build_menu(self) -> None:
         menubar = tk.Menu(self.root)
@@ -578,6 +583,7 @@ class QwkGuiApp:
             self.status_label.config(
                 text=f"Showing {len(self.messages)} of {total_count} messages from {source_display}"
             )
+            self.root.title(f"{source_display} - PyQWK Reader")
 
             # Restore selection if possible
             new_iid_to_select = None
@@ -707,9 +713,15 @@ class QwkGuiApp:
 
 
 def main() -> None:
+    parser = argparse.ArgumentParser(description="PyQWK Graphical Reader")
+    parser.add_argument(
+        "path", nargs="?", help="Path to a QWK archive or messages.dat file"
+    )
+    args = parser.parse_args()
+
     logging.basicConfig(level=logging.INFO)
     root = tk.Tk()
-    QwkGuiApp(root)
+    QwkGuiApp(root, initial_path=args.path)
     root.mainloop()
 
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -67,10 +67,10 @@ def mock_gui_deps():
             "combo": mock_combo,
         }
 
-def get_app():
+def get_app(initial_path=None):
     from pyqwk.gui import QwkGuiApp
     root = MagicMock()
-    return QwkGuiApp(root)
+    return QwkGuiApp(root, initial_path=initial_path)
 
 class TestQwkGui:
     def test_initialization(self, mock_gui_deps):
@@ -551,6 +551,33 @@ class TestQwkGui:
         # Then From and To via insert_field
         app.detail_text.insert.assert_any_call(mock_gui_deps["tk"].END, "User\t", "header_value")
         app.detail_text.insert.assert_any_call(mock_gui_deps["tk"].END, "All\t", "header_value")
+
+    def test_initial_path_loading(self, mock_gui_deps):
+        """Test that passing an initial path to the constructor triggers loading."""
+        with patch("pyqwk.gui.QwkGuiApp.load_messages") as mock_load:
+            app = get_app(initial_path="initial.qwk")
+            assert app.current_path == "initial.qwk"
+            # Since we use self.root.after, we need to check that it was scheduled
+            app.root.after.assert_called_with(100, ANY)
+
+    def test_title_update(self, mock_gui_deps):
+        """Test that the window title is updated when a message is loaded."""
+        app = get_app()
+        with patch("pyqwk.gui.load_data") as mock_load_data, \
+             patch("pyqwk.gui.parse_messages") as mock_parse_messages:
+
+            mock_board_dict = MagicMock(spec=dict)
+            mock_board_dict.get.return_value = "General"
+            mock_board_dict.items.return_value = {1: "General"}.items()
+            bbs_info = MagicMock()
+            bbs_info.name = "Test BBS"
+            mock_board_dict.bbs_info = bbs_info
+
+            mock_load_data.return_value = (bytearray(), mock_board_dict)
+            mock_parse_messages.return_value = []
+
+            app.load_messages("test.qwk")
+            app.root.title.assert_called_with("Test BBS (test.qwk) - PyQWK Reader")
 
     def test_conference_discovery(self, mock_gui_deps):
         """Test that conferences found in messages.dat but not in CONTROL.DAT are discovered."""


### PR DESCRIPTION
This improvement reduces friction for power users by allowing them to open QWK archives directly from the command line when launching the graphical reader. It also improves feedback by dynamically updating the window title to reflect the currently loaded BBS archive and filename.

**Changes:**
- `pyqwk/gui.py`: Added `argparse` support in `main()`, updated `QwkGuiApp.__init__` to handle an optional initial path, and updated `load_messages()` to set the window title.
- `tests/test_gui.py`: Added tests for these new features and updated the `get_app` helper.

---
*PR created automatically by Jules for task [3223857258037828949](https://jules.google.com/task/3223857258037828949) started by @RainRat*