### PR TITLE
[DOCS] Simplify mbox export tip in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ qwk archive.qwk --format html -o messages.html
 ```bash
 qwk archive.qwk --format mbox -o messages.mbox
 ```
-*Tip: Use `--threaded` to include standard email threading headers for better organization in your mail app.*
+*Tip: Use `--threaded` to help your mail app group messages into conversations.*
 
 **Convert to EML files (individual messages for mail apps):**
 ```bash


### PR DESCRIPTION
**PR Title:** [DOCS] Simplify mbox export tip in README.md
**Description:**
* **Type:** Documentation
* **What:** The `mbox` export example tip in `README.md`.
* **Why:** Replaced technical jargon ("include standard email threading headers for better organization") with a simpler, benefit-oriented description ("help your mail app group messages into conversations") to improve clarity for all users.

---
*PR created automatically by Jules for task [13819821852906881823](https://jules.google.com/task/13819821852906881823) started by @RainRat*