### PR TITLE
[TEST] [Bug Fix] Align terminology and increase Graphical Reader coverage

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -832,9 +832,9 @@ def load_data(
                     with open(control_path, 'rb') as f:
                         control_data = f.read().splitlines()
                     board_dict = _parse_control_dat(control_data, logger, encoding)
-                    logger.info("Found sidecar %s; loaded conference names.", os.path.basename(control_path))
+                    logger.info("Found accompanying %s; loaded conference names.", os.path.basename(control_path))
                 except Exception as e:
-                    logger.warning("Found sidecar CONTROL.DAT but failed to parse it: %s", str(e))
+                    logger.warning("Found accompanying CONTROL.DAT but failed to parse it: %s", str(e))
 
     return file_data, board_dict
 

--- a/tests/test_gui_export_coverage.py
+++ b/tests/test_gui_export_coverage.py
@@ -1,0 +1,85 @@
+import sys
+from unittest.mock import MagicMock, patch
+import pytest
+
+# Mock tkinter before any pyqwk.gui imports
+mock_tk = MagicMock()
+mock_ttk = MagicMock()
+sys.modules["tkinter"] = mock_tk
+sys.modules["tkinter.filedialog"] = MagicMock()
+sys.modules["tkinter.messagebox"] = MagicMock()
+sys.modules["tkinter.ttk"] = mock_ttk
+
+from pyqwk.core import ParsedMessage, MessageHeader
+
+@pytest.fixture
+def mock_gui_deps():
+    with patch("pyqwk.gui.tk") as mock_tk, \
+         patch("pyqwk.gui.ttk") as mock_ttk, \
+         patch("pyqwk.gui.filedialog") as mock_fd, \
+         patch("pyqwk.gui.messagebox") as mock_mb:
+
+        # Configure Variable mocks
+        def make_var(value=None):
+            m = MagicMock()
+            m.get.return_value = value
+            return m
+
+        mock_tk.BooleanVar.side_effect = lambda value=False, **kwargs: make_var(value)
+        mock_tk.StringVar.side_effect = lambda value="", **kwargs: make_var(value)
+        mock_tk.IntVar.side_effect = lambda value=0, **kwargs: make_var(value)
+        mock_tk.NORMAL = "normal"
+        mock_tk.DISABLED = "disabled"
+        mock_tk.END = "end"
+
+        yield {
+            "tk": mock_tk,
+            "ttk": mock_ttk,
+            "filedialog": mock_fd,
+            "messagebox": mock_mb,
+        }
+
+def get_app():
+    from pyqwk.gui import QwkGuiApp
+    root = MagicMock()
+    return QwkGuiApp(root)
+
+def test_export_messages_no_messages(mock_gui_deps):
+    app = get_app()
+    app.messages = []
+    app.export_messages()
+    mock_gui_deps["messagebox"].showwarning.assert_called_with("Export", "No messages to export.")
+
+def test_export_messages_error_handling(mock_gui_deps):
+    app = get_app()
+
+    header = MessageHeader(' ', 1, "01-01-90", "12:00", "To", "From", "Sub", "", None, 1, " ", 1, 1, "")
+    msg = ParsedMessage("Body", 1, None, 1, header)
+    app.messages = [msg]
+    app.board_dict = {1: "General"}
+
+    # Avoid recursion in _get_all_tree_items
+    app.message_list.get_children.return_value = []
+    with patch.object(app, "_get_all_tree_items", return_value=["0"]):
+        mock_gui_deps["filedialog"].asksaveasfilename.return_value = "export.txt"
+
+        with patch("pyqwk.gui.write_messages", side_effect=Exception("Export failed")):
+            app.export_messages()
+            mock_gui_deps["messagebox"].showerror.assert_called_with("Export Failed", "Export failed")
+
+def test_export_messages_skips_invalid_iid(mock_gui_deps):
+    app = get_app()
+    header = MessageHeader(' ', 1, "01-01-90", "12:00", "To", "From", "Sub", "", None, 1, " ", 1, 1, "")
+    msg = ParsedMessage("Body", 1, None, 1, header)
+    app.messages = [msg]
+    app.board_dict = {1: "General"}
+
+    # Mocking _get_all_tree_items to return an invalid iid (line 761)
+    with patch.object(app, "_get_all_tree_items", return_value=["invalid"]):
+        mock_gui_deps["filedialog"].asksaveasfilename.return_value = "export.txt"
+        with patch("pyqwk.gui.write_messages") as mock_write:
+            app.export_messages()
+            # Verify that write_messages was called with an empty list
+            mock_write.assert_called_once()
+            args, _ = mock_write.call_args
+            assert args[0] == []

--- a/tests/test_gui_main.py
+++ b/tests/test_gui_main.py
@@ -1,0 +1,43 @@
+import sys
+import argparse
+from unittest.mock import MagicMock, patch
+import pytest
+import tkinter as tk
+
+# Mock tkinter before any pyqwk.gui imports
+mock_tk = MagicMock()
+mock_ttk = MagicMock()
+sys.modules["tkinter"] = mock_tk
+sys.modules["tkinter.filedialog"] = MagicMock()
+sys.modules["tkinter.messagebox"] = MagicMock()
+sys.modules["tkinter.ttk"] = mock_ttk
+
+from pyqwk.gui import main
+
+def test_gui_main_with_path():
+    """Test that gui.main correctly passes the path argument to QwkGuiApp."""
+    with patch("pyqwk.gui.tk.Tk") as mock_tk_class, \
+         patch("pyqwk.gui.QwkGuiApp") as mock_app_class, \
+         patch("argparse.ArgumentParser.parse_args") as mock_parse_args:
+
+        mock_parse_args.return_value = argparse.Namespace(path="test.qwk")
+
+        main()
+
+        mock_tk_class.assert_called_once()
+        mock_app_class.assert_called_once_with(mock_tk_class.return_value, initial_path="test.qwk")
+        mock_tk_class.return_value.mainloop.assert_called_once()
+
+def test_gui_main_without_path():
+    """Test that gui.main works without a path argument."""
+    with patch("pyqwk.gui.tk.Tk") as mock_tk_class, \
+         patch("pyqwk.gui.QwkGuiApp") as mock_app_class, \
+         patch("argparse.ArgumentParser.parse_args") as mock_parse_args:
+
+        mock_parse_args.return_value = argparse.Namespace(path=None)
+
+        main()
+
+        mock_tk_class.assert_called_once()
+        mock_app_class.assert_called_once_with(mock_tk_class.return_value, initial_path=None)
+        mock_tk_class.return_value.mainloop.assert_called_once()

--- a/tests/test_gui_navigation_coverage.py
+++ b/tests/test_gui_navigation_coverage.py
@@ -1,0 +1,63 @@
+import sys
+from unittest.mock import MagicMock, patch
+import pytest
+
+# Mock tkinter before any pyqwk.gui imports
+mock_tk = MagicMock()
+mock_ttk = MagicMock()
+sys.modules["tkinter"] = mock_tk
+sys.modules["tkinter.filedialog"] = MagicMock()
+sys.modules["tkinter.messagebox"] = MagicMock()
+sys.modules["tkinter.ttk"] = mock_ttk
+
+from pyqwk.gui import QwkGuiApp
+
+@pytest.fixture
+def mock_gui_deps():
+    with patch("pyqwk.gui.tk") as mock_tk, \
+         patch("pyqwk.gui.ttk") as mock_ttk:
+
+        # Configure Variable mocks
+        def make_var(value=None):
+            m = MagicMock()
+            m.get.return_value = value
+            return m
+
+        mock_tk.BooleanVar.side_effect = lambda value=False, **kwargs: make_var(value)
+        mock_tk.StringVar.side_effect = lambda value="", **kwargs: make_var(value)
+        mock_tk.IntVar.side_effect = lambda value=0, **kwargs: make_var(value)
+
+        yield {
+            "tk": mock_tk,
+            "ttk": mock_ttk,
+        }
+
+def test_select_relative_message_edge_cases(mock_gui_deps):
+    root = MagicMock()
+    app = QwkGuiApp(root)
+
+    # 1. Test when self.messages is empty (line 121)
+    app.messages = []
+    app._select_relative_message(1)
+    app.message_list.selection_set.assert_not_called()
+
+    # 2. Test when search_entry has focus and force is False (line 125)
+    app.messages = [MagicMock()]
+    root.focus_get.return_value = app.search_entry
+    app._select_relative_message(1, force=False)
+    app.message_list.selection_set.assert_not_called()
+
+    # 3. Test when all_items is empty (line 129)
+    root.focus_get.return_value = None
+    with patch.object(app, "_get_all_tree_items", return_value=[]):
+        app._select_relative_message(1)
+        app.message_list.selection_set.assert_not_called()
+
+    # 4. Test ValueError in all_items.index (line 141)
+    # This happens if current_iid is not in all_items
+    app.messages = [MagicMock()]
+    app.message_list.selection.return_value = ["invalid_iid"]
+    with patch.object(app, "_get_all_tree_items", return_value=["iid1", "iid2"]):
+        app._select_relative_message(1)
+        # Should fallback to selecting all_items[0]
+        app.message_list.selection_set.assert_called_with("iid1")

--- a/tests/test_gui_traversal_coverage.py
+++ b/tests/test_gui_traversal_coverage.py
@@ -1,0 +1,90 @@
+import sys
+from unittest.mock import MagicMock, patch
+import pytest
+
+# Mock tkinter before any pyqwk.gui imports
+mock_tk = MagicMock()
+mock_ttk = MagicMock()
+sys.modules["tkinter"] = mock_tk
+sys.modules["tkinter.filedialog"] = MagicMock()
+sys.modules["tkinter.messagebox"] = MagicMock()
+sys.modules["tkinter.ttk"] = mock_ttk
+
+from pyqwk.gui import QwkGuiApp
+
+@pytest.fixture
+def mock_gui_deps():
+    with patch("pyqwk.gui.tk") as mock_tk, \
+         patch("pyqwk.gui.ttk") as mock_ttk:
+
+        # Configure Variable mocks
+        def make_var(value=None):
+            m = MagicMock()
+            m.get.return_value = value
+            return m
+
+        mock_tk.BooleanVar.side_effect = lambda value=False, **kwargs: make_var(value)
+        mock_tk.StringVar.side_effect = lambda value="", **kwargs: make_var(value)
+        mock_tk.IntVar.side_effect = lambda value=0, **kwargs: make_var(value)
+
+        yield {
+            "tk": mock_tk,
+            "ttk": mock_ttk,
+        }
+
+def test_get_all_tree_items_traversal(mock_gui_deps):
+    root = MagicMock()
+    app = QwkGuiApp(root)
+
+    # Mocking a tree structure:
+    # "" (root)
+    # ├── "iid1"
+    # │   └── "iid1.1"
+    # └── "iid2"
+
+    def get_children(parent):
+        if parent == "":
+            return ["iid1", "iid2"]
+        if parent == "iid1":
+            return ["iid1.1"]
+        return []
+
+    app.message_list.get_children.side_effect = get_children
+
+    items = app._get_all_tree_items()
+
+    # Expected flattened list in depth-first order
+    assert items == ["iid1", "iid1.1", "iid2"]
+
+def test_apply_zebra_striping_traversal(mock_gui_deps):
+    root = MagicMock()
+    app = QwkGuiApp(root)
+
+    # Mocking same tree structure
+    def get_children(parent):
+        if parent == "":
+            return ["iid1", "iid2"]
+        if parent == "iid1":
+            return ["iid1.1"]
+        return []
+
+    app.message_list.get_children.side_effect = get_children
+
+    app._apply_zebra_striping()
+
+    # iid1: index 0 (even=False)
+    # iid1.1: index 1 (even=True)
+    # iid2: index 2 (even=False)
+
+    app.message_list.item.assert_any_call("iid1", tags=())
+    app.message_list.item.assert_any_call("iid1.1", tags=("even",))
+    app.message_list.item.assert_any_call("iid2", tags=())
+
+def test_sort_column_empty(mock_gui_deps):
+    root = MagicMock()
+    app = QwkGuiApp(root)
+    app.message_list.get_children.return_value = []
+
+    app.sort_column("Num", False)
+    # Should return early (line 826)
+    app.message_list.move.assert_not_called()


### PR DESCRIPTION
This PR addresses a terminology mismatch in `pyqwk/core.py` and significantly improves the test coverage of the Graphical Reader (`pyqwk/gui.py`).

1. **Bug Fix/Terminology Alignment**: In `pyqwk/core.py`, I replaced the word "sidecar" with "accompanying" in the `load_data` function's logging messages. This change aligns with the project's style guidelines (as noted in memory) and resolves the existing failure in `tests/test_coverage_gap_filler.py`.

2. **Gap Analysis (QA Improvement)**: I identified several uncovered branches and edge cases in the Graphical Reader (`pyqwk/gui.py`) and added four new test files to address them:
    * `tests/test_gui_main.py`: Tests the `main()` function and CLI argument parsing for the GUI.
    * `tests/test_gui_navigation_coverage.py`: Covers guard clauses in `_select_relative_message`.
    * `tests/test_gui_export_coverage.py`: Covers error handling and validation in the export flow.
    * `tests/test_gui_traversal_coverage.py`: Covers the recursive logic in `_get_all_tree_items` and `_apply_zebra_striping`.

These changes increase `pyqwk/gui.py` coverage from 96% to 99% and ensure the entire test suite (446 tests) passes.


---
*PR created automatically by Jules for task [17844597990202109168](https://jules.google.com/task/17844597990202109168) started by @RainRat*