### PR TITLE
Refactor RFC 822 serialization logic to reduce duplication

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -2037,8 +2037,8 @@ def _parse_qwk_date(msgdate: str, msgtime: str) -> datetime.datetime:
         return datetime.datetime(1970, 1, 1, 0, 0)
 
 
-def _serialize_message_mbox(message: ProcessedMessage) -> str:
-    """Serialize a message to mbox format with threading and extra headers.
+def _serialize_rfc822(message: ProcessedMessage, include_mbox_header: bool = True) -> str:
+    """Serialize a message to RFC 822 (Email) format with optional MBOX header.
 
     Includes standard email headers for threading (Message-ID, In-Reply-To, References)
     and custom X-QWK headers for conference names, message numbers, and statuses.
@@ -2055,13 +2055,6 @@ def _serialize_message_mbox(message: ProcessedMessage) -> str:
     from_line_date = dt.ctime()
     rfc_date = email.utils.format_datetime(dt)
 
-    if "@" in header.msgfrom:
-        sender_addr = header.msgfrom
-    else:
-        # Create a safe address from the name
-        safe_name = re.sub(r'[^A-Za-z0-9]', '.', header.msgfrom).strip('.')
-        sender_addr = f"{safe_name}@example.com"
-
     # Escape "From " lines in body
     body_lines = []
     for line in message.text.splitlines():
@@ -2071,9 +2064,18 @@ def _serialize_message_mbox(message: ProcessedMessage) -> str:
             body_lines.append(line)
     body = "\n".join(body_lines)
 
-    # Construct mbox entry
-    # From <sender> <date>
-    parts = [f"From {sender_addr} {from_line_date}"]
+    parts = []
+    if include_mbox_header:
+        if "@" in header.msgfrom:
+            sender_addr = header.msgfrom
+        else:
+            # Create a safe address from the name
+            safe_name = re.sub(r'[^A-Za-z0-9]', '.', header.msgfrom).strip('.')
+            sender_addr = f"{safe_name}@example.com"
+        # Construct mbox entry
+        # From <sender> <date>
+        parts.append(f"From {sender_addr} {from_line_date}")
+
     parts.append(f"From: {header.msgfrom}")
     parts.append(f"To: {header.msgto}")
     parts.append(f"Subject: {header.msgsubject}")
@@ -2110,19 +2112,19 @@ def _serialize_message_mbox(message: ProcessedMessage) -> str:
 
     parts.append("")  # Separator before body
     parts.append(body)
-    parts.append("")  # Trailing newline required by mbox
+    parts.append("")  # Trailing newline required by mbox/eml
 
     return "\n".join(parts)
 
 
+def _serialize_message_mbox(message: ProcessedMessage) -> str:
+    """Serialize a message to mbox format with threading and extra headers."""
+    return _serialize_rfc822(message, include_mbox_header=True)
+
+
 def _serialize_message_eml(message: ProcessedMessage) -> str:
     """Serialize a message to EML format (RFC 822)."""
-    mbox_str = _serialize_message_mbox(message)
-    # Remove the first "From " line which is specific to mbox
-    lines = mbox_str.splitlines()
-    if lines and lines[0].startswith("From "):
-        return "\n".join(lines[1:])
-    return mbox_str
+    return _serialize_rfc822(message, include_mbox_header=False)
 
 
 def _write_mbox(

--- a/tests/test_coverage_final_gaps.py
+++ b/tests/test_coverage_final_gaps.py
@@ -154,15 +154,16 @@ def test_decode_yenc_exception_coverage():
     assert _decode_yenc(None) == b""
 
 def test_eml_serialize_no_from_header_coverage(message_factory):
-    # Coverage for line 2062
     from pyqwk.core import _serialize_message_eml
 
     msg = message_factory(1, None, "Test")
     msg.text = "Body"
 
-    with patch('pyqwk.core._serialize_message_mbox', return_value="Just headers\nBody"):
-        result = _serialize_message_eml(msg)
-        assert result == "Just headers\nBody"
+    result = _serialize_message_eml(msg)
+    # _serialize_message_eml does not have the mbox "From " separator
+    assert not result.startswith("From ")
+    assert "From: " in result
+    assert "Subject: Test" in result
 
 def test_oneline_html_markdown_text_content_coverage(message_factory, default_settings, logger):
     # Coverage for line 1396


### PR DESCRIPTION
This PR refactors the RFC 822 (Email/MBOX) serialization logic in `pyqwk/core.py`.

### Changes:
- Introduced a new private helper function `_serialize_rfc822` that handles the core serialization logic for both MBOX and EML formats.
- Updated `_serialize_message_mbox` and `_serialize_message_eml` to be thin wrappers around this new helper, controlled by an `include_mbox_header` flag.
- Fixed a broken test in `tests/test_coverage_final_gaps.py` that was mocking internal logic that was replaced by this refactor.

### Benefits:
- **Reduces Duplication:** The same headers and body-escaping logic are now shared between formats.
- **Improved Readability:** Removes the inefficient splitting and joining of strings previously used to convert MBOX output to EML format.
- **Safety:** The external behavior of the serialization functions remains identical. All existing tests for MBOX and EML output pass.

---
*PR created automatically by Jules for task [9931682124708497197](https://jules.google.com/task/9931682124708497197) started by @RainRat*