### PR TITLE
[TEST] Add GUI attachment rendering coverage and fix terminology mismatch

### DIFF
--- a/tests/test_coverage_gap_filler.py
+++ b/tests/test_coverage_gap_filler.py
@@ -21,7 +21,7 @@ def test_load_data_sidecar_control_dat_corrupt(tmp_path, caplog):
     logger = logging.getLogger("pyqwk.test")
     with caplog.at_level(logging.WARNING):
         load_data(str(messages_path), logger)
-        assert "Found sidecar CONTROL.DAT but failed to parse it" in caplog.text
+        assert "Found accompanying CONTROL.DAT but failed to parse it" in caplog.text
 
 @patch('zipfile.is_zipfile', return_value=True)
 @patch('zipfile.ZipFile')

--- a/tests/test_gui_attachments.py
+++ b/tests/test_gui_attachments.py
@@ -1,0 +1,71 @@
+import sys
+from unittest.mock import MagicMock, patch
+import pytest
+from pyqwk.core import ParsedMessage, MessageHeader
+
+# Mock tkinter before any pyqwk.gui imports
+mock_tk = MagicMock()
+mock_ttk = MagicMock()
+sys.modules["tkinter"] = mock_tk
+sys.modules["tkinter.filedialog"] = MagicMock()
+sys.modules["tkinter.messagebox"] = MagicMock()
+sys.modules["tkinter.ttk"] = mock_ttk
+
+from pyqwk.gui import QwkGuiApp
+
+@pytest.fixture
+def mock_gui_deps():
+    with patch("pyqwk.gui.tk") as mock_tk, \
+         patch("pyqwk.gui.ttk") as mock_ttk, \
+         patch("pyqwk.gui.filedialog") as mock_fd, \
+         patch("pyqwk.gui.messagebox") as mock_mb:
+
+        mock_tk.END = "end"
+        mock_tk.INSERT = "insert"
+
+        # Configure Variable mocks
+        def make_var(value=None):
+            m = MagicMock()
+            m.get.return_value = value
+            return m
+
+        mock_tk.BooleanVar.side_effect = lambda value=False, **kwargs: make_var(value)
+        mock_tk.StringVar.side_effect = lambda value="", **kwargs: make_var(value)
+        mock_tk.IntVar.side_effect = lambda value=0, **kwargs: make_var(value)
+
+        yield {
+            "tk": mock_tk,
+            "ttk": mock_ttk,
+            "filedialog": mock_fd,
+            "messagebox": mock_mb,
+        }
+
+def test_gui_renders_attachments(mock_gui_deps):
+    root = MagicMock()
+    app = QwkGuiApp(root)
+
+    header = MessageHeader(
+        status=' ', msgnum=1, msgdate='01-01-90', msgtime='12:00',
+        msgto='All', msgfrom='User', msgsubject='Subject',
+        msgpassword='', refnum=None, numblocks=1, msgflag=' ',
+        confnum=1, lognum=1, nettag=''
+    )
+    message = ParsedMessage(
+        text="Body",
+        msgnum=1,
+        refnum=None,
+        confnum=1,
+        header=header,
+        attachments=["file1.zip", "image.jpg"]
+    )
+
+    app.messages = [message]
+    app.board_dict = {1: "General"}
+
+    # Trigger rendering of the message
+    app._render_message(0)
+
+    # Check if "Attachments: " label was inserted
+    app.detail_text.insert.assert_any_call(mock_gui_deps["tk"].END, "Attachments: ", "header_label")
+    # Check if attachment names were inserted
+    app.detail_text.insert.assert_any_call(mock_gui_deps["tk"].END, "file1.zip, image.jpg\n", "header_value")


### PR DESCRIPTION
This PR improves test coverage for the Graphical Reader and fixes a regression in the existing test suite.

### Changes:
1.  **New Test:** Added `tests/test_gui_attachments.py`. This test mocks the `tkinter` environment to verify that the message detail view correctly renders attachment information when present in a `ParsedMessage`. This covers line 402 of `pyqwk/gui.py`, which was previously uncovered.
2.  **Maintenance:** Updated `tests/test_coverage_gap_filler.py`. A previous terminology change in the core logic ("sidecar" -> "accompanying") had broken an assertion in `test_load_data_sidecar_control_dat_corrupt`. I've updated the test to reflect the correct terminology, restoring the test to a passing state.

All 432 tests now pass.

---
*PR created automatically by Jules for task [14079888074502889475](https://jules.google.com/task/14079888074502889475) started by @RainRat*