### PR TITLE
[UI/UX] Improve CLI oneline output alignment and visual hierarchy

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -613,15 +613,22 @@ class MessageHeader:
         from_name = self.msgfrom.strip()
         subject = self.msgsubject.strip()
 
-        from_name = _highlight_text(from_name, highlight_term, is_regex, use_colors)
-        subject = _highlight_text(subject, highlight_term, is_regex, use_colors)
-        conf_name = _highlight_text(conf_name, highlight_term, is_regex, use_colors)
+        def prepare_field(text: str, width: int, highlight: bool = True) -> str:
+            truncated = text[:width]
+            display_len = len(truncated)
+            if highlight:
+                truncated = _highlight_text(truncated, highlight_term, is_regex, use_colors)
+            return truncated + (" " * (width - display_len))
+
+        conf_part = prepare_field(conf_name, 16)
+        from_part = prepare_field(from_name, 20)
+        subject_part = _highlight_text(subject, highlight_term, is_regex, use_colors)
 
         msgnum_part = ""
         if verbose:
             msgnum_part = f"{(self.msgnum or ''):<6} "
 
-        return f"{msgnum_part}{conf_name:<16} {date_str:<14} {from_name:<20} {subject}\r\n"
+        return f"{msgnum_part}{conf_part} {date_str:<14} {from_part} {subject_part}\r\n"
 
 
 class MessagesDatFormatError(Exception):
@@ -2108,9 +2115,28 @@ def _write_text(
 
     if settings and settings.oneline:
         msgnum_hdr = f"{'Num':<6} " if settings.verbose else ""
-        header_line = f"{msgnum_hdr}{'Conference':<16} {'Date':<14} {'From':<20} {'Subject'}\r\n"
+        conf_hdr = f"{'Conference':<16}"
+        date_hdr = f"{'Date':<14}"
+        from_hdr = f"{'From':<20}"
+        subj_hdr = "Subject"
+
+        use_colors = (
+            not output_path
+            and hasattr(sys.stdout, 'isatty')
+            and sys.stdout.isatty()
+        )
+
+        if use_colors:
+            BOLD = "1"
+            def b(t): return f"\033[{BOLD}m{t}\033[0m"
+            header_line = f"{b(msgnum_hdr)}{b(conf_hdr)} {b(date_hdr)} {b(from_hdr)} {b(subj_hdr)}\r\n"
+        else:
+            header_line = f"{msgnum_hdr}{conf_hdr} {date_hdr} {from_hdr} {subj_hdr}\r\n"
+
         parts.append(header_line)
-        parts.append("-" * len(header_line.strip()) + "\r\n")
+        # Calculate separator length from the plain text header
+        plain_header = f"{msgnum_hdr}{conf_hdr} {date_hdr} {from_hdr} {subj_hdr}"
+        parts.append("-" * len(plain_header) + "\r\n")
 
     if settings and settings.include_toc:
         title = 'QWK Message Archive'

--- a/tests/test_ui_oneline_alignment.py
+++ b/tests/test_ui_oneline_alignment.py
@@ -1,0 +1,101 @@
+import pytest
+from pyqwk.core import MessageHeader
+
+def test_oneline_alignment_long_names():
+    header = MessageHeader(
+        status=" ",
+        msgnum=1,
+        msgdate="01-01-24",
+        msgtime="12:00",
+        msgto="Recipient",
+        msgfrom="A Very Long Author Name That Should Be Truncated",
+        msgsubject="Test Subject",
+        msgpassword="",
+        refnum=None,
+        numblocks=1,
+        msgflag="",
+        confnum=1,
+        lognum=0,
+        nettag="",
+    )
+    board_dict = {1: "A Very Long Conference Name That Should Also Be Truncated"}
+
+    oneline = header.format_oneline(board_dict)
+
+    # Expected truncation:
+    # Conf: "A Very Long Conf" (16 chars)
+    # From: "A Very Long Author N" (20 chars)
+    # Date: "01-01-24 12:00" (14 chars)
+
+    assert "A Very Long Conf " in oneline
+    assert "01-01-24 12:00 " in oneline
+    assert "A Very Long Author N " in oneline
+
+    # Check total length of fixed parts
+    # msgnum_part: ""
+    # conf_part: 16
+    # space: 1
+    # date_part: 14
+    # space: 1
+    # from_part: 20
+    # space: 1
+    # total before subject: 16+1+14+1+20+1 = 53
+
+    prefix = oneline[:53]
+    assert len(prefix) == 53
+    assert prefix.endswith("A Very Long Author N ")
+
+def test_oneline_alignment_with_highlighting():
+    header = MessageHeader(
+        status=" ",
+        msgnum=1,
+        msgdate="01-01-24",
+        msgtime="12:00",
+        msgto="Recipient",
+        msgfrom="Author Name",
+        msgsubject="Subject",
+        msgpassword="",
+        refnum=None,
+        numblocks=1,
+        msgflag="",
+        confnum=1,
+        lognum=0,
+        nettag="",
+    )
+    board_dict = {1: "Conference"}
+
+    # Highlight "Auth"
+    oneline = header.format_oneline(
+        board_dict,
+        use_colors=True,
+        highlight_term="Auth"
+    )
+
+    # ANSI escape for reverse video is \x1b[7m and reset is \x1b[0m
+    assert "\x1b[7mAuthor\x1b[0m Name" not in oneline # Wait, "Author" contains "Auth"
+    # Actually _highlight_text highlights exact matches or regex
+    # If highlight_term is "Auth", it highlights "Auth"
+    assert "\x1b[7mAuth\x1b[0m" in oneline
+
+    # Even with ANSI codes, the spacing should be preserved.
+    # The prepare_field function calculates display_len WITHOUT the ANSI codes
+    # because it truncates first, then highlights, but it adds padding based on display_len.
+
+    # "Author Name" is 11 chars. Truncated to 20 is still 11 chars.
+    # display_len = 11.
+    # Highlighted "Auth" -> "\x1b[7mAuth\x1b[0mor Name"
+    # Padding = 20 - 11 = 9 spaces.
+
+    assert "Author Name         " in oneline.replace("\x1b[7m", "").replace("\x1b[0m", "")
+
+    # Check the whole line structure
+    plain_line = oneline.replace("\x1b[7m", "").replace("\x1b[0m", "")
+    # Conf (16) + space (1) + Date (14) + space (1) + From (20) + space (1) + Subject
+    # "Conference      " (16)
+    # "01-01-24 12:00 " (14+1)
+    # "Author Name         " (20)
+    # " " (1)
+    # "Subject"
+
+    expected_start = "Conference       01-01-24 12:00 Author Name          Subject"
+    assert plain_line.startswith(expected_start)


### PR DESCRIPTION
**Context:** CLI
**Problem:** When using the `--oneline` (`-1`) flag with search highlighting (`-S`), the terminal output's column alignment would break. This happened because ANSI color codes added to the text were being counted towards the column width padding. Additionally, the table header lacked visual distinction and the separator line didn't always match the header width.
**Solution:** Refactored `MessageHeader.format_oneline` to truncate fields to their fixed widths *before* applying highlighting, and then padding based on the original visible length. This ensures columns stay aligned regardless of search matches. Added bold formatting to the table headers when outputting to a terminal and synchronized the separator line length with the header.

---
*PR created automatically by Jules for task [16409600635144514718](https://jules.google.com/task/16409600635144514718) started by @RainRat*