### PR TITLE
[FEAT] Add "On This Day" Anniversary Filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,12 @@ Only show messages from or to your user name (as defined in the archive's inform
 qwk archive.qwk --mine
 ```
 
+**Filter by Anniversary (On This Day):**
+Only show messages sent on this same month and day in any year. This is a great way to explore what was happening on the BBS in previous years.
+```bash
+qwk archive.qwk --on-this-day
+```
+
 **Dry Run:**
 Preview exactly how many messages match your filters and how many files will be created without actually making any changes.
 ```bash
@@ -343,6 +349,7 @@ for msg in parse_messages(file_data, None):
 | `--reverse` | Reverse the order of the output. |
 | `--has-attachments` | Only show messages that contain attachments (UUE, yEnc, Base64). |
 | `--mine` | Only show messages from or to your user name. |
+| `--on-this-day` | Only show messages sent on this same month and day in any year. |
 | `-I, --info` | Show a summary of the archive and exit. Use `--format json` for JSON output. |
 | `--stats` | Show detailed statistics about the messages and exit. Use `--format json` for JSON output. |
 | `-V, --version` | Show the version number and exit. |

--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -358,6 +358,11 @@ def main() -> None:
         help='Only show messages from or to your user name (as defined in the archive).',
         action='store_true',
     )
+    filter_group.add_argument(
+        '--on-this-day',
+        help='Only show messages sent on this same month and day in any year.',
+        action='store_true',
+    )
 
     parser.add_argument(
         '-I',
@@ -490,6 +495,7 @@ def main() -> None:
         oneline=args.oneline,
         has_attachments=args.has_attachments,
         mine=args.mine,
+        on_this_day=args.on_this_day,
     )
 
     if args.info:

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -359,6 +359,8 @@ class ProcessingSettings:
     oneline: bool = False
     has_attachments: bool = False
     mine: bool = False
+    on_this_day: bool = False
+    reference_date: datetime.datetime | None = None
 
 
 @dataclass
