### PR TITLE
[DOCS] Replace technical jargon and idioms with Plain English

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ pyqwk is a tool to convert old `.QWK` mail archives (from the BBS era) into mode
 
 ## What is a QWK file?
 
-QWK is a file format created in the late 1980s for Bulletin Board Systems (BBS). In the days before the modern internet, it allowed users to download all their new messages in a single "packet." They could then disconnect their phone line, read the messages at their own pace, and write replies without tying up the BBS's phone line. Once finished, they would upload their replies back to the BBS.
+QWK is a file format created in the late 1980s for Bulletin Board Systems (BBS). In the days before the modern internet, it allowed users to download all their new messages in a single "packet." They could then disconnect their phone line, read the messages at their own pace, and write replies without keeping the BBS's phone line busy. Once finished, they would upload their replies back to the BBS.
 
 Today, these files are valuable pieces of digital history. `pyqwk` helps you open these archives and convert them into modern, easy-to-read formats.
 
@@ -223,7 +223,7 @@ qwk archive.qwk --skip 100 --limit 50
 ```
 
 **Rich Terminal Output:**
-When viewing messages in your terminal, pyqwk automatically uses colors to make them easier to read. Message headers are bolded, and search terms are highlighted using reverse video. This only applies to terminal output; file exports remain clean.
+When viewing messages in your terminal, pyqwk automatically uses colors to make them easier to read. Message headers are bolded, and search terms are highlighted using inverted colors. This only applies to terminal output; file exports remain clean.
 
 **Sorting Results:**
 You can sort the output by various fields such as date, author, or subject.

--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -85,7 +85,7 @@ def main() -> None:
         help=(
             'The archives, message files, or folders you want to read. '
             'If you provide a path to a raw MESSAGES.DAT file, pyqwk will '
-            'also look for a sidecar CONTROL.DAT in the same folder to '
+            'also look for an accompanying CONTROL.DAT in the same folder to '
             'automatically load conference names.'
         ),
         nargs='+',

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -714,7 +714,7 @@ def load_data(
         be the conference numbers.
 
         Note: If you provide a path to a raw ``MESSAGES.DAT`` file, this function
-        will also look for a sidecar ``CONTROL.DAT`` file in the same directory
+        will also look for an accompanying ``CONTROL.DAT`` file in the same directory
         to automatically load conference information.
     """
     board_dict: dict[int, str] = {}
@@ -797,7 +797,7 @@ def load_data(
         with open(input_path, 'rb') as f:
             file_data = bytearray(f.read())
 
-        # If the file is MESSAGES.DAT, look for a sidecar CONTROL.DAT in the same folder
+        # If the file is MESSAGES.DAT, look for an accompanying CONTROL.DAT in the same folder
         if os.path.basename(input_path).lower() == MESSAGES_FILENAME:
             parent_dir = os.path.dirname(input_path)
             control_path = os.path.join(parent_dir, CONTROL_FILENAME)
@@ -816,9 +816,9 @@ def load_data(
                     with open(control_path, 'rb') as f:
                         control_data = f.read().splitlines()
                     board_dict = _parse_control_dat(control_data, logger, encoding)
-                    logger.info("Found sidecar %s; loaded conference names.", os.path.basename(control_path))
+                    logger.info("Found accompanying %s; loaded conference names.", os.path.basename(control_path))
                 except Exception as e:
-                    logger.warning("Found sidecar CONTROL.DAT but failed to parse it: %s", str(e))
+                    logger.warning("Found accompanying CONTROL.DAT but failed to parse it: %s", str(e))
 
     return file_data, board_dict
 
@@ -2512,7 +2512,7 @@ def _highlight_text(
     is_regex: bool = False,
     use_colors: bool = False,
 ) -> str:
-    """Apply reverse-video highlighting to matching terms in text for terminal output."""
+    """Apply inverted colors highlighting to matching terms in text for terminal output."""
     if not term or not use_colors:
         return text
 


### PR DESCRIPTION
* **Type:** Documentation / Internal Help / Code Comments
* **What:** README.md, CLI help strings in pyqwk/cli.py, and docstrings/logs in pyqwk/core.py.
* **Why:** Replaced technical jargon like "sidecar" and "reverse video" and idioms like "tying up" with Plain English equivalents to make the tool more accessible to a global audience and non-technical users.

---
*PR created automatically by Jules for task [15888449835016270368](https://jules.google.com/task/15888449835016270368) started by @RainRat*