### PR TITLE
[DOCS] Expand format support documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pyqwk
 
-pyqwk is a tool to convert old `.QWK` and `.REP` mail archives (from the BBS era) into modern formats like Text, HTML, JSON, XML, CSV, mbox, and SQLite.
+pyqwk is a tool to convert old `.QWK`, `.REP`, `.JSON`, and SQLite mail archives into modern formats like Text, HTML, JSON, XML, Markdown, CSV, mbox, EML, and SQLite.
 
 ## What are QWK and REP files?
 
@@ -29,10 +29,12 @@ Today, these files are valuable pieces of digital history. `pyqwk` helps you ope
 
 ## Quick Start
 
-Run the script on any QWK or REP archive:
+Run the script on any QWK, REP, JSON, or SQLite archive:
 ```bash
 python qwk.py archive.qwk
 python qwk.py replies.rep
+python qwk.py archive.json
+python qwk.py messages.db
 ```
 
 ## Installation
@@ -60,11 +62,15 @@ python -m pyqwk.gui
 
 ## Graphical Reader
 
-If you prefer a visual interface, you can use the built-in reader. It allows you to browse conferences, search for messages, and follow threaded conversations.
+If you prefer a visual interface, you can use the built-in reader. It allows you to browse conferences, search for messages, and follow threaded conversations. It supports all input formats (QWK, REP, JSON, and SQLite).
 
 **To start the reader:**
 ```bash
-qwk-gui [archive.qwk|replies.rep]
+# Open the reader and select a file from the menu
+qwk-gui
+
+# Or open a specific file immediately
+qwk-gui archive.qwk
 ```
 
 **Key Features:**

--- a/tests/test_coverage_gap_filler.py
+++ b/tests/test_coverage_gap_filler.py
@@ -6,10 +6,13 @@ from unittest.mock import MagicMock, patch, mock_open
 from pyqwk.cli import main
 from pyqwk.core import load_data, ProcessingSettings
 
-def test_cli_invalid_loglevel(monkeypatch):
+def test_cli_invalid_loglevel(monkeypatch, capsys):
     monkeypatch.setattr("sys.argv", ["qwk", "test.qwk", "--loglevel", "INVALID"])
-    with pytest.raises(ValueError, match="is not a valid log level"):
+    with pytest.raises(SystemExit) as excinfo:
         main()
+    assert excinfo.value.code == 2
+    captured = capsys.readouterr()
+    assert "invalid choice: 'INVALID'" in captured.err
 
 def test_load_data_sidecar_control_dat_corrupt(tmp_path, caplog):
     messages_path = tmp_path / "MESSAGES.DAT"


### PR DESCRIPTION
This Pull Request improves the project's documentation by ensuring it accurately reflects all supported input and output formats.

### Changes:
- **README.md**:
    - Updated the introduction to include `.JSON` and SQLite as supported input formats.
    - Included `Markdown` and `EML` in the list of modern output formats.
    - Added practical examples for processing JSON and SQLite archives to the "Quick Start" section.
    - Clarified that the `qwk-gui` command can be launched without arguments and supports all input formats.
- **tests/test_coverage_gap_filler.py**:
    - Fixed a test case (`test_cli_invalid_loglevel`) that was incorrectly asserting a `ValueError` for `argparse` validation. It now correctly expects a `SystemExit` and verifies the error message via `capsys`.

These changes make the tool more accessible to users who may be working with the tool's own exported formats or looking for specific modern exports like Markdown or EML.

---
*PR created automatically by Jules for task [3405490755843343669](https://jules.google.com/task/3405490755843343669) started by @RainRat*