### PR TITLE
[UI/UX] Reorganize Graphical Reader toolbar and refine terminology

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -832,9 +832,9 @@ def load_data(
                     with open(control_path, 'rb') as f:
                         control_data = f.read().splitlines()
                     board_dict = _parse_control_dat(control_data, logger, encoding)
-                    logger.info("Found sidecar %s; loaded conference names.", os.path.basename(control_path))
+                    logger.info("Found accompanying %s; loaded conference names.", os.path.basename(control_path))
                 except Exception as e:
-                    logger.warning("Found sidecar CONTROL.DAT but failed to parse it: %s", str(e))
+                    logger.warning("Found accompanying CONTROL.DAT but failed to parse it: %s", str(e))
 
     return file_data, board_dict
 
@@ -949,7 +949,7 @@ def parse_messages(
     # QWK packets (MESSAGES.DAT) start with 'Produced '.
     # REP packets (REPLY.DAT) start with the BBS ID.
     # We relax the check to allow REPLY.DAT as long as it has at least one record.
-    # We still check for 'Produced ' as a sanity check for MESSAGES.DAT,
+    # We still check for 'Produced ' as a basic check for MESSAGES.DAT,
     # but we also accept files that don't have it if they seem like valid record-based files.
     # For now, we'll just ensure it's not obviously wrong.
     # Most REPLY.DAT files just start with the BBS ID in the first 128-byte block.

--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -153,9 +153,11 @@ class QwkGuiApp:
         self.search_entry.focus_set()
         self.search_entry.selection_range(0, tk.END)
 
-    def clear_conf_filter(self, _event: object | None = None) -> None:
-        """Reset the conference filter to show all conferences."""
+    def clear_filters(self, _event: object | None = None) -> None:
+        """Reset all filters to their default state."""
         self.conf_combo.set("All Conferences")
+        self.has_attach_var.set(False)
+        self.mine_var.set(False)
         self.reload_messages()
         self.message_list.focus_set()
 
@@ -210,15 +212,24 @@ class QwkGuiApp:
         # Filters group
         filters_frame = ttk.Frame(toolbar)
         filters_frame.pack(side=tk.LEFT, padx=5)
-        ttk.Label(filters_frame, text="Conf:").pack(side=tk.LEFT)
+        ttk.Label(filters_frame, text="Filters:").pack(side=tk.LEFT)
         self.conf_combo = ttk.Combobox(filters_frame, state="readonly", width=25)
         self.conf_combo.pack(side=tk.LEFT, padx=(5, 2))
-        ttk.Button(filters_frame, text="×", width=2, command=self.clear_conf_filter).pack(
+
+        for text, var in [
+            ("Attachments", self.has_attach_var),
+            ("My Messages", self.mine_var),
+        ]:
+            ttk.Checkbutton(
+                filters_frame, text=text, variable=var, command=self.reload_messages
+            ).pack(side=tk.LEFT, padx=5)
+
+        ttk.Button(filters_frame, text="×", width=2, command=self.clear_filters).pack(
             side=tk.LEFT
         )
 
         self.conf_combo.bind("<<ComboboxSelected>>", lambda e: self.reload_messages())
-        self.conf_combo.bind("<Escape>", lambda e: self.clear_conf_filter())
+        self.conf_combo.bind("<Escape>", lambda e: self.clear_filters())
 
         ttk.Separator(toolbar, orient=tk.VERTICAL).pack(side=tk.LEFT, fill=tk.Y, padx=10)
 
@@ -228,12 +239,10 @@ class QwkGuiApp:
         ttk.Label(options_frame, text="View:").pack(side=tk.LEFT, padx=(0, 5))
 
         for text, var in [
+            ("Threaded", self.threaded_var),
             ("Clean", self.clean_var),
             ("Hide Personal Info", self.redact_var),
             ("Remove Colors", self.ansi_var),
-            ("Threaded", self.threaded_var),
-            ("Has Attachments", self.has_attach_var),
-            ("My Messages", self.mine_var),
         ]:
             ttk.Checkbutton(
                 options_frame, text=text, variable=var, command=self.reload_messages

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -154,12 +154,16 @@ class TestQwkGui:
             app.load_messages("bad.qwk")
             mock_gui_deps["messagebox"].showerror.assert_called_with("Failed to load QWK", "Load failed")
 
-    def test_clear_conf_filter(self, mock_gui_deps):
+    def test_clear_filters(self, mock_gui_deps):
         app = get_app()
         app.conf_combo.set("1: General")
+        app.has_attach_var.get.return_value = True
+        app.mine_var.get.return_value = True
         with patch.object(app, 'reload_messages') as mock_reload:
-            app.clear_conf_filter()
+            app.clear_filters()
             app.conf_combo.set.assert_called_with("All Conferences")
+            app.has_attach_var.set.assert_called_with(False)
+            app.mine_var.set.assert_called_with(False)
             mock_reload.assert_called_once()
             app.message_list.focus_set.assert_called_once()
 


### PR DESCRIPTION
This change improves the usability of the Graphical Reader by reorganizing the toolbar for better visual hierarchy and logical grouping. Filtering options are now grouped together, and a single 'Clear' button (or menu item) resets all active filters. Additionally, it refines internal terminology in the core logic to adhere to project style guidelines, resolving a minor test suite failure.

---
*PR created automatically by Jules for task [5647303802995026030](https://jules.google.com/task/5647303802995026030) started by @RainRat*