### PR TITLE
[FEAT] SQLite Archive Import Symmetry

### DIFF
--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -27,7 +27,7 @@ def _expand_directories(paths: list[str]) -> list[str]:
             for root, _, files in os.walk(path):
                 for file in files:
                     lower_file = file.lower()
-                    if lower_file.endswith(('.qwk', '.zip', '.rep', '.json')) or lower_file == 'messages.dat':
+                    if lower_file.endswith(('.qwk', '.zip', '.rep', '.json', '.db', '.sqlite')) or lower_file == 'messages.dat':
                         expanded_paths.append(os.path.join(root, file))
         else:
             expanded_paths.append(path)
@@ -85,7 +85,7 @@ def main() -> None:
         'input_paths',
         help=(
             'The archives, message files, or folders you want to read. '
-            'Supported formats include QWK, REP, and JSON. '
+            'Supported formats include QWK, REP, JSON, and SQLite. '
             'If you provide a path to a raw MESSAGES.DAT file, pyqwk will '
             'also look for an accompanying CONTROL.DAT in the same folder to '
             'automatically load conference names.'

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -723,6 +723,62 @@ class LogFormatter(logging.Formatter):
         return formatter.format(record)
 
 
+def _parse_sqlite_messages(db_path: str) -> list[ParsedMessage]:
+    """Import messages from a pyqwk SQLite database."""
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    cursor = conn.cursor()
+
+    try:
+        cursor.execute("SELECT * FROM messages")
+    except sqlite3.OperationalError as e:
+        conn.close()
+        raise ValueError(f"SQLite database is missing the 'messages' table: {e}")
+
+    messages = []
+    for row in cursor.fetchall():
+        # Reconstruct header dict
+        header_dict = {
+            'confnum': row['conference_number'],
+            'msgnum': row['message_number'],
+            'msgdate': row['date'],
+            'msgtime': "", # ISO date in SQLite includes time
+            'msgfrom': row['author'],
+            'msgto': row['recipient'],
+            'msgsubject': row['subject'],
+            'status': row['status'],
+            'refnum': row['reference_number']
+        }
+
+        # Add remaining fields with defaults
+        for f in fields(MessageHeader):
+            if f.name not in header_dict:
+                header_dict[f.name] = ""
+
+        header = MessageHeader.from_dict(header_dict)
+
+        attachments = row['attachments'].split(';') if row['attachments'] else []
+
+        msg = ParsedMessage(
+            text=row['text'],
+            msgnum=header.msgnum,
+            refnum=header.refnum,
+            confnum=header.confnum,
+            header=header,
+            depth=row['depth'],
+            thread_id=row['thread_id'],
+            parent_msgnum=row['parent_message_number'],
+            confname=row['conference_name'],
+            bbs_name=row['bbs_name'],
+            source_file=row['source_file'],
+            attachments=attachments,
+        )
+        messages.append(msg)
+
+    conn.close()
+    return messages
+
+
 def _parse_json_messages(data: list[dict[str, Any]]) -> list[ParsedMessage]:
     """Convert a list of dictionaries into ParsedMessage objects."""
     messages = []
@@ -769,6 +825,26 @@ def load_data(
         to automatically load conference information.
     """
     board_dict: dict[int, str] = {}
+
+    if input_path.lower().endswith(('.db', '.sqlite')):
+        try:
+            messages = _parse_sqlite_messages(input_path)
+        except Exception as e:
+            raise ValueError(f"Failed to load SQLite archive: {e}")
+
+        # Reconstruct board_dict and bbs_info
+        board_dict = ConferenceMap()
+        bbs_info = BBSInfo()
+        for msg in messages:
+            if msg.confnum is not None:
+                if msg.confnum not in board_dict or (not board_dict[msg.confnum] and msg.confname):
+                    board_dict[msg.confnum] = msg.confname or f"Conference {msg.confnum}"
+            if msg.bbs_name:
+                bbs_info.name = msg.bbs_name
+
+        board_dict.bbs_info = bbs_info
+        return messages, board_dict
+
     if input_path.lower().endswith('.json'):
         with open(input_path, 'r', encoding='utf-8') as f:
             data = json.load(f)
@@ -2182,6 +2258,10 @@ def _parse_qwk_date(msgdate: str, msgtime: str) -> datetime.datetime:
     If the date is invalid, it returns a default date of 1970-01-01.
     """
     try:
+        # Handle ISO 8601 format (used in SQLite exports)
+        if 'T' in msgdate:
+            return datetime.datetime.fromisoformat(msgdate)
+
         # Normalize date separators
         msgdate = msgdate.replace('/', '-')
 

--- a/tests/test_sqlite_import.py
+++ b/tests/test_sqlite_import.py
@@ -1,0 +1,102 @@
+import sqlite3
+import logging
+from pathlib import Path
+import pytest
+from pyqwk.core import (
+    load_data,
+    process_file,
+    ProcessingSettings,
+    ParsedMessage,
+    MessageHeader
+)
+
+@pytest.fixture
+def baseline_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "testdata" / "messages.dat"
+
+@pytest.fixture
+def logger():
+    logger = logging.getLogger("pyqwk.tests")
+    logger.addHandler(logging.NullHandler())
+    return logger
+
+def _make_settings(**overrides):
+    defaults = dict(
+        verbose=True,
+        private=True,
+        no_header=False,
+        truncate_signatures=False,
+        cut_quoting=False,
+        individual_files=False,
+        threaded=False,
+        binaries_removal=False,
+        redact_pii=False,
+        format="text",
+        separator="auto",
+        output_mode="stdout",
+        output_path=None,
+        encoding="latin1",
+        quiet=True,
+    )
+    defaults.update(overrides)
+    return ProcessingSettings(**defaults)
+
+def test_sqlite_export_reimport_symmetry(tmp_path, baseline_path, logger):
+    """Test that messages exported to SQLite can be re-imported and processed."""
+    # 1. Export baseline to SQLite
+    db_path = tmp_path / "archive.db"
+    settings_export = _make_settings(
+        format="sqlite",
+        output_mode="file",
+        output_path=str(db_path)
+    )
+    process_file(str(baseline_path), settings_export, logger)
+
+    assert db_path.exists()
+
+    # 2. Re-import from SQLite
+    messages, board_dict = load_data(str(db_path), logger)
+
+    assert isinstance(messages, list)
+    assert len(messages) > 0
+    assert isinstance(messages[0], ParsedMessage)
+
+    # Check that header data was preserved
+    # The first message in baseline is msgnum 28, conference 3
+    msg = messages[0]
+    assert msg.msgnum == 28
+    assert msg.header.msgnum == 28
+    assert msg.header.msgfrom.strip() == "GammaO #571 @0*1"
+    assert msg.confnum == 3
+    # Note: baseline messages.dat doesn't have an accompanying CONTROL.DAT,
+    # so conference name will be based on the number if not provided.
+    # But load_data in test_json_import.py says 384 bytes, let's see.
+
+    # Verify board_dict reconstruction
+    assert 3 in board_dict
+
+    # 3. Process re-imported data (e.g., convert to HTML)
+    html_path = tmp_path / "archive.html"
+    settings_html = _make_settings(
+        format="html",
+        output_mode="file",
+        output_path=str(html_path)
+    )
+
+    # We can use process_file on the db path directly now
+    process_file(str(db_path), settings_html, logger)
+
+    assert html_path.exists()
+    html_content = html_path.read_text(encoding="utf-8")
+    assert "GammaO #571 @0*1" in html_content
+    assert "New User" in html_content # Subject
+
+def test_sqlite_import_handles_missing_table(tmp_path, logger):
+    """Test SQLite import fails gracefully if the messages table is missing."""
+    db_path = tmp_path / "empty.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE wrong_table (id INTEGER)")
+    conn.close()
+
+    with pytest.raises(ValueError, match="missing the 'messages' table"):
+        load_data(str(db_path), logger)


### PR DESCRIPTION
**PR Title:** [FEAT] SQLite Archive Import Symmetry

**Description:**
* **What:** Added the ability for `pyqwk` to read and process message archives stored in SQLite databases (previously, it could only export to this format). This includes updating the CLI to accept `.db` and `.sqlite` files, enhancing the core date parser to support ISO 8601 timestamps, and implementing a database loader that reconstructs conference and BBS metadata from the stored records.
* **Why:** I noticed that while `pyqwk` has a robust "Export to SQLite" feature, it lacked the reciprocal ability to read those same databases back into the tool ("Symmetry" heuristic). By adding this functionality, users can now use SQLite as a powerful, queryable intermediate format for their BBS message collections before eventually converting them to other formats like HTML or Markdown.

**Changes:**
- `pyqwk/cli.py`: Added SQLite extensions to directory expansion and updated help text.
- `pyqwk/core.py`: 
    - Enhanced `_parse_qwk_date` for ISO 8601 support.
    - Added `_parse_sqlite_messages` to handle database querying and object reconstruction.
    - Updated `load_data` to detect and route SQLite inputs.
- `tests/test_sqlite_import.py`: New test suite verifying full-loop symmetry and error handling.
- `tests/test_date_parsing.py`: Minor update to maintain strictness for non-ISO formats.

---
*PR created automatically by Jules for task [17728941001605450002](https://jules.google.com/task/17728941001605450002) started by @RainRat*