### PR TITLE
Consolidate message text selection logic and fix test suite regressions

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -1244,6 +1244,22 @@ def _generate_safe_filename(message: ParsedMessage, output_format: str, count: i
     return f"{message.confnum:03d}-{msg_num:05d}-{slug}{ext}"
 
 
+def _get_message_text_for_format(
+    settings: ProcessingSettings,
+    processed_buffer: str,
+    cleaned_body: str,
+) -> str:
+    """Determine the appropriate text content for a message based on the output format."""
+    if settings.format in ('json', 'xml', 'csv', 'sqlite', 'mbox', 'eml'):
+        if settings.headers_only:
+            return ""
+
+    if settings.format in ('json', 'xml', 'csv', 'sqlite', 'mbox', 'eml', 'html', 'markdown'):
+        return cleaned_body if settings.oneline else processed_buffer
+
+    return processed_buffer
+
+
 def process_merged_files(
     input_paths: list[str],
     settings: ProcessingSettings,
@@ -1434,21 +1450,21 @@ def process_merged_files(
             if settings.extract_attachments:
                 attachment_prefix = "../attachments/" if settings.organize else "attachments/"
 
-            # Structured formats use the cleaned_body (if oneline) or processed_buffer
+            # Determine appropriate text content for structured formats
+            text_content = _get_message_text_for_format(settings, processed_buffer, cleaned_body)
+
             if settings.format == 'text':
                 encoded_buffer = processed_buffer.encode(target_encoding)
             elif settings.format == 'json':
-                text_content = "" if settings.headers_only else (processed_buffer if not settings.oneline else cleaned_body)
                 temp_msg = replace(parsed_message, text=text_content)
                 encoded_buffer = json.dumps(
                     _message_to_dict(temp_msg), indent=4, ensure_ascii=False
                 ).encode(target_encoding)
             elif settings.format == 'xml':
-                text_content = "" if settings.headers_only else (processed_buffer if not settings.oneline else cleaned_body)
                 temp_msg = replace(parsed_message, text=text_content)
                 encoded_buffer = _xml_element_to_str(_message_to_xml_element(temp_msg)).encode(target_encoding)
             elif settings.format == 'html':
-                temp_msg = replace(parsed_message, text=cleaned_body if settings.oneline else processed_buffer)
+                temp_msg = replace(parsed_message, text=text_content)
                 encoded_buffer = _serialize_message_html(
                     temp_msg,
                     attachment_prefix=attachment_prefix,
@@ -1456,7 +1472,7 @@ def process_merged_files(
                     is_regex=settings.regex,
                 ).encode(target_encoding)
             elif settings.format == 'markdown':
-                temp_msg = replace(parsed_message, text=cleaned_body if settings.oneline else processed_buffer)
+                temp_msg = replace(parsed_message, text=text_content)
                 encoded_buffer = _serialize_message_markdown(
                     temp_msg,
                     attachment_prefix=attachment_prefix,
@@ -1464,11 +1480,9 @@ def process_merged_files(
                     is_regex=settings.regex,
                 ).encode(target_encoding)
             elif settings.format == 'mbox':
-                text_content = "" if settings.headers_only else (processed_buffer if not settings.oneline else cleaned_body)
                 temp_msg = replace(parsed_message, text=text_content)
                 encoded_buffer = _serialize_message_mbox(temp_msg).encode(target_encoding)
             elif settings.format == 'eml':
-                text_content = "" if settings.headers_only else (processed_buffer if not settings.oneline else cleaned_body)
                 temp_msg = replace(parsed_message, text=text_content)
                 encoded_buffer = _serialize_message_eml(temp_msg).encode(target_encoding)
             else:
@@ -1514,13 +1528,7 @@ def process_merged_files(
         else:
             estimated_bytes += len(processed_buffer.encode('utf-8'))
             if not settings.dry_run:
-                text_content = processed_buffer
-                # For structured formats, we prefer the cleaned body (if oneline) or processed_buffer
-                # (which might contain headers or terminal highlighting)
-                if settings.format in ('json', 'xml', 'csv', 'sqlite', 'mbox', 'eml'):
-                    text_content = "" if settings.headers_only else (processed_buffer if not settings.oneline else cleaned_body)
-                elif settings.format in ('html', 'markdown') and settings.oneline:
-                    text_content = cleaned_body
+                text_content = _get_message_text_for_format(settings, processed_buffer, cleaned_body)
 
                 collected_messages.append(
                     replace(

--- a/tests/test_qwk.py
+++ b/tests/test_qwk.py
@@ -93,6 +93,10 @@ def _make_settings(**overrides) -> ProcessingSettings:
         mine=False,
         on_this_day=False,
         reference_date=None,
+        merge=False,
+        unique=False,
+        organize=False,
+        organize_by_bbs=False,
     )
     defaults.update(overrides)
     return ProcessingSettings(**defaults)
@@ -145,6 +149,7 @@ def _make_cli_namespace(**overrides: object) -> argparse.Namespace:
         msgnum_filter=None,
         mine=False,
         on_this_day=False,
+        organize_by_bbs=False,
     )
     base.update(overrides)
     return argparse.Namespace(**base)


### PR DESCRIPTION
This PR addresses a duplication issue in `pyqwk/core.py` and fixes a regression in the test suite.

The logic for determining which text content to use for a message (e.g., the full buffer with headers, just the cleaned body, or an empty string for headers-only mode) was duplicated in two places within `process_merged_files`: once for individual file exports and once for merged collections. This logic has been consolidated into a private helper function `_get_message_text_for_format`, improving readability and ensuring consistency.

Additionally, an `AttributeError` in `tests/test_qwk.py` was resolved. The mocked CLI namespace was missing the `organize_by_bbs` attribute, causing several tests to fail. The mock helper functions in the test suite were updated to include this and other missing fields.

All 452 tests pass successfully after these changes.

---
*PR created automatically by Jules for task [16531302697767348839](https://jules.google.com/task/16531302697767348839) started by @RainRat*