### PR TITLE
[UI/UX] Add syntax highlighting for quoted text in Graphical Reader

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -12,6 +12,7 @@ from pyqwk.core import (
     parse_messages,
     process_message,
     matches_filters,
+    RE_QUOTE_PATTERN,
     get_allowed_conferences,
     _parse_qwk_date,
     resolve_output_format,
@@ -326,6 +327,7 @@ class QwkGuiApp:
         )
         self.detail_text.tag_configure("header_separator", foreground="#cccccc")
         self.detail_text.tag_configure("body", font=("TkFixedFont", 10))
+        self.detail_text.tag_configure("quote", foreground="#4e9a06")
         self.detail_text.tag_configure(
             "search_highlight", background="#ffff00", foreground="#000000"
         )
@@ -427,7 +429,12 @@ class QwkGuiApp:
         self.detail_text.window_create(tk.END, window=separator, stretch=True)
         self.detail_text.insert(tk.END, "\n\n")
 
-        self.detail_text.insert(tk.END, message.text, "body")
+        # Insert body with quote highlighting
+        for line in message.text.splitlines(keepends=True):
+            tags = ["body"]
+            if RE_QUOTE_PATTERN.match(line):
+                tags.append("quote")
+            self.detail_text.insert(tk.END, line, tuple(tags))
 
         # Highlight search terms if present
         search_term = self.search_var.get().strip()

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -184,7 +184,7 @@ class TestQwkGui:
         app.messages = [ParsedMessage(text="Body", msgnum=1, refnum=None, confnum=1, header=header)]
         app.message_list.selection.return_value = ("0",)
         app.on_message_selected()
-        app.detail_text.insert.assert_any_call(mock_gui_deps["tk"].END, "Body", "body")
+        app.detail_text.insert.assert_any_call(mock_gui_deps["tk"].END, "Body", ("body",))
 
     def test_open_file_cancel(self, mock_gui_deps):
         app = get_app()
@@ -350,6 +350,19 @@ class TestQwkGui:
         app.detail_text.tag_add.assert_any_call("search_highlight", "1.10", "1.10+9c")
         # Verify that auto-scroll was triggered for the first match
         app.detail_text.see.assert_called_with("1.10")
+
+    def test_render_message_quotes(self, mock_gui_deps):
+        app = get_app()
+        header = MessageHeader(' ', 1, "01-01-90", "12:00", "To", "From", "Sub", "", None, 1, " ", 1, 1, "")
+        msg = ParsedMessage("Normal line\n> Quoted line\n", 1, None, 1, header)
+        app.messages = [msg]
+        app.board_dict = {1: "General"}
+        app._render_message(0)
+
+        # Verify normal line
+        app.detail_text.insert.assert_any_call(mock_gui_deps["tk"].END, "Normal line\n", ("body",))
+        # Verify quoted line has both 'body' and 'quote' tags
+        app.detail_text.insert.assert_any_call(mock_gui_deps["tk"].END, "> Quoted line\n", ("body", "quote"))
 
     def test_search_invalid_regex(self, mock_gui_deps):
         app = get_app()


### PR DESCRIPTION
Improved the readability of the message detail view in the Graphical Reader by adding syntax highlighting for quoted text.

Key changes:
- Defined a new 'quote' tag in the tk.Text widget with a professional green color (#4e9a06).
- Modified message rendering to identify quoted lines using the existing RE_QUOTE_PATTERN and apply the styling dynamically.
- Updated the test suite to verify the correct application of tags and ensure no regressions in detail view functionality.

---
*PR created automatically by Jules for task [7827957572400414001](https://jules.google.com/task/7827957572400414001) started by @RainRat*