### PR TITLE
[UI/UX] Add 'To' recipient field to CLI one-line summary output

### DIFF
--- a/output.txt
+++ b/output.txt
@@ -1,9 +1,0 @@
---------------------------------------------------------------------------------
-Date:           07-21-94 21:32
-From:           GammaO #571 @0*1
-To:             All
-Subject:        New User
-
-
-Hello this is my first day in the wonderful world of BBSing and I need some
-help.

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -640,6 +640,7 @@ class MessageHeader:
         conf_name = board_dict.get(self.confnum, str(self.confnum))
         date_str = f"{self.msgdate} {self.msgtime}"
         from_name = self.msgfrom.strip()
+        to_name = self.msgto.strip()
         subject = self.msgsubject.strip()
 
         def prepare_field(text: str, width: int, highlight: bool = True) -> str:
@@ -649,15 +650,16 @@ class MessageHeader:
                 truncated = _highlight_text(truncated, highlight_term, is_regex, use_colors)
             return truncated + (" " * (width - display_len))
 
-        conf_part = prepare_field(conf_name, 16)
-        from_part = prepare_field(from_name, 20)
+        conf_part = prepare_field(conf_name, 12)
+        from_part = prepare_field(from_name, 15)
+        to_part = prepare_field(to_name, 15)
         subject_part = _highlight_text(subject, highlight_term, is_regex, use_colors)
 
         msgnum_part = ""
         if verbose:
             msgnum_part = f"{(self.msgnum or ''):<6} "
 
-        return f"{msgnum_part}{conf_part} {date_str:<14} {from_part} {subject_part}\r\n"
+        return f"{msgnum_part}{conf_part} {date_str:<14} {from_part} {to_part} {subject_part}\r\n"
 
 
 class MessagesDatFormatError(Exception):
@@ -2338,9 +2340,10 @@ def _write_text(
 
     if settings and settings.oneline:
         msgnum_hdr = f"{'Num':<6} " if settings.verbose else ""
-        conf_hdr = f"{'Conference':<16}"
+        conf_hdr = f"{'Conference':<12}"
         date_hdr = f"{'Date':<14}"
-        from_hdr = f"{'From':<20}"
+        from_hdr = f"{'From':<15}"
+        to_hdr = f"{'To':<15}"
         subj_hdr = "Subject"
 
         use_colors = (
@@ -2352,13 +2355,13 @@ def _write_text(
         if use_colors:
             BOLD = "1"
             def b(t): return f"\033[{BOLD}m{t}\033[0m"
-            header_line = f"{b(msgnum_hdr)}{b(conf_hdr)} {b(date_hdr)} {b(from_hdr)} {b(subj_hdr)}\r\n"
+            header_line = f"{b(msgnum_hdr)}{b(conf_hdr)} {b(date_hdr)} {b(from_hdr)} {b(to_hdr)} {b(subj_hdr)}\r\n"
         else:
-            header_line = f"{msgnum_hdr}{conf_hdr} {date_hdr} {from_hdr} {subj_hdr}\r\n"
+            header_line = f"{msgnum_hdr}{conf_hdr} {date_hdr} {from_hdr} {to_hdr} {subj_hdr}\r\n"
 
         parts.append(header_line)
         # Calculate separator length from the plain text header
-        plain_header = f"{msgnum_hdr}{conf_hdr} {date_hdr} {from_hdr} {subj_hdr}"
+        plain_header = f"{msgnum_hdr}{conf_hdr} {date_hdr} {from_hdr} {to_hdr} {subj_hdr}"
         parts.append("-" * len(plain_header) + "\r\n")
 
     if settings and settings.include_toc:

--- a/tests/test_ui_oneline_alignment.py
+++ b/tests/test_ui_oneline_alignment.py
@@ -22,28 +22,32 @@ def test_oneline_alignment_long_names():
 
     oneline = header.format_oneline(board_dict)
 
-    # Expected truncation:
-    # Conf: "A Very Long Conf" (16 chars)
-    # From: "A Very Long Author N" (20 chars)
+    # Expected truncation (New widths):
+    # Conf: "A Very Long " (12 chars)
     # Date: "01-01-24 12:00" (14 chars)
+    # From: "A Very Long Aut" (15 chars)
+    # To:   "Recipient      " (15 chars)
 
-    assert "A Very Long Conf " in oneline
+    assert "A Very Long  " in oneline
     assert "01-01-24 12:00 " in oneline
-    assert "A Very Long Author N " in oneline
+    assert "A Very Long Aut" in oneline
+    assert "Recipient      " in oneline
 
     # Check total length of fixed parts
     # msgnum_part: ""
-    # conf_part: 16
+    # conf_part: 12
     # space: 1
     # date_part: 14
     # space: 1
-    # from_part: 20
+    # from_part: 15
     # space: 1
-    # total before subject: 16+1+14+1+20+1 = 53
+    # to_part: 15
+    # space: 1
+    # total before subject: 12+1+14+1+15+1+15+1 = 60
 
-    prefix = oneline[:53]
-    assert len(prefix) == 53
-    assert prefix.endswith("A Very Long Author N ")
+    prefix = oneline[:60]
+    assert len(prefix) == 60
+    assert prefix.endswith("Recipient       ")
 
 def test_oneline_alignment_with_highlighting():
     header = MessageHeader(
@@ -81,21 +85,22 @@ def test_oneline_alignment_with_highlighting():
     # The prepare_field function calculates display_len WITHOUT the ANSI codes
     # because it truncates first, then highlights, but it adds padding based on display_len.
 
-    # "Author Name" is 11 chars. Truncated to 20 is still 11 chars.
+    # "Author Name" is 11 chars. Truncated to 15 is still 11 chars.
     # display_len = 11.
     # Highlighted "Auth" -> "\x1b[7mAuth\x1b[0mor Name"
-    # Padding = 20 - 11 = 9 spaces.
+    # Padding = 15 - 11 = 4 spaces.
 
-    assert "Author Name         " in oneline.replace("\x1b[7m", "").replace("\x1b[0m", "")
+    assert "Author Name    " in oneline.replace("\x1b[7m", "").replace("\x1b[0m", "")
 
     # Check the whole line structure
     plain_line = oneline.replace("\x1b[7m", "").replace("\x1b[0m", "")
-    # Conf (16) + space (1) + Date (14) + space (1) + From (20) + space (1) + Subject
-    # "Conference      " (16)
+    # Conf (12) + space (1) + Date (14) + space (1) + From (15) + space (1) + To (15) + space (1) + Subject
+    # "Conference  " (12)
     # "01-01-24 12:00 " (14+1)
-    # "Author Name         " (20)
+    # "Author Name    " (15)
+    # "Recipient      " (15)
     # " " (1)
     # "Subject"
 
-    expected_start = "Conference       01-01-24 12:00 Author Name          Subject"
+    expected_start = "Conference   01-01-24 12:00 Author Name     Recipient       Subject"
     assert plain_line.startswith(expected_start)


### PR DESCRIPTION
Add 'To' recipient field to CLI one-line summary output to improve information density and consistency with the Graphical Reader. adjusted field widths for a better visual balance on standard terminals.

---
*PR created automatically by Jules for task [6901736283654713302](https://jules.google.com/task/6901736283654713302) started by @RainRat*