### PR TITLE
[FEAT] JSON Import Support

### DIFF
--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -27,7 +27,7 @@ def _expand_directories(paths: list[str]) -> list[str]:
             for root, _, files in os.walk(path):
                 for file in files:
                     lower_file = file.lower()
-                    if lower_file.endswith(('.qwk', '.zip', '.rep')) or lower_file == 'messages.dat':
+                    if lower_file.endswith(('.qwk', '.zip', '.rep', '.json')) or lower_file == 'messages.dat':
                         expanded_paths.append(os.path.join(root, file))
         else:
             expanded_paths.append(path)
@@ -79,12 +79,13 @@ def _parse_cli_date(date_str: str | None, end_of_day: bool = False) -> datetime.
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="A tool to read and convert old Bulletin Board System (BBS) message packets (QWK and REP formats) into modern formats like Text, HTML, or JSON."
+        description="A tool to read and convert old Bulletin Board System (BBS) message packets (QWK, REP, and JSON formats) into modern formats like Text, HTML, or JSON."
     )
     parser.add_argument(
         'input_paths',
         help=(
             'The archives, message files, or folders you want to read. '
+            'Supported formats include QWK, REP, and JSON. '
             'If you provide a path to a raw MESSAGES.DAT file, pyqwk will '
             'also look for an accompanying CONTROL.DAT in the same folder to '
             'automatically load conference names.'

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -527,6 +527,26 @@ class MessageHeader:
 
         return header
 
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "MessageHeader":
+        """Reconstruct a MessageHeader from a dictionary."""
+        # Convert numeric fields that might be strings
+        def to_int(v):
+            if v is None or v == "": return None
+            try: return int(v)
+            except (ValueError, TypeError): return None
+
+        kwargs = {}
+        for field_info in fields(cls):
+            name = field_info.name
+            val = data.get(name)
+            if name in ('msgnum', 'refnum', 'numblocks', 'confnum', 'lognum'):
+                kwargs[name] = to_int(val)
+            else:
+                kwargs[name] = val if val is not None else ""
+
+        return cls(**kwargs)
+
     def format_text(
         self,
         board_dict: Mapping[int, str],
@@ -703,9 +723,34 @@ class LogFormatter(logging.Formatter):
         return formatter.format(record)
 
 
+def _parse_json_messages(data: list[dict[str, Any]]) -> list[ParsedMessage]:
+    """Convert a list of dictionaries into ParsedMessage objects."""
+    messages = []
+    for entry in data:
+        header_dict = entry.get('header', {})
+        header = MessageHeader.from_dict(header_dict)
+
+        msg = ParsedMessage(
+            text=entry.get('text', ""),
+            msgnum=header.msgnum,
+            refnum=header.refnum,
+            confnum=header.confnum,
+            header=header,
+            depth=entry.get('depth', 0),
+            thread_id=entry.get('thread_id'),
+            parent_msgnum=entry.get('parent_msgnum'),
+            confname=entry.get('conference'),
+            bbs_name=entry.get('bbs_name'),
+            source_file=entry.get('source_file'),
+            attachments=entry.get('attachments'),
+        )
+        messages.append(msg)
+    return messages
+
+
 def load_data(
     input_path: str, logger: logging.Logger, encoding: str = 'cp437'
-) -> tuple[bytearray, dict[int, str]]:
+) -> tuple[bytearray | list[ParsedMessage], dict[int, str]]:
     """Load message and conference information from a QWK packet or raw file.
 
     Args:
@@ -724,6 +769,25 @@ def load_data(
         to automatically load conference information.
     """
     board_dict: dict[int, str] = {}
+    if input_path.lower().endswith('.json'):
+        with open(input_path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+            if not isinstance(data, list):
+                raise ValueError("JSON archive must be a list of messages.")
+            messages = _parse_json_messages(data)
+
+            # Reconstruct board_dict and bbs_info if possible
+            board_dict = ConferenceMap()
+            bbs_info = BBSInfo()
+            for msg in messages:
+                if msg.confnum is not None and msg.confname:
+                    board_dict[msg.confnum] = msg.confname
+                if msg.bbs_name:
+                    bbs_info.name = msg.bbs_name
+
+            board_dict.bbs_info = bbs_info
+            return messages, board_dict
+
     if zipfile.is_zipfile(input_path):
         messages_name = ''
         reply_name = ''
@@ -1541,13 +1605,43 @@ def process_merged_files(
         allowed_conferences = get_allowed_conferences(settings.conferences, board_dict)
 
         desc = f"Processing {os.path.basename(input_path)}"
-        with _create_progress_bar(len(file_data), settings.quiet, desc=desc) as progress_bar:
-            for parsed_message in parse_messages(
+
+        if isinstance(file_data, list):
+            # For pre-parsed messages (JSON), we iterate directly
+            messages_to_process = file_data
+            total_progress = len(file_data)
+            progress_unit = 'msg'
+        else:
+            # For raw data, we use parse_messages
+            messages_to_process = parse_messages(
                 file_data,
-                progress_bar,
+                None, # Will be set below
                 settings.encoding,
                 settings.headers_only,
-            ):
+            )
+            total_progress = len(file_data)
+            progress_unit = 'B'
+
+        with _create_progress_bar(total_progress, settings.quiet, desc=desc) as progress_bar:
+            if progress_bar is not None:
+                if progress_unit == 'msg':
+                    # tqdm settings for message count
+                    progress_bar.unit = 'msg'
+                    progress_bar.unit_scale = False
+                else:
+                    # If it's a bytearray and we're using parse_messages,
+                    # we need to pass the progress bar to it.
+                    messages_to_process = parse_messages(
+                        file_data,
+                        progress_bar,
+                        settings.encoding,
+                        settings.headers_only,
+                    )
+
+            for parsed_message in messages_to_process:
+                if isinstance(file_data, list) and progress_bar is not None:
+                    progress_bar.update(1)
+
                 parsed_message = replace(
                     parsed_message,
                     confname=board_dict.get(parsed_message.confnum),
@@ -2630,20 +2724,24 @@ def show_info(input_paths: list[str], settings: ProcessingSettings, logger: logg
             if bbs_info:
                 info_entry["bbs_info"] = asdict(bbs_info)
 
-            if len(file_data) < BLOCK_SIZE:
-                if settings.format != 'json':
-                    print(f"File: {_colorize(input_path, CYAN)}")
-                    print("  Invalid or empty file.")
-                all_info.append(info_entry)
-                continue
+            if isinstance(file_data, list):
+                messages_to_process = file_data
+            else:
+                if len(file_data) < BLOCK_SIZE:
+                    if settings.format != 'json':
+                        print(f"File: {_colorize(input_path, CYAN)}")
+                        print("  Invalid or empty file.")
+                    all_info.append(info_entry)
+                    continue
+                messages_to_process = parse_messages(
+                    file_data, None, settings.encoding, headers_only=True
+                )
 
             total_messages = 0
             conference_counts = defaultdict(int)
 
             try:
-                for message in parse_messages(
-                    file_data, None, settings.encoding, headers_only=True
-                ):
+                for message in messages_to_process:
                     total_messages += 1
                     conference_counts[message.confnum] += 1
             except MessagesDatFormatError as e:
@@ -2743,10 +2841,31 @@ def show_stats(input_paths: list[str], settings: ProcessingSettings, logger: log
             # Use a progress bar for statistics gathering
             # We must read message bodies to accurately count attachments
             need_body = True
-            with _create_progress_bar(len(file_data), settings.quiet, desc=desc) as progress_bar:
-                for message in parse_messages(
-                    file_data, progress_bar, settings.encoding, headers_only=not need_body
-                ):
+
+            if isinstance(file_data, list):
+                messages_to_process = file_data
+                total_progress = len(file_data)
+                progress_unit = 'msg'
+            else:
+                messages_to_process = parse_messages(
+                    file_data, None, settings.encoding, headers_only=not need_body
+                )
+                total_progress = len(file_data)
+                progress_unit = 'B'
+
+            with _create_progress_bar(total_progress, settings.quiet, desc=desc) as progress_bar:
+                if progress_bar is not None:
+                    if progress_unit == 'msg':
+                        progress_bar.unit = 'msg'
+                        progress_bar.unit_scale = False
+                    else:
+                        messages_to_process = parse_messages(
+                            file_data, progress_bar, settings.encoding, headers_only=not need_body
+                        )
+
+                for message in messages_to_process:
+                    if isinstance(file_data, list) and progress_bar is not None:
+                        progress_bar.update(1)
                     total_count += 1
 
                     if not matches_filters(message, settings, allowed_conferences, user_name):

--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -469,6 +469,7 @@ class QwkGuiApp:
     def open_file(self, _event: object | None = None) -> None:
         filetypes = [
             ("QWK archives", "*.qwk"),
+            ("JSON archives", "*.json"),
             ("messages.dat", "messages.dat"),
             ("All files", "*.*"),
         ]

--- a/tests/test_json_import.py
+++ b/tests/test_json_import.py
@@ -1,0 +1,108 @@
+import json
+import logging
+from pathlib import Path
+import pytest
+from pyqwk.core import (
+    load_data,
+    process_file,
+    ProcessingSettings,
+    ParsedMessage,
+    MessageHeader
+)
+
+@pytest.fixture
+def baseline_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "testdata" / "messages.dat"
+
+@pytest.fixture
+def logger():
+    logger = logging.getLogger("pyqwk.tests")
+    logger.addHandler(logging.NullHandler())
+    return logger
+
+def _make_settings(**overrides):
+    defaults = dict(
+        verbose=False,
+        private=True,
+        no_header=False,
+        truncate_signatures=False,
+        cut_quoting=False,
+        individual_files=False,
+        threaded=False,
+        binaries_removal=False,
+        redact_pii=False,
+        format="text",
+        separator="auto",
+        output_mode="stdout",
+        output_path=None,
+        encoding="latin1",
+        quiet=True,
+    )
+    defaults.update(overrides)
+    return ProcessingSettings(**defaults)
+
+def test_json_export_reimport_symmetry(tmp_path, baseline_path, logger):
+    """Test that messages exported to JSON can be re-imported and processed."""
+    # 1. Export baseline to JSON
+    json_path = tmp_path / "archive.json"
+    settings_export = _make_settings(
+        format="json",
+        output_mode="file",
+        output_path=str(json_path)
+    )
+    process_file(str(baseline_path), settings_export, logger)
+
+    assert json_path.exists()
+
+    # 2. Re-import from JSON
+    messages, board_dict = load_data(str(json_path), logger)
+
+    assert isinstance(messages, list)
+    assert len(messages) > 0
+    assert isinstance(messages[0], ParsedMessage)
+
+    # Check that header data was preserved
+    # The first message in baseline is msgnum 28
+    assert messages[0].msgnum == 28
+    assert messages[0].header.msgnum == 28
+    assert messages[0].header.msgfrom.strip() == "GammaO #571 @0*1"
+
+    # 3. Process re-imported data (e.g., convert to HTML)
+    html_path = tmp_path / "archive.html"
+    settings_html = _make_settings(
+        format="html",
+        output_mode="file",
+        output_path=str(html_path)
+    )
+
+    # We can use process_file on the json path directly now
+    process_file(str(json_path), settings_html, logger)
+
+    assert html_path.exists()
+    html_content = html_path.read_text(encoding="utf-8")
+    assert "GammaO #571 @0*1" in html_content
+    assert "New User" in html_content # Subject
+
+def test_json_import_with_missing_fields(tmp_path, logger):
+    """Test JSON import handles missing or malformed fields gracefully."""
+    json_data = [
+        {
+            "header": {
+                "msgfrom": "Test User",
+                "confnum": "100" # String instead of int
+            },
+            "text": "Hello world",
+            "conference": "Test Conf"
+        }
+    ]
+    json_path = tmp_path / "partial.json"
+    json_path.write_text(json.dumps(json_data), encoding="utf-8")
+
+    messages, board_dict = load_data(str(json_path), logger)
+
+    assert len(messages) == 1
+    assert messages[0].header.msgfrom == "Test User"
+    assert messages[0].confnum == 100
+    assert messages[0].text == "Hello world"
+    assert 100 in board_dict
+    assert board_dict[100] == "Test Conf"

--- a/tests/test_qwk.py
+++ b/tests/test_qwk.py
@@ -145,6 +145,7 @@ def _make_cli_namespace(**overrides: object) -> argparse.Namespace:
         msgnum_filter=None,
         mine=False,
         on_this_day=False,
+        organize_by_bbs=False,
     )
     base.update(overrides)
     return argparse.Namespace(**base)


### PR DESCRIPTION
This PR adds the ability to import BBS message archives in JSON format. This enables a "round-trip" workflow where messages can be exported to JSON for manual processing or archival, and then read back into `pyqwk` for further filtering, formatting (e.g., converting to HTML/Markdown), or viewing in the Graphical Reader.

The implementation is non-breaking and additive, maintaining full compatibility with existing QWK/REP/DAT workflows.

---
*PR created automatically by Jules for task [3144003809111072916](https://jules.google.com/task/3144003809111072916) started by @RainRat*