### PR TITLE
[DOCS] Improve CLI log level help and validation

### DIFF
--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -264,8 +264,10 @@ def main() -> None:
     control_group.add_argument(
         '-l',
         '--loglevel',
-        help='Choose how much detail to show in logs (DEBUG, INFO, WARNING, ERROR).',
+        help='Set the amount of detail shown in logs (DEBUG, INFO, WARNING, ERROR, CRITICAL).',
         default='INFO',
+        type=str.upper,
+        choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
     )
 
     filter_group = parser.add_argument_group('Filtering Options')
@@ -398,9 +400,7 @@ def main() -> None:
     if args.oneline and args.individualfiles:
         parser.error("You cannot use --oneline and --individual-files at the same time.")
 
-    numeric_level = getattr(logging, args.loglevel.upper(), None)
-    if not isinstance(numeric_level, int):
-        raise ValueError(f"'{args.loglevel}' is not a valid log level.")
+    numeric_level = getattr(logging, args.loglevel)
 
     use_colors = hasattr(sys.stderr, 'isatty') and sys.stderr.isatty()
     handler = logging.StreamHandler()

--- a/tests/test_qwk.py
+++ b/tests/test_qwk.py
@@ -816,13 +816,19 @@ def test_cli_treats_extra_positional_args_as_inputs_requiring_output_dir(
 
 
 def test_cli_rejects_invalid_log_level(
-    monkeypatch: pytest.MonkeyPatch, baseline_path: Path
+    monkeypatch: pytest.MonkeyPatch, baseline_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    namespace = _make_cli_namespace(input_paths=[str(baseline_path)], loglevel="NOPE")
-    monkeypatch.setattr(argparse.ArgumentParser, "parse_args", lambda self: namespace)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["prog", str(baseline_path), "--loglevel", "NOPE"],
+    )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(SystemExit):
         main()
+
+    stderr = capsys.readouterr().err
+    assert "invalid choice: 'NOPE'" in stderr
 
 
 def test_cli_reports_missing_file(


### PR DESCRIPTION
* **Type:** Internal Help
* **What:** The `--loglevel` CLI argument in `pyqwk/cli.py`.
* **Why:** Simplified log level selection by adding valid choices and case-insensitivity. Improved error handling by letting `argparse` provide a standard error message instead of a technical traceback. Added the missing `CRITICAL` level to the help text.

---
*PR created automatically by Jules for task [17688221103100024783](https://jules.google.com/task/17688221103100024783) started by @RainRat*