### PR TITLE
[DOCS] Document intent of sandwich quoting logic

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -1051,6 +1051,8 @@ def process_message(
         if cut_quoting:
             if RE_QUOTE_PATTERN.match(line):
                 continue
+            # Remove lines between two quoted lines to handle quotes that were broken
+            # across lines by the original BBS software.
             elif j > 0 and j < (len(lines) - 1) \
                 and RE_QUOTE_PATTERN.match(lines[j - 1]) \
                 and RE_QUOTE_PATTERN.match(lines[j + 1]):

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -20,7 +20,7 @@ def _make_settings(**kwargs):
         quiet=False, headers_only=False, oneline=False,
         extract_attachments=False, limit=None, skip=None,
         sort=None, reverse=False, merge=False, unique=False, organize=False,
-        include_toc=False
+        organize_by_bbs=False, include_toc=False
     )
     defaults.update(kwargs)
     field_names = {f.name for f in dataclasses.fields(ProcessingSettings)}

--- a/tests/test_qwk.py
+++ b/tests/test_qwk.py
@@ -115,6 +115,7 @@ def _make_cli_namespace(**overrides: object) -> argparse.Namespace:
         merge=False,
         unique=False,
         organize=False,
+        organize_by_bbs=False,
         binariesremoval=False,
         redactpii=False,
         stripansi=False,


### PR DESCRIPTION
* **Type:** Code Comments
* **What:** Added a descriptive comment to the `cut_quoting` logic in `pyqwk/core.py`.
* **Why:** Explains the non-obvious reasoning for removing lines between quoted blocks, which handles wrapped quotes from legacy BBS systems. This improves maintainability and understanding for future developers. Added necessary maintenance to test helpers to ensure the test suite correctly reflects the current code structure.

---
*PR created automatically by Jules for task [2364416656441406364](https://jules.google.com/task/2364416656441406364) started by @RainRat*