### PR TITLE
[UI/UX] Auto-scroll to first search match in Graphical Reader

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -419,6 +419,8 @@ class QwkGuiApp:
             start_pos = "1.0"
             is_regex = self.regex_var.get()
             count_var = tk.IntVar()
+            first_match_pos = None
+
             while True:
                 try:
                     start_pos = self.detail_text.search(
@@ -430,6 +432,10 @@ class QwkGuiApp:
                     break
                 if not start_pos:
                     break
+
+                if first_match_pos is None:
+                    first_match_pos = start_pos
+
                 match_count = count_var.get()
                 if match_count == 0:  # Avoid infinite loop on zero-width match
                     start_pos = f"{start_pos}+1c"
@@ -437,7 +443,10 @@ class QwkGuiApp:
                 end_pos = f"{start_pos}+{match_count}c"
                 self.detail_text.tag_add("search_highlight", start_pos, end_pos)
                 start_pos = end_pos
+
             self.detail_text.tag_raise("search_highlight")
+            if first_match_pos:
+                self.detail_text.see(first_match_pos)
 
         self.detail_text.config(state=tk.DISABLED)
 

--- a/tests/test_coverage_gap_filler.py
+++ b/tests/test_coverage_gap_filler.py
@@ -21,7 +21,7 @@ def test_load_data_sidecar_control_dat_corrupt(tmp_path, caplog):
     logger = logging.getLogger("pyqwk.test")
     with caplog.at_level(logging.WARNING):
         load_data(str(messages_path), logger)
-        assert "Found sidecar CONTROL.DAT but failed to parse it" in caplog.text
+        assert "Found accompanying CONTROL.DAT but failed to parse it" in caplog.text
 
 @patch('zipfile.is_zipfile', return_value=True)
 @patch('zipfile.ZipFile')

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -344,6 +344,8 @@ class TestQwkGui:
         app._render_message(0)
         # Check that tag_add was called with correct start and end positions
         app.detail_text.tag_add.assert_any_call("search_highlight", "1.10", "1.10+9c")
+        # Verify that auto-scroll was triggered for the first match
+        app.detail_text.see.assert_called_with("1.10")
 
     def test_search_invalid_regex(self, mock_gui_deps):
         app = get_app()


### PR DESCRIPTION
* **Context:** GUI
* **Problem:** When searching in long messages, users have to manually scroll to find the first highlighted match, which is tedious and lacks immediate visual feedback.
* **Solution:** Automatically scroll the message detail view to the first occurrence of the search term upon selection. This ensures the most relevant part of the message is immediately visible.

**Changes:**
- Updated `pyqwk/gui.py` to track the first search match and use `detail_text.see()` to scroll to it.
- Added a unit test in `tests/test_gui.py` to verify the scrolling behavior.
- Fixed a broken test assertion in `tests/test_coverage_gap_filler.py` caused by a previous 'sidecar' -> 'accompanying' renaming.

---
*PR created automatically by Jules for task [4929486826962972913](https://jules.google.com/task/4929486826962972913) started by @RainRat*