### PR TITLE
Fix binary line detection failing on lines with trailing whitespace

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -144,29 +144,30 @@ def _is_binary_line(
     - A boolean that is True if the line should be hidden.
     - Three booleans representing if we are currently inside a specific type of attachment (yEnc, UUE, or Base64).
     """
+    stripped_line = line.strip()
     if in_base64_block:
-        if RE_BASE64_LOOSE_PATTERN.match(line):
+        if RE_BASE64_LOOSE_PATTERN.match(stripped_line):
             return True, in_yenc_block, in_uue_block, True
         in_base64_block = False
 
-    is_yenc_marker = RE_YENC_PATTERN.match(line)
+    is_yenc_marker = RE_YENC_PATTERN.match(stripped_line)
 
     if is_yenc_marker:
-        return True, not line.startswith('=yend'), in_uue_block, in_base64_block
+        return True, not stripped_line.startswith('=yend'), in_uue_block, in_base64_block
 
     if in_yenc_block:
         return True, True, in_uue_block, in_base64_block
 
     if in_uue_block:
-        if line.strip() == 'end':
+        if stripped_line == 'end':
             return True, in_yenc_block, False, in_base64_block
         return True, in_yenc_block, True, in_base64_block
 
-    if RE_BASE64_PATTERN.match(line):
+    if RE_BASE64_PATTERN.match(stripped_line):
         return True, in_yenc_block, in_uue_block, True
-    elif RE_UUE_DATA_PATTERN.match(line) or RE_UUE_PATTERN.match(line):
+    elif RE_UUE_DATA_PATTERN.match(stripped_line) or RE_UUE_PATTERN.match(stripped_line):
         return True, in_yenc_block, True, in_base64_block
-    elif RE_UUE_LOOSE_PATTERN.match(line):
+    elif RE_UUE_LOOSE_PATTERN.match(stripped_line):
         if previous_line and (
             RE_UUE_DATA_PATTERN.match(previous_line)
             or RE_UUE_PATTERN.match(previous_line)

--- a/tests/test_content_processing.py
+++ b/tests/test_content_processing.py
@@ -232,3 +232,18 @@ def test_process_message_strips_ansi_escapes() -> None:
         strip_ansi=False,
     )
     assert processed_disabled == "Intro\r\n\x1b[31mRed Text\x1b[0m\r\nOutro\r\n"
+
+def test_process_message_removes_base64_with_trailing_space() -> None:
+    # A valid base64 line (60+ chars) with a trailing space
+    b64_line = "TWFuIGlzIGRpc3Rpbmd1aXNoZWQsIG5vdCBvbmx5IGJ5IGhpcyByZWFzb24sIGJ1dCBieSB0aGlz"
+    message = f"Intro\r\n{b64_line} \r\nEnd of message\r\n"
+
+    processed = process_message(
+        message,
+        truncate_signatures=False,
+        cut_quoting=False,
+        binaries_removal=True,
+        redact_pii=False,
+    )
+
+    assert processed == "Intro\r\nEnd of message\r\n"


### PR DESCRIPTION
This PR fixes a logic bug in the attachment detection logic where trailing whitespace would cause binary data lines (Base64, yEnc, UUE) to be incorrectly treated as text.

By stripping the line before regex matching in `_is_binary_line`, the detection becomes more robust against common formatting artifacts.

Verified with a new test case and the existing test suite.

---
*PR created automatically by Jules for task [13956995700703865734](https://jules.google.com/task/13956995700703865734) started by @RainRat*