### PR TITLE
[UI/UX] Provide default folder for individual file exports

### DIFF
--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -425,7 +425,11 @@ def main() -> None:
         resolved_output_path = None
     elif args.individualfiles:
         if output_path is None:
-            parser.error("You must provide an output folder when saving messages as individual files.")
+            if len(args.input_paths) == 1 and not has_directory_input:
+                output_path = os.path.splitext(os.path.basename(args.input_paths[0]))[0]
+                logger.info("No output path provided. Using default folder: %s/", output_path)
+            else:
+                parser.error("You must provide an output folder when saving messages as individual files.")
         if os.path.exists(output_path) and not os.path.isdir(output_path):
             parser.error("The output path must be a folder when saving messages as individual files.")
         output_mode = 'file'

--- a/tests/test_cli_coverage_extra.py
+++ b/tests/test_cli_coverage_extra.py
@@ -37,16 +37,31 @@ def test_individual_files_output_not_a_directory(monkeypatch, tmp_path, testdata
     stderr = capsys.readouterr().err
     assert "The output path must be a folder when saving messages as individual files." in stderr
 
-def test_individual_files_missing_output_path(monkeypatch, testdata_dir, capsys):
-    input_file = testdata_dir / "messages.dat"
-    # --individual-files but no -o
-    monkeypatch.setattr(sys, "argv", ["qwk", str(input_file), "--individual-files"])
+def test_individual_files_missing_output_path_multiple_inputs(monkeypatch, testdata_dir, capsys):
+    input1 = testdata_dir / "test1_qwk.zip"
+    input2 = testdata_dir / "test2_qwk.zip"
+    # --individual-files but no -o with multiple inputs should still error
+    monkeypatch.setattr(sys, "argv", ["qwk", str(input1), str(input2), "--individual-files"])
 
     with pytest.raises(SystemExit):
         main()
 
     stderr = capsys.readouterr().err
     assert "You must provide an output folder when saving messages as individual files." in stderr
+
+def test_individual_files_default_output_path(monkeypatch, testdata_dir, capsys):
+    input_file = testdata_dir / "test1_qwk.zip"
+    # --individual-files but no -o with single input should succeed and use default folder
+    monkeypatch.setattr(sys, "argv", ["qwk", str(input_file), "--individual-files", "--dry-run"])
+
+    # Mock process_merged_files to avoid actual dry run logic if needed,
+    # but here we just want to see if it reaches the processing stage without exiting
+    import pyqwk.cli as cli
+    with monkeypatch.context() as m:
+        m.setattr(cli, "process_merged_files", lambda *args: None)
+        main()
+
+    # Verify we didn't exit with error
 
 def test_multiple_inputs_without_output_directory(monkeypatch, testdata_dir, capsys):
     input1 = testdata_dir / "test1_qwk.zip"

--- a/tests/test_coverage_gap_filler.py
+++ b/tests/test_coverage_gap_filler.py
@@ -6,10 +6,12 @@ from unittest.mock import MagicMock, patch, mock_open
 from pyqwk.cli import main
 from pyqwk.core import load_data, ProcessingSettings
 
-def test_cli_invalid_loglevel(monkeypatch):
+def test_cli_invalid_loglevel(monkeypatch, capsys):
     monkeypatch.setattr("sys.argv", ["qwk", "test.qwk", "--loglevel", "INVALID"])
-    with pytest.raises(ValueError, match="is not a valid log level"):
+    with pytest.raises(SystemExit) as exc:
         main()
+    assert exc.value.code == 2
+    assert "invalid choice: 'INVALID'" in capsys.readouterr().err
 
 def test_load_data_sidecar_control_dat_corrupt(tmp_path, caplog):
     messages_path = tmp_path / "MESSAGES.DAT"


### PR DESCRIPTION
This improvement reduces friction in the CLI by providing a sensible default output folder when extracting individual files from a single archive. 

Previously, users were required to always provide an explicit `-o` path when using the `--individual-files` (`-i`) flag. Now, if exactly one archive is provided as input and no output path is specified, the tool will automatically create a folder named after the input archive (e.g., `my_archive.qwk` will export to `my_archive/`). This action is clearly communicated to the user via an informative log message.

The change also includes updates to the test suite to verify this new behavior and a fix for an existing test case that was incorrectly asserting a `ValueError` for invalid log levels instead of the standard `SystemExit` produced by `argparse`.

---
*PR created automatically by Jules for task [8760982158285215849](https://jules.google.com/task/8760982158285215849) started by @RainRat*