### PR TITLE
[UI/UX] Add vertical scrollbar to message detail view

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -272,7 +272,13 @@ class QwkGuiApp:
             relief=tk.FLAT,
             borderwidth=0,
         )
-        self.detail_text.pack(fill=tk.BOTH, expand=True)
+        detail_scrollbar = ttk.Scrollbar(
+            detail_frame, orient=tk.VERTICAL, command=self.detail_text.yview
+        )
+        self.detail_text.configure(yscrollcommand=detail_scrollbar.set)
+
+        detail_scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
+        self.detail_text.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
         self.detail_text.config(state=tk.DISABLED)
 
         # Configure tags for visual hierarchy


### PR DESCRIPTION
**PR Title:** [UI/UX] Add vertical scrollbar to message detail view

**Description:**
*   **Context:** GUI
*   **Problem:** Long messages in the detail view were difficult to navigate because there was no visible scrollbar. Users had to rely on the mouse wheel or keyboard navigation, and had no visual feedback regarding the length of the message or their current position.
*   **Solution:** Added a standard `ttk.Scrollbar` to the `detail_frame`, linked it to the `detail_text` widget, and updated the layout. This provides a native look-and-feel and improves accessibility by following standard platform conventions for scrollable text areas.

**Changes:**
In `pyqwk/gui.py`:
- Added `detail_scrollbar` using `ttk.Scrollbar`.
- Configured `self.detail_text` to use the scrollbar via `yscrollcommand`.
- Updated packing logic to position the scrollbar on the right of the text area.

---
*PR created automatically by Jules for task [7189215426216416148](https://jules.google.com/task/7189215426216416148) started by @RainRat*