### PR TITLE
Inline single-use private helper `_regex_match`

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -1017,14 +1017,6 @@ def get_allowed_conferences(
     return allowed
 
 
-def _regex_match(pattern: str, text: str) -> bool:
-    """Helper for case-insensitive regex matching with error handling."""
-    try:
-        return bool(re.search(pattern, text, re.IGNORECASE))
-    except re.error:
-        return False
-
-
 def matches_filters(
     message: ParsedMessage,
     settings: ProcessingSettings,
@@ -1050,7 +1042,10 @@ def matches_filters(
 
     def check_str_match(pattern: str, text: str) -> bool:
         if settings.regex:
-            return _regex_match(pattern, text)
+            try:
+                return bool(re.search(pattern, text, re.IGNORECASE))
+            except re.error:
+                return False
         return pattern.lower() in text.lower()
 
     def any_match(patterns: list[str] | None, text: str) -> bool:


### PR DESCRIPTION
Inlined the `_regex_match` private helper function into its only call site in `pyqwk/core.py` to reduce premature abstraction. Verified with full test suite.

---
*PR created automatically by Jules for task [15797162581121780182](https://jules.google.com/task/15797162581121780182) started by @RainRat*