### PR TITLE
[FEAT] Graphical Reader: Export Current View

### DIFF
--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -12,37 +12,10 @@ from pyqwk.core import (
     process_file,
     process_merged_files,
     process_multiple_files,
+    resolve_output_format,
     show_info,
     show_stats,
 )
-
-
-def _resolve_output_format(
-    output_format: str | None,
-    output_path: str | None,
-    output_mode: str,
-) -> str:
-    if output_format is None:
-        if output_path and output_mode == 'file':
-            ext = os.path.splitext(output_path)[1].lower()
-            if ext == '.json':
-                return 'json'
-            if ext == '.xml':
-                return 'xml'
-            if ext == '.html':
-                return 'html'
-            if ext == '.csv':
-                return 'csv'
-            if ext == '.mbox':
-                return 'mbox'
-            if ext == '.eml':
-                return 'eml'
-            if ext == '.md' or ext == '.markdown':
-                return 'markdown'
-            if ext == '.sqlite' or ext == '.db':
-                return 'sqlite'
-        return 'text'
-    return output_format
 
 
 def _expand_directories(paths: list[str]) -> list[str]:
@@ -415,7 +388,7 @@ def main() -> None:
         output_mode = 'stdout' if not output_path else 'file'
         resolved_output_path = output_path
 
-    output_format = _resolve_output_format(args.format, output_path, output_mode)
+    output_format = resolve_output_format(args.format, output_path, output_mode)
 
     # Default to individual files for EML format if an output path is provided
     if output_format == 'eml' and not args.individualfiles and output_path:

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -40,6 +40,44 @@ FORMAT_EXTENSIONS = {
     'eml': '.eml',
 }
 
+
+def resolve_output_format(
+    output_format: str | None,
+    output_path: str | None,
+    output_mode: str,
+) -> str:
+    """Determine the output format based on the user's choice or the file extension.
+
+    Args:
+        output_format: The format explicitly requested by the user (e.g., 'json', 'html').
+        output_path: The path where the output will be saved.
+        output_mode: Whether the output is going to a 'file' or 'stdout'.
+
+    Returns:
+        The resolved format name (e.g., 'text', 'json', 'html').
+    """
+    if output_format is None:
+        if output_path and output_mode == 'file':
+            ext = os.path.splitext(output_path)[1].lower()
+            if ext == '.json':
+                return 'json'
+            if ext == '.xml':
+                return 'xml'
+            if ext == '.html':
+                return 'html'
+            if ext == '.csv':
+                return 'csv'
+            if ext == '.mbox':
+                return 'mbox'
+            if ext == '.eml':
+                return 'eml'
+            if ext in ('.md', '.markdown'):
+                return 'markdown'
+            if ext in ('.sqlite', '.db'):
+                return 'sqlite'
+        return 'text'
+    return output_format
+
 RE_QUOTE_PATTERN = re.compile(r'^\s*[A-Za-z\-\=]{0,4}\s?(>|\xb3|\||\}|│)')
 RE_UUE_PATTERN = re.compile(r'^begin\s\d{3}\s')
 RE_UUE_DATA_PATTERN = re.compile(r'^M[\x21-\x60]{60}$')
@@ -1442,24 +1480,9 @@ def process_merged_files(
                 if settings.threaded
                 else collected_messages
             )
-
-            writers: dict[str, Callable[[list[ProcessedMessage], str | None, str, ProcessingSettings, BBSInfo | None], None]] = {
-                'json': _write_json,
-                'xml': _write_xml,
-                'html': _write_html,
-                'markdown': _write_markdown,
-                'text': _write_text,
-                'csv': _write_csv,
-                'mbox': _write_mbox,
-                'eml': _write_eml,
-                'sqlite': _write_sqlite,
-            }
-
-            writer = writers.get(settings.format, _write_text)
-            output_encoding = 'utf-8'
-            if settings.format == 'text':
-                output_encoding = settings.encoding
-            writer(ordered_messages, resolved_output_path, output_encoding, settings, bbs_info_to_use)
+            write_messages(
+                ordered_messages, resolved_output_path, settings, bbs_info_to_use
+            )
         else:
             potential_files = 1
 
