### PR TITLE
[UI/UX] Improve Message List Information Density and Alignment

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -37,6 +37,7 @@ class QwkGuiApp:
             "#0": "Subject",
             "Num": "Num",
             "From": "From",
+            "To": "To",
             "Date": "Date",
             "Conference": "Conference",
         }
@@ -241,21 +242,23 @@ class QwkGuiApp:
         # Treeview setup
         self.message_list = ttk.Treeview(
             list_frame,
-            columns=("Num", "From", "Date", "Conference"),
+            columns=("Num", "From", "To", "Date", "Conference"),
             selectmode="browse",
         )
 
         for col, label in self.column_labels.items():
+            header_anchor = tk.E if col == "Num" else tk.W
             self.message_list.heading(
                 col,
                 text=label,
-                anchor=tk.W,
+                anchor=header_anchor,
                 command=lambda c=col: self.sort_column(c, False),
             )
 
         self.message_list.column("#0", minwidth=200, width=300)
         self.message_list.column("Num", minwidth=50, width=60, anchor=tk.E)
         self.message_list.column("From", minwidth=80, width=120)
+        self.message_list.column("To", minwidth=80, width=120)
         self.message_list.column("Date", minwidth=80, width=120)
         self.message_list.column("Conference", minwidth=80, width=100)
 
@@ -468,9 +471,11 @@ class QwkGuiApp:
     def _reset_column_headers(self) -> None:
         """Reset all column headers to their original labels without sort indicators."""
         for col, label in self.column_labels.items():
+            header_anchor = tk.E if col == "Num" else tk.W
             self.message_list.heading(
                 col,
                 text=label,
+                anchor=header_anchor,
                 command=lambda c=col: self.sort_column(c, False)
             )
 
@@ -585,7 +590,8 @@ class QwkGuiApp:
                     text=subject,
                     values=(
                         header.msgnum if header.msgnum is not None else "",
-                        header.msgfrom,
+                        header.msgfrom.strip(),
+                        header.msgto.strip(),
                         f"{header.msgdate} {header.msgtime}",
                         conf_name,
                     ),
@@ -831,9 +837,11 @@ class QwkGuiApp:
                 # If we click a different column, it should start as ascending
                 next_reverse = False
 
+            header_anchor = tk.E if c == "Num" else tk.W
             self.message_list.heading(
                 c,
                 text=label,
+                anchor=header_anchor,
                 command=lambda _c=c, _r=next_reverse: self.sort_column(_c, _r)
             )
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -133,7 +133,11 @@ class TestQwkGui:
 
             app.load_messages("test.qwk")
             assert len(app.messages) == 1
-            app.message_list.insert.assert_called()
+            app.message_list.insert.assert_called_with(
+                '', 'end', iid='0', text='Subject',
+                values=(1, 'User', 'All', '01-01-90 12:00', 'General'),
+                open=True, tags=()
+            )
 
             # Verify status bar contains BBS name
             calls = app.status_label.config.call_args_list
@@ -300,7 +304,11 @@ class TestQwkGui:
         app.message_list.set.return_value = "Val"
         app.threaded_var.get.return_value = False
         app.sort_column("From", False)
-        app.message_list.heading.assert_any_call("From", text="From ▲", command=ANY)
+        app.message_list.heading.assert_any_call("From", text="From ▲", anchor="w", command=ANY)
+
+        # Verify Num header is right-aligned even when sorted
+        app.sort_column("Num", False)
+        app.message_list.heading.assert_any_call("Num", text="Num ▲", anchor="e", command=ANY)
 
     def test_status_bar_counts(self, mock_gui_deps):
         app = get_app()


### PR DESCRIPTION
* **Context:** GUI
* **Problem:** The message list (Treeview) was missing the "To" (recipient) field, which is crucial context in QWK conversations. Additionally, numeric fields like "Num" had misaligned headers, and names often contained messy trailing whitespace from the fixed-width QWK format.
* **Solution:** Added a "To" column to the message list, stripped whitespace from "From" and "To" fields for a cleaner look, and right-aligned the "Num" column header to match its numeric values.

---
*PR created automatically by Jules for task [17576639719516129553](https://jules.google.com/task/17576639719516129553) started by @RainRat*