### PR TITLE
[UI/UX] Improve search bar navigation and focus behavior

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -81,7 +81,7 @@ class QwkGuiApp:
         edit_menu = tk.Menu(menubar, tearoff=0)
         edit_menu.add_command(
             label="Find",
-            command=lambda: self.search_entry.focus_set(),
+            command=self._focus_search,
             accelerator="Ctrl+F",
         )
         edit_menu.add_command(
@@ -114,13 +114,13 @@ class QwkGuiApp:
             traverse(root_item)
         return items
 
-    def _select_relative_message(self, delta: int) -> None:
+    def _select_relative_message(self, delta: int, force: bool = False) -> None:
         """Move the selection up or down in the treeview display order."""
         if not self.messages:
             return
 
-        # If the search entry has focus, don't hijack keyboard navigation
-        if self.root.focus_get() == self.search_entry:
+        # If the search entry has focus, don't hijack keyboard navigation unless forced
+        if not force and self.root.focus_get() == self.search_entry:
             return
 
         all_items = self._get_all_tree_items()
@@ -146,6 +146,11 @@ class QwkGuiApp:
     def clear_search(self, _event: object | None = None) -> None:
         self.search_var.set("")
         self.message_list.focus_set()
+
+    def _focus_search(self, _event: object | None = None) -> None:
+        """Focus the search bar and select all text for quick replacement."""
+        self.search_entry.focus_set()
+        self.search_entry.selection_range(0, tk.END)
 
     def clear_conf_filter(self, _event: object | None = None) -> None:
         """Reset the conference filter to show all conferences."""
@@ -195,7 +200,9 @@ class QwkGuiApp:
 
         self.search_entry.bind("<Return>", self._on_search_enter)
         self.search_entry.bind("<Escape>", self.clear_search)
-        self.root.bind("<Control-f>", lambda e: self.search_entry.focus_set())
+        self.search_entry.bind("<Up>", lambda e: self._select_relative_message(-1, force=True))
+        self.search_entry.bind("<Down>", lambda e: self._select_relative_message(1, force=True))
+        self.root.bind("<Control-f>", self._focus_search)
 
         ttk.Separator(toolbar, orient=tk.VERTICAL).pack(side=tk.LEFT, fill=tk.Y, padx=10)
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -689,3 +689,32 @@ class TestQwkGui:
             # Should NOT crash and still load messages
             app.load_messages("test.qwk")
             assert len(app.messages) == 1
+
+    def test_search_bar_navigation(self, mock_gui_deps):
+        app = get_app()
+        with patch.object(app, "_select_relative_message") as mock_select:
+            # Simulate <Up> key event in search entry
+            up_binding = None
+            for call_args in app.search_entry.bind.call_args_list:
+                if call_args[0][0] == "<Up>":
+                    up_binding = call_args[0][1]
+                    break
+            assert up_binding is not None
+            up_binding(MagicMock())
+            mock_select.assert_called_with(-1, force=True)
+
+            # Simulate <Down> key event in search entry
+            down_binding = None
+            for call_args in app.search_entry.bind.call_args_list:
+                if call_args[0][0] == "<Down>":
+                    down_binding = call_args[0][1]
+                    break
+            assert down_binding is not None
+            down_binding(MagicMock())
+            mock_select.assert_called_with(1, force=True)
+
+    def test_focus_search(self, mock_gui_deps):
+        app = get_app()
+        app._focus_search()
+        app.search_entry.focus_set.assert_called_once()
+        app.search_entry.selection_range.assert_called_with(0, mock_gui_deps["tk"].END)


### PR DESCRIPTION
**PR Title:** [UI/UX] Improve search bar navigation and focus behavior

**Description:**
* **Context:** GUI
* **Problem:** There were two primary friction points in the Graphical Reader's search workflow:
    1. Navigation: After typing a search term, users had to manually click the message list or press Tab/Enter to use arrow keys for scrolling through results.
    2. Replacement: Activating the search bar via `Ctrl+F` or the menu focused the entry but didn't select existing text, forcing users to manually clear the previous term before typing a new one.
* **Solution:** 
    1. Bound the `<Up>` and `<Down>` keys within the search entry to navigate the message list directly. This was enabled by adding a `force` parameter to `_select_relative_message`.
    2. Implemented `_focus_search`, which handles both focusing the entry and selecting all its text (`selection_range(0, tk.END)`). This method is now used by the `Edit > Find` menu and the `Ctrl+F` global shortcut.

**Changes:**
- Modified `pyqwk/gui.py`:
    - Updated `_select_relative_message` signature and logic to support `force` navigation.
    - Added `_focus_search` helper method.
    - Updated `_build_menu` and `_build_toolbar` with new bindings and commands.
- Modified `tests/test_gui.py`:
    - Added `test_search_bar_navigation` to verify arrow key behavior.
    - Added `test_focus_search` to verify text selection behavior.

---
*PR created automatically by Jules for task [4891597034988943776](https://jules.google.com/task/4891597034988943776) started by @RainRat*