### PR TITLE
Fix redundant text headers in structured output formats

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -1467,7 +1467,7 @@ def process_merged_files(
         and hasattr(sys.stdout, 'isatty')
         and sys.stdout.isatty()
     )
-    include_header = not settings.no_header and settings.format not in ('html', 'markdown')
+    include_header = not settings.no_header and settings.format == 'text'
     target_encoding = 'utf-8'
     if settings.individual_files and settings.format == 'text':
         target_encoding = settings.encoding

--- a/tests/test_fix_separators.py
+++ b/tests/test_fix_separators.py
@@ -41,8 +41,9 @@ def test_sqlite_no_separator_by_default(tmp_path, logger):
     conn.close()
 
     assert not text.startswith("-" * 80)
-    # It should start with the header if no_header is False
-    assert text.startswith("Date:")
+    # It should NOT start with the text header in structured formats even if no_header is False
+    assert not text.startswith("Date:")
+    assert text == "Hello this is my first day in the wonderful world of BBSing and I need some\r\nhelp.\r\n"
 
 def test_mbox_no_separator_by_default(tmp_path, logger):
     input_path = Path(__file__).resolve().parents[1] / "testdata" / "messages.dat"

--- a/tests/test_qwk.py
+++ b/tests/test_qwk.py
@@ -505,10 +505,11 @@ def test_process_file_writes_json(
     assert "header" in message
     assert "text" in message
     expected_message = _read_expected(expected_output_path)
-    # Structured output should NOT contain the separator line
+    # Structured output should NOT contain the separator line or text headers
     separator = ("-" * 80) + "\r\n"
     assert separator not in message["text"]
-    assert message["text"] == expected_message.replace(separator, "", 1)
+    assert "From:" not in message["text"]
+    assert message["text"] == "Hello this is my first day in the wonderful world of BBSing and I need some\r\nhelp.\r\n"
     assert message["header"]["msgnum"] == 28
 
 
@@ -596,10 +597,11 @@ def test_process_file_writes_xml(
     assert '<header>' in content
     assert '<msgnum>28' in content
     expected_message = _read_expected(expected_output_path)
-    # Structured output should NOT contain the separator line
+    # Structured output should NOT contain the separator line or text headers
     separator = ("-" * 80) + "\r\n"
-    expected_content = expected_message.replace(separator, "", 1).replace('\r\n', '\n')
-    assert expected_content in content
+    assert separator not in content
+    assert "<text>Date:" not in content
+    assert "<text>Hello this is my first day in the wonderful world of BBSing and I need some\nhelp.\n</text>" in content
     assert ("-" * 80) not in content
 
 


### PR DESCRIPTION
* **What:** Updated the `include_header` logic in `process_merged_files` to ensure that plain-text headers (e.g., "From:", "Date:") are only prepended to the message body when the output format is 'text'.
* **Why:** Previously, structured formats like JSON, XML, CSV, and SQLite had these headers redundantly included in their `text` fields, which is unnecessary as the metadata is already present in separate fields. This change ensures a cleaner data export for these formats.
* **Verification:** Verified with a reproduction script for JSON output. Updated existing tests in `tests/test_qwk.py` and `tests/test_fix_separators.py` to assert the exact clean body content. All relevant tests pass. Pre-existing failure in `test_cli_invalid_loglevel` was preserved to maintain atomic scope.

---
*PR created automatically by Jules for task [35421192665984118](https://jules.google.com/task/35421192665984118) started by @RainRat*