@@ -2173,6 +2196,43 @@ def _write_sqlite(
 
     conn.commit()
     conn.close()
+
+
+def write_messages(
+    messages: list[ProcessedMessage],
+    output_path: str | None,
+    settings: ProcessingSettings,
+    bbs_info: BBSInfo | None = None,
+) -> None:
+    """Save a list of messages to a file or print them to the screen.
+
+    This function selects the appropriate writer based on the settings and
+    handles the encoding for the output.
+    """
+    writers: dict[
+        str,
+        Callable[
+            [list[ProcessedMessage], str | None, str, ProcessingSettings, BBSInfo | None],
+            None,
+        ],
+    ] = {
+        'json': _write_json,
+        'xml': _write_xml,
+        'html': _write_html,
+        'markdown': _write_markdown,
+        'text': _write_text,
+        'csv': _write_csv,
+        'mbox': _write_mbox,
+        'eml': _write_eml,
+        'sqlite': _write_sqlite,
+    }
+
+    writer = writers.get(settings.format, _write_text)
+    output_encoding = 'utf-8'
+    if settings.format == 'text':
+        output_encoding = settings.encoding
+
+    writer(messages, output_path, output_encoding, settings, bbs_info)
 
 
 def _write_index(

--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -14,6 +14,8 @@ from pyqwk.core import (
     matches_filters,
     get_allowed_conferences,
     _parse_qwk_date,
+    resolve_output_format,
+    write_messages,
 )
 
 
@@ -66,6 +68,11 @@ class QwkGuiApp:
         file_menu.add_command(
             label="Open...", command=self.open_file, accelerator="Ctrl+O"
         )
+        file_menu.add_command(
+            label="Export Current View...",
+            command=self.export_messages,
+            accelerator="Ctrl+S",
+        )
         file_menu.add_separator()
         file_menu.add_command(label="Exit", command=self.quit_app, accelerator="Ctrl+Q")
         menubar.add_cascade(label="File", menu=file_menu)
@@ -85,6 +92,7 @@ class QwkGuiApp:
 
         # Bind keyboard shortcuts
         self.root.bind("<Control-o>", self.open_file)
+        self.root.bind("<Control-s>", self.export_messages)
         self.root.bind("<Control-q>", self.quit_app)
         self.root.bind("<Escape>", self.clear_search)
         self.root.bind("j", lambda e: self._select_relative_message(1))
@@ -612,6 +620,68 @@ class QwkGuiApp:
         self.detail_text.delete("1.0", tk.END)
         self.detail_text.insert(tk.END, text)
         self.detail_text.config(state=tk.DISABLED)
+
+    def export_messages(self, _event: object | None = None) -> None:
+        """Export the currently filtered and sorted messages to a file."""
+        if not self.messages:
+            messagebox.showwarning("Export", "No messages to export.")
+            return
+
+        filetypes = [
+            ("Text files", "*.txt"),
+            ("HTML files", "*.html"),
+            ("Markdown files", "*.md"),
+            ("JSON files", "*.json"),
+            ("mbox files", "*.mbox"),
+            ("EML files", "*.eml"),
+            ("CSV files", "*.csv"),
+            ("SQLite database", "*.db"),
+            ("XML files", "*.xml"),
+            ("All files", "*.*"),
+        ]
+
+        path = filedialog.asksaveasfilename(
+            title="Export Messages",
+            filetypes=filetypes,
+            defaultextension=".txt",
+        )
+
+        if not path:
+            return
+
+        try:
+            # Determine format from extension
+            fmt = resolve_output_format(None, path, "file")
+
+            # Update settings for export
+            settings = self._current_settings()
+            settings = replace(
+                settings,
+                format=fmt,
+                output_mode="file",
+                output_path=path,
+                no_header=False,  # We want headers in the export
+            )
+
+            # Use messages in their current display order from the treeview
+            ordered_item_ids = self._get_all_tree_items()
+            export_list = []
+            for iid in ordered_item_ids:
+                try:
+                    idx = int(iid)
+                    export_list.append(self.messages[idx])
+                except (ValueError, IndexError):
+                    continue
+
+            bbs_info = getattr(self.board_dict, "bbs_info", None)
+            write_messages(export_list, path, settings, bbs_info)
+
+            messagebox.showinfo(
+                "Export Successful",
+                f"Successfully exported {len(export_list)} messages to {os.path.basename(path)}",
+            )
+        except Exception as exc:
+            messagebox.showerror("Export Failed", str(exc))
 
     def jump_to_message(self, confnum: int, msgnum: int) -> None:
         """Find and select a message by conference and message number."""

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -1,6 +1,7 @@
 import pytest
 import datetime
-from pyqwk.cli import _parse_cli_date, _resolve_output_format
+from pyqwk.cli import _parse_cli_date
+from pyqwk.core import resolve_output_format as _resolve_output_format
 
 def test_parse_cli_date_valid():
     assert _parse_cli_date("2023-01-01") == datetime.datetime(2023, 1, 1)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -78,6 +78,7 @@ class TestQwkGui:
         assert app.root is not None
         assert hasattr(app, 'message_list')
         app.root.bind.assert_any_call("<Control-o>", app.open_file)
+        app.root.bind.assert_any_call("<Control-s>", app.export_messages)
         app.root.bind.assert_any_call("<Escape>", app.clear_search)
 
     def test_current_settings(self, mock_gui_deps):
@@ -576,6 +577,43 @@ class TestQwkGui:
 
             app.load_messages("test.qwk")
             app.root.title.assert_called_with("Test BBS (test.qwk) - PyQWK Reader")
+
+    def test_export_messages_success(self, mock_gui_deps):
+        app = get_app()
+        header = MessageHeader(' ', 1, "01-01-90", "12:00", "To", "From", "Sub", "", None, 1, " ", 1, 1, "")
+        app.messages = [ParsedMessage("Body", 1, None, 1, header)]
+
+        def mock_traverse(item_id):
+            return [item_id]
+
+        with patch.object(app, "_get_all_tree_items", return_value=["0"]):
+            mock_gui_deps["filedialog"].asksaveasfilename.return_value = "export.json"
+
+            with patch("pyqwk.gui.write_messages") as mock_write:
+                app.export_messages()
+
+                mock_write.assert_called_once()
+                args, _ = mock_write.call_args
+                assert args[0] == app.messages
+                assert args[1] == "export.json"
+                assert args[2].format == "json"
+                mock_gui_deps["messagebox"].showinfo.assert_called()
+
+    def test_export_messages_no_messages(self, mock_gui_deps):
+        app = get_app()
+        app.messages = []
+        app.export_messages()
+        mock_gui_deps["messagebox"].showwarning.assert_called_with("Export", "No messages to export.")
+
+    def test_export_messages_cancel(self, mock_gui_deps):
+        app = get_app()
+        header = MessageHeader(' ', 1, "01-01-90", "12:00", "To", "From", "Sub", "", None, 1, " ", 1, 1, "")
+        app.messages = [ParsedMessage("Body", 1, None, 1, header)]
+        mock_gui_deps["filedialog"].asksaveasfilename.return_value = ""
+
+        with patch("pyqwk.gui.write_messages") as mock_write:
+            app.export_messages()
+            mock_write.assert_not_called()
 
     def test_conference_discovery(self, mock_gui_deps):
         """Test that conferences found in messages.dat but not in CONTROL.DAT are discovered."""


### PR DESCRIPTION
**PR Title:** [FEAT] Graphical Reader: Export Current View
**Description:**
* **What:** Refactored the internal export logic to be reusable and added an "Export Current View" feature to the Graphical Reader (GUI). Users can now save their filtered, searched, and sorted messages into any of the 9 supported formats (Text, HTML, JSON, XML, Markdown, CSV, mbox, EML, and SQLite).
* **Why:** I noticed that while the CLI is a powerful conversion tool, the GUI was limited to viewing. Adding an Export feature to the GUI creates immediate value by allowing users to use the visual search and filtering tools to curate a selection of messages and then save them for use in other applications, fulfilling both "Symmetry" and "Interoperability" heuristics.

**Changes:**
- **Refactoring (`pyqwk/core.py`):**
    - Extracted the message writing registry into a reusable `write_messages` function.
    - Moved format resolution logic from the CLI to `core.py` as `resolve_output_format`.
- **Graphical Reader (`pyqwk/gui.py`):**
    - Added "Export Current View..." to the "File" menu.
    - Bound `Ctrl+S` for quick exporting.
    - Implemented `export_messages` which respects current GUI filters and display order.
- **CLI (`pyqwk/cli.py`):** Updated to use the new shared `resolve_output_format` function.
- **Tests:** Updated `tests/test_cli_helpers.py` and added new test cases to `tests/test_gui.py` to verify the export functionality.

---
*PR created automatically by Jules for task [10404024528129724277](https://jules.google.com/task/10404024528129724277) started by @RainRat*