### PR TITLE
Allow show_info to process REP packets

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -2616,13 +2616,10 @@ def show_info(input_paths: list[str], settings: ProcessingSettings, logger: logg
             if bbs_info:
                 info_entry["bbs_info"] = asdict(bbs_info)
 
-            if len(file_data) < BLOCK_SIZE or not file_data.startswith(b'Produced '):
+            if len(file_data) < BLOCK_SIZE:
                 if settings.format != 'json':
                     print(f"File: {_colorize(input_path, CYAN)}")
-                    if len(file_data) < BLOCK_SIZE:
-                        print("  Invalid or empty file.")
-                    else:
-                        print("  Not a valid QWK messages.dat file.")
+                    print("  Invalid or empty file.")
                 all_info.append(info_entry)
                 continue
 

--- a/tests/test_coverage_gap_filler.py
+++ b/tests/test_coverage_gap_filler.py
@@ -21,7 +21,7 @@ def test_load_data_sidecar_control_dat_corrupt(tmp_path, caplog):
     logger = logging.getLogger("pyqwk.test")
     with caplog.at_level(logging.WARNING):
         load_data(str(messages_path), logger)
-        assert "Found sidecar CONTROL.DAT but failed to parse it" in caplog.text
+        assert "Found accompanying CONTROL.DAT but failed to parse it" in caplog.text
 
 @patch('zipfile.is_zipfile', return_value=True)
 @patch('zipfile.ZipFile')

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -66,17 +66,6 @@ def test_show_info_invalid_file(capsys, mock_logger, default_settings):
         captured = capsys.readouterr()
         assert "Invalid or empty file" in captured.out
 
-def test_show_info_not_messages_dat(capsys, mock_logger, default_settings):
-    # Mock load_data to return data with wrong header
-    with patch('pyqwk.core.load_data') as mock_load:
-        # Return enough bytes but wrong header
-        bad_data = bytearray(b'X' * 128)
-        mock_load.return_value = (bad_data, {})
-
-        show_info(['fake.zip'], default_settings, mock_logger)
-
-        captured = capsys.readouterr()
-        assert "Not a valid QWK messages.dat file" in captured.out
 
 
 def test_show_info_colors_enabled(capsys, mock_logger, default_settings):

--- a/tests/test_rep_support.py
+++ b/tests/test_rep_support.py
@@ -4,7 +4,7 @@ import os
 import logging
 from pathlib import Path
 import pytest
-from pyqwk.core import load_data, parse_messages, ProcessingSettings, process_file
+from pyqwk.core import load_data, parse_messages, ProcessingSettings, process_file, show_info
 
 def create_rep_packet(path, bbs_id=b"TESTBBS", msg_count=1):
     # Header record
@@ -94,3 +94,32 @@ def test_rep_with_lowercase_filename(tmp_path):
     logger = logging.getLogger("pyqwk.test")
     file_data, _ = load_data(str(rep_path), logger)
     assert len(file_data) == 128
+
+def test_show_info_rep_packet(tmp_path, capsys):
+    rep_path = tmp_path / "test.rep"
+    create_rep_packet(rep_path, msg_count=3)
+
+    settings = ProcessingSettings(
+        verbose=False,
+        private=True,
+        no_header=True,
+        truncate_signatures=False,
+        cut_quoting=False,
+        individual_files=False,
+        threaded=False,
+        binaries_removal=False,
+        redact_pii=False,
+        format="text",
+        separator="none",
+        output_mode="stdout",
+        output_path=None,
+        encoding="cp437",
+        quiet=True
+    )
+
+    logger = logging.getLogger("pyqwk.test")
+    show_info([str(rep_path)], settings, logger)
+
+    captured = capsys.readouterr()
+    assert "Total Messages: 3" in captured.out
+    assert "Not a valid QWK messages.dat file." not in captured.out


### PR DESCRIPTION
This PR resolves a logic bug where the `show_info` diagnostic tool would incorrectly report REP packets as invalid QWK files. The format of REP packets (and some QWK variants) does not always start with the 'Produced ' string, yet they are fully supported by the core parsing logic.

Changes:
- Removed the strict `startswith(b'Produced ')` check in `show_info` (pyqwk/core.py).
- Added `test_show_info_rep_packet` to `tests/test_rep_support.py`.
- Removed `test_show_info_not_messages_dat` from `tests/test_info.py` as it enforced the buggy behavior.
- Adjusted `tests/test_coverage_gap_filler.py` to match the project's preferred terminology ('accompanying' instead of 'sidecar').

No breaking changes were introduced, and all 431 tests passed.

---
*PR created automatically by Jules for task [12226905184221705495](https://jules.google.com/task/12226905184221705495) started by @RainRat*