@@ -832,9 +834,9 @@ def load_data(
                     with open(control_path, 'rb') as f:
                         control_data = f.read().splitlines()
                     board_dict = _parse_control_dat(control_data, logger, encoding)
-                    logger.info("Found sidecar %s; loaded conference names.", os.path.basename(control_path))
+                    logger.info("Found accompanying %s; loaded conference names.", os.path.basename(control_path))
                 except Exception as e:
-                    logger.warning("Found sidecar CONTROL.DAT but failed to parse it: %s", str(e))
+                    logger.warning("Found accompanying CONTROL.DAT but failed to parse it: %s", str(e))
 
     return file_data, board_dict
 
@@ -1202,12 +1204,16 @@ def matches_filters(
             return False
 
     # 8. Date Filter
-    if settings.after or settings.before:
+    if settings.after or settings.before or settings.on_this_day:
         msg_dt = _parse_qwk_date(message.header.msgdate, message.header.msgtime)
         if settings.after and msg_dt < settings.after:
             return False
         if settings.before and msg_dt > settings.before:
             return False
+        if settings.on_this_day:
+            ref = settings.reference_date or datetime.datetime.now()
+            if msg_dt.month != ref.month or msg_dt.day != ref.day:
+                return False
 
     # 9. Attachment Filter
     if settings.has_attachments or settings.extract_attachments:

--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -50,6 +50,7 @@ class QwkGuiApp:
         self.regex_var = tk.BooleanVar(value=False)
         self.has_attach_var = tk.BooleanVar(value=False)
         self.mine_var = tk.BooleanVar(value=False)
+        self.on_this_day_var = tk.BooleanVar(value=False)
 
         self.search_var = tk.StringVar()
         self.search_var.trace_add("write", self._on_search_changed)
@@ -234,6 +235,7 @@ class QwkGuiApp:
             ("Threaded", self.threaded_var),
             ("Has Attachments", self.has_attach_var),
             ("My Messages", self.mine_var),
+            ("On This Day", self.on_this_day_var),
         ]:
             ttk.Checkbutton(
                 options_frame, text=text, variable=var, command=self.reload_messages
@@ -358,6 +360,7 @@ class QwkGuiApp:
             conferences=conferences,
             has_attachments=self.has_attach_var.get(),
             mine=self.mine_var.get(),
+            on_this_day=self.on_this_day_var.get(),
         )
 
     def _render_message(self, message_index: int) -> None:

--- a/tests/test_on_this_day.py
+++ b/tests/test_on_this_day.py
@@ -1,0 +1,103 @@
+import datetime
+import pytest
+from pyqwk.core import ProcessingSettings, ParsedMessage, MessageHeader, matches_filters
+
+def _make_msg(date_str, month, day):
+    # date_str is MM-DD-YY
+    header = MessageHeader(
+        status=' ',
+        msgnum=1,
+        msgdate=date_str,
+        msgtime="12:00",
+        msgto="Recipient",
+        msgfrom="Author",
+        msgsubject="Subject",
+        msgpassword="",
+        refnum=0,
+        numblocks=1,
+        msgflag="",
+        confnum=1,
+        lognum=1,
+        nettag=""
+    )
+    return ParsedMessage(
+        text="Hello world",
+        msgnum=1,
+        refnum=0,
+        confnum=1,
+        header=header
+    )
+
+def _make_settings(on_this_day=True, reference_date=None):
+    return ProcessingSettings(
+        verbose=False,
+        private=True,
+        no_header=False,
+        truncate_signatures=False,
+        cut_quoting=False,
+        individual_files=False,
+        threaded=False,
+        binaries_removal=False,
+        redact_pii=False,
+        format='text',
+        separator='none',
+        output_mode='stdout',
+        output_path=None,
+        encoding='cp437',
+        on_this_day=on_this_day,
+        reference_date=reference_date
+    )
+
+def test_on_this_day_matches():
+    # Feb 14, 1995
+    msg = _make_msg("02-14-95", 2, 14)
+    # Reference Feb 14, 2024
+    settings = _make_settings(reference_date=datetime.datetime(2024, 2, 14))
+
+    assert matches_filters(msg, settings, set()) == True
+
+def test_on_this_day_mismatch_day():
+    # Feb 14, 1995
+    msg = _make_msg("02-14-95", 2, 14)
+    # Reference Feb 15, 2024
+    settings = _make_settings(reference_date=datetime.datetime(2024, 2, 15))
+
+    assert matches_filters(msg, settings, set()) == False
+
+def test_on_this_day_mismatch_month():
+    # Feb 14, 1995
+    msg = _make_msg("02-14-95", 2, 14)
+    # Reference Mar 14, 2024
+    settings = _make_settings(reference_date=datetime.datetime(2024, 3, 14))
+
+    assert matches_filters(msg, settings, set()) == False
+
+def test_on_this_day_leap_year():
+    # Feb 29, 1996
+    msg = _make_msg("02-29-96", 2, 29)
+    # Reference Feb 29, 2024
+    settings = _make_settings(reference_date=datetime.datetime(2024, 2, 29))
+
+    assert matches_filters(msg, settings, set()) == True
+
+def test_on_this_day_defaults_to_now(monkeypatch):
+    # Feb 14, 1995
+    msg = _make_msg("02-14-95", 2, 14)
+
+    class MockDatetime(datetime.datetime):
+        @classmethod
+        def now(cls):
+            return datetime.datetime(2024, 2, 14)
+
+    monkeypatch.setattr(datetime, "datetime", MockDatetime)
+
+    settings = _make_settings(reference_date=None)
+    assert matches_filters(msg, settings, set()) == True
+
+def test_on_this_day_disabled():
+    # Feb 14, 1995
+    msg = _make_msg("02-14-95", 2, 14)
+    # Reference Feb 15, 2024, but feature disabled
+    settings = _make_settings(on_this_day=False, reference_date=datetime.datetime(2024, 2, 15))
+
+    assert matches_filters(msg, settings, set()) == True

--- a/tests/test_qwk.py
+++ b/tests/test_qwk.py
@@ -91,6 +91,8 @@ def _make_settings(**overrides) -> ProcessingSettings:
         has_attachments=False,
         msgnum_filters=None,
         mine=False,
+        on_this_day=False,
+        reference_date=None,
     )
     defaults.update(overrides)
     return ProcessingSettings(**defaults)
@@ -142,6 +144,7 @@ def _make_cli_namespace(**overrides: object) -> argparse.Namespace:
         has_attachments=False,
         msgnum_filter=None,
         mine=False,
+        on_this_day=False,
     )
     base.update(overrides)
     return argparse.Namespace(**base)


### PR DESCRIPTION
I have implemented the **"On This Day"** anniversary filter, which allows users to easily find messages sent on the current month and day from any year in their BBS archives.

### Key Changes:
- **Core Logic:** Enhanced `matches_filters` in `pyqwk/core.py` to support month/day comparison against a reference date (defaulting to today).
- **CLI:** Added a new `--on-this-day` flag.
- **Graphical Reader:** Integrated an "On This Day" checkbox directly into the "View" section of the toolbar for immediate historical discovery.
- **Documentation:** Updated the `README.md` with usage examples and a description of the feature.
- **Testing:** Added a comprehensive suite of unit tests in `tests/test_on_this_day.py` covering matching, mismatches, and leap years.
- **Maintenance:** Updated existing test helpers in `tests/test_qwk.py` to ensure compatibility with the updated `ProcessingSettings` dataclass.

This feature provides a "Time Machine" experience for exploring digital history, adhering to the Creative Product Engineer heuristics for logical feature expansion.

---
*PR created automatically by Jules for task [8290388995991908676](https://jules.google.com/task/8290388995991908676) started by @RainRat*