### PR TITLE
[UI/UX] Aligned Threaded One-Line Summaries

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -635,9 +635,12 @@ class MessageHeader:
         highlight_term: str | None = None,
         is_regex: bool = False,
         verbose: bool = False,
+        depth: int = 0,
+        conf_name: str | None = None,
     ) -> str:
         """Render a message header as a single line summary."""
-        conf_name = board_dict.get(self.confnum, str(self.confnum))
+        if conf_name is None:
+            conf_name = board_dict.get(self.confnum, str(self.confnum))
         date_str = f"{self.msgdate} {self.msgtime}"
         from_name = self.msgfrom.strip()
         to_name = self.msgto.strip()
@@ -653,6 +656,11 @@ class MessageHeader:
         conf_part = prepare_field(conf_name, 12)
         from_part = prepare_field(from_name, 15)
         to_part = prepare_field(to_name, 15)
+
+        # Apply threading indent to subject
+        if depth > 0:
+            indent = "  " * (depth - 1)
+            subject = f"{indent}└ {subject}"
         subject_part = _highlight_text(subject, highlight_term, is_regex, use_colors)
 
         msgnum_part = ""
@@ -1601,6 +1609,8 @@ def process_merged_files(
                 highlight_term=settings.search_term,
                 is_regex=settings.regex,
                 verbose=settings.verbose,
+                depth=parsed_message.depth,
+                conf_name=parsed_message.confname,
             )
         else:
             processed_buffer = cleaned_body
@@ -2513,7 +2523,8 @@ def _write_text(
 
     for message in messages:
         text = message.text
-        if message.depth > 0:
+        # Apply indentation only if NOT in oneline mode (oneline mode handles depth internally)
+        if message.depth > 0 and not (settings and settings.oneline):
             indent = "  " * message.depth
             lines = text.splitlines(keepends=True)
             indented_lines = [indent + line for line in lines]


### PR DESCRIPTION
The CLI one-line summary (`--oneline`) has been improved to handle conversation threading more gracefully. 

Previously, if `--threaded` was used with `--oneline`, the entire line was indented for replies, causing all columns (Conference, Date, From, To) to shift and break vertical alignment. 

This change modifies `MessageHeader.format_oneline` to accept a `depth` parameter and handle indentation internally within the subject field. It also updates `_write_text` to prevent double-indentation.

**Changes:**
- `pyqwk/core.py`: Updated `MessageHeader.format_oneline` to indent only the subject and add a `└` indicator when `depth > 0`.
- `pyqwk/core.py`: Updated `process_merged_files` to pass `depth` and `conf_name` to `format_oneline`.
- `pyqwk/core.py`: Updated `_write_text` to skip whole-line indentation if `oneline` mode is active.
- `tests/test_oneline.py`: Updated tests to match the new signature and behavior.
- `tests/test_ui_oneline_alignment.py`: Updated tests to verify alignment and thread indicators.

---
*PR created automatically by Jules for task [9003502072355381043](https://jules.google.com/task/9003502072355381043) started by @RainRat*