### PR TITLE
[FEAT] Symmetric CSV Import Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Today, these files are valuable pieces of digital history. `pyqwk` helps you ope
 
 ## Features
 
-- **Multiple Formats:** Export to Text, HTML, JSON, XML, Markdown, CSV, mbox, EML, or SQLite.
+- **Multiple Formats:** Export to Text, HTML, JSON, XML, Markdown, CSV, mbox, EML, or SQLite. Import from QWK, REP, JSON, CSV, or SQLite.
 - **Conversation Threading:** Group replies together to follow discussions easily.
 - **Content Cleaning:** Automatically remove signatures, old quotes, and attachments like images.
 - **Privacy:** Hide personal information and handle private messages.
@@ -64,7 +64,7 @@ If you prefer a visual interface, you can use the built-in reader. It allows you
 
 **To start the reader:**
 ```bash
-qwk-gui [archive.qwk|replies.rep]
+qwk-gui [archive.qwk|replies.rep|archive.csv]
 ```
 
 **Key Features:**
@@ -184,6 +184,11 @@ qwk archive.qwk --format sqlite -o messages.db
 **Export to a spreadsheet-friendly format (CSV):**
 ```bash
 qwk archive.qwk --format csv -o messages.csv
+```
+
+**Import from a CSV file (spreadsheet):**
+```bash
+qwk messages.csv -o updated.html
 ```
 
 *Note for Windows users: If you use symbols like `*` (wildcards) to select multiple files, use PowerShell instead of the standard Command Prompt.*

--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -27,7 +27,7 @@ def _expand_directories(paths: list[str]) -> list[str]:
             for root, _, files in os.walk(path):
                 for file in files:
                     lower_file = file.lower()
-                    if lower_file.endswith(('.qwk', '.zip', '.rep', '.json', '.db', '.sqlite')) or lower_file == 'messages.dat':
+                    if lower_file.endswith(('.qwk', '.zip', '.rep', '.json', '.csv', '.db', '.sqlite')) or lower_file == 'messages.dat':
                         expanded_paths.append(os.path.join(root, file))
         else:
             expanded_paths.append(path)
@@ -85,7 +85,7 @@ def main() -> None:
         'input_paths',
         help=(
             'The archives, message files, or folders you want to read. '
-            'Supported formats include QWK, REP, JSON, and SQLite. '
+            'Supported formats include QWK, REP, JSON, CSV, and SQLite. '
             'If you provide a path to a raw MESSAGES.DAT file, pyqwk will '
             'also look for an accompanying CONTROL.DAT in the same folder to '
             'automatically load conference names.'

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -806,6 +806,40 @@ def _parse_json_messages(data: list[dict[str, Any]]) -> list[ParsedMessage]:
     return messages
 
 
+def _parse_csv_messages(data: Iterator[dict[str, Any]]) -> list[ParsedMessage]:
+    """Convert CSV rows into ParsedMessage objects."""
+    messages = []
+    header_fields = {f.name for f in fields(MessageHeader)}
+
+    def to_int(v):
+        if v is None or v == "": return None
+        try: return int(v)
+        except (ValueError, TypeError): return None
+
+    for row in data:
+        header_dict = {k: v for k, v in row.items() if k in header_fields}
+        header = MessageHeader.from_dict(header_dict)
+
+        attachments = row.get('attachments', "").split(';') if row.get('attachments') else []
+
+        msg = ParsedMessage(
+            text=row.get('text', ""),
+            msgnum=header.msgnum,
+            refnum=header.refnum,
+            confnum=header.confnum,
+            header=header,
+            depth=to_int(row.get('depth', 0)),
+            thread_id=row.get('thread_id'),
+            parent_msgnum=to_int(row.get('parent_msgnum')),
+            confname=row.get('conference_name') or row.get('conference'),
+            bbs_name=row.get('bbs_name'),
+            source_file=row.get('source_file'),
+            attachments=attachments,
+        )
+        messages.append(msg)
+    return messages
+
+
 def load_data(
     input_path: str, logger: logging.Logger, encoding: str = 'cp437'
 ) -> tuple[bytearray | list[ParsedMessage], dict[int, str]]:
@@ -853,6 +887,23 @@ def load_data(
             if not isinstance(data, list):
                 raise ValueError("JSON archive must be a list of messages.")
             messages = _parse_json_messages(data)
+
+            # Reconstruct board_dict and bbs_info if possible
+            board_dict = ConferenceMap()
+            bbs_info = BBSInfo()
+            for msg in messages:
+                if msg.confnum is not None and msg.confname:
+                    board_dict[msg.confnum] = msg.confname
+                if msg.bbs_name:
+                    bbs_info.name = msg.bbs_name
+
+            board_dict.bbs_info = bbs_info
+            return messages, board_dict
+
+    if input_path.lower().endswith('.csv'):
+        with open(input_path, 'r', encoding='utf-8') as f:
+            reader = csv.DictReader(f)
+            messages = _parse_csv_messages(reader)
 
             # Reconstruct board_dict and bbs_info if possible
             board_dict = ConferenceMap()

--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -475,8 +475,12 @@ class QwkGuiApp:
 
     def open_file(self, _event: object | None = None) -> None:
         filetypes = [
+            ("All supported formats", "*.qwk *.rep *.json *.csv *.db *.sqlite"),
             ("QWK archives", "*.qwk"),
+            ("REP archives", "*.rep"),
             ("JSON archives", "*.json"),
+            ("CSV archives", "*.csv"),
+            ("SQLite databases", "*.db *.sqlite"),
             ("messages.dat", "messages.dat"),
             ("All files", "*.*"),
         ]

--- a/tests/test_coverage_gap_filler.py
+++ b/tests/test_coverage_gap_filler.py
@@ -6,10 +6,13 @@ from unittest.mock import MagicMock, patch, mock_open
 from pyqwk.cli import main
 from pyqwk.core import load_data, ProcessingSettings
 
-def test_cli_invalid_loglevel(monkeypatch):
+def test_cli_invalid_loglevel(monkeypatch, capsys):
     monkeypatch.setattr("sys.argv", ["qwk", "test.qwk", "--loglevel", "INVALID"])
-    with pytest.raises(ValueError, match="is not a valid log level"):
+    with pytest.raises(SystemExit) as cm:
         main()
+    assert cm.value.code == 2
+    captured = capsys.readouterr()
+    assert "invalid choice: 'INVALID'" in captured.err
 
 def test_load_data_sidecar_control_dat_corrupt(tmp_path, caplog):
     messages_path = tmp_path / "MESSAGES.DAT"

--- a/tests/test_csv_import.py
+++ b/tests/test_csv_import.py
@@ -1,0 +1,104 @@
+import os
+import csv
+import logging
+import pytest
+from pyqwk.core import (
+    ProcessingSettings,
+    write_messages,
+    load_data,
+)
+
+def test_csv_export_import_symmetry(tmp_path, message_factory):
+    """Test that messages exported to CSV can be read back with metadata intact."""
+    csv_path = tmp_path / "test_messages.csv"
+
+    # 1. Create sample messages
+    msg1 = message_factory(
+        confnum=1,
+        msgnum=101,
+        refnum=None,
+        subject="Test Subject 1",
+        text="Hello Bob, this is a test.",
+    )
+    msg1.header.msgfrom = "Alice"
+    msg1.header.msgto = "Bob"
+    msg1.confname = "General"
+
+    msg2 = message_factory(
+        confnum=2,
+        msgnum=202,
+        refnum=101,
+        subject="Re: Test Subject 1",
+        text="Hello Alice, I received your test.",
+    )
+    msg2.header.msgfrom = "Bob"
+    msg2.header.msgto = "Alice"
+    msg2.confname = "Support"
+    msg2.depth = 1
+    msg2.parent_msgnum = 101
+    msg2.attachments = ["image.png", "data.zip"]
+
+    messages = [msg1, msg2]
+
+    # 2. Export to CSV
+    settings = ProcessingSettings(
+        verbose=True,
+        private=True,
+        no_header=False,
+        truncate_signatures=False,
+        cut_quoting=False,
+        individual_files=False,
+        threaded=False,
+        binaries_removal=False,
+        redact_pii=False,
+        format='csv',
+        separator='none',
+        output_mode='file',
+        output_path=str(csv_path),
+        encoding='utf-8'
+    )
+
+    write_messages(messages, str(csv_path), settings)
+    assert os.path.exists(csv_path)
+
+    # 3. Import from CSV
+    logger = logging.getLogger("test")
+    imported_messages, board_dict = load_data(str(csv_path), logger)
+
+    # 4. Verify data integrity
+    assert len(imported_messages) == 2
+
+    # Check first message
+    m1 = imported_messages[0]
+    assert m1.confnum == 1
+    assert m1.msgnum == 101
+    assert m1.header.msgfrom == "Alice"
+    assert m1.header.msgsubject == "Test Subject 1"
+    assert m1.text == "Hello Bob, this is a test."
+    assert board_dict[1] == "General"
+
+    # Check second message (with hierarchy and attachments)
+    m2 = imported_messages[1]
+    assert m2.confnum == 2
+    assert m2.msgnum == 202
+    assert m2.depth == 1
+    assert m2.parent_msgnum == 101
+    assert m2.attachments == ["image.png", "data.zip"]
+    assert board_dict[2] == "Support"
+
+def test_csv_import_malformed(tmp_path):
+    """Test handling of empty or missing CSV fields."""
+    csv_path = tmp_path / "malformed.csv"
+
+    with open(csv_path, 'w', encoding='utf-8', newline='') as f:
+        writer = csv.DictWriter(f, fieldnames=['confnum', 'msgfrom', 'text'])
+        writer.writeheader()
+        writer.writerow({'confnum': '10', 'msgfrom': 'System', 'text': 'Body'})
+
+    logger = logging.getLogger("test")
+    imported, board = load_data(str(csv_path), logger)
+
+    assert len(imported) == 1
+    assert imported[0].confnum == 10
+    assert imported[0].header.msgfrom == "System"
+    assert imported[0].text == "Body"


### PR DESCRIPTION
This PR implements CSV import functionality, completing the symmetry with the existing CSV export feature.

Key changes:
- **Core:** Added `_parse_csv_messages` which maps CSV columns (including metadata like conference names and attachments) back to internal `ParsedMessage` objects. `load_data` now automatically detects and parses `.csv` files.
- **CLI:** Users can now pass `.csv` files as input. The help text and directory expansion logic have been updated accordingly.
- **GUI:** The "Open" archive dialog now includes CSV files, as well as previously supported but missing REP and SQLite extensions.
- **Documentation:** `README.md` now includes a dedicated "Import from a CSV file" example.
- **Tests:** A new test file `tests/test_csv_import.py` verifies that archives can be exported to CSV and imported back without loss of metadata or structure.

Additionally, a fix was applied to `tests/test_coverage_gap_filler.py` to accommodate the CLI's switch to `argparse` choices for log level validation.

---
*PR created automatically by Jules for task [10770814630712834895](https://jules.google.com/task/10770814630712834895) started by @RainRat*