### PR TITLE
[FEAT] Add XML Archive Import support

### DIFF
--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -27,7 +27,7 @@ def _expand_directories(paths: list[str]) -> list[str]:
             for root, _, files in os.walk(path):
                 for file in files:
                     lower_file = file.lower()
-                    if lower_file.endswith(('.qwk', '.zip', '.rep', '.json', '.csv', '.db', '.sqlite')) or lower_file == 'messages.dat':
+                    if lower_file.endswith(('.qwk', '.zip', '.rep', '.json', '.csv', '.db', '.sqlite', '.xml')) or lower_file == 'messages.dat':
                         expanded_paths.append(os.path.join(root, file))
         else:
             expanded_paths.append(path)

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -530,18 +530,12 @@ class MessageHeader:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> "MessageHeader":
         """Reconstruct a MessageHeader from a dictionary."""
-        # Convert numeric fields that might be strings
-        def to_int(v):
-            if v is None or v == "": return None
-            try: return int(v)
-            except (ValueError, TypeError): return None
-
         kwargs = {}
         for field_info in fields(cls):
             name = field_info.name
             val = data.get(name)
             if name in ('msgnum', 'refnum', 'numblocks', 'confnum', 'lognum'):
-                kwargs[name] = to_int(val)
+                kwargs[name] = _safe_to_int(val)
             else:
                 kwargs[name] = val if val is not None else ""
 
@@ -806,15 +800,64 @@ def _parse_json_messages(data: list[dict[str, Any]]) -> list[ParsedMessage]:
     return messages
 
 
+def _safe_to_int(v: Any) -> int | None:
+    """Safely convert a value to an integer, returning None on failure."""
+    if v is None or v == "":
+        return None
+    try:
+        return int(v)
+    except (ValueError, TypeError):
+        return None
+
+
+def _parse_xml_messages(root: ET.Element) -> list[ParsedMessage]:
+    """Convert an XML tree into ParsedMessage objects."""
+    messages = []
+    header_fields = {f.name for f in fields(MessageHeader)}
+
+    for entry in root.findall('message'):
+        header_el = entry.find('header')
+        header_dict = {}
+        if header_el is not None:
+            for field_el in header_el:
+                if field_el.tag in header_fields:
+                    header_dict[field_el.tag] = field_el.text
+
+        header = MessageHeader.from_dict(header_dict)
+
+        attachments_el = entry.find('attachments')
+        attachments = []
+        if attachments_el is not None:
+            for attach_el in attachments_el.findall('attachment'):
+                if attach_el.text:
+                    attachments.append(attach_el.text)
+
+        def get_text(tag):
+            el = entry.find(tag)
+            return el.text if el is not None and el.text is not None else ""
+
+        msg = ParsedMessage(
+            text=get_text('text'),
+            msgnum=header.msgnum,
+            refnum=header.refnum,
+            confnum=header.confnum,
+            header=header,
+            depth=_safe_to_int(get_text('depth') or 0) or 0,
+            thread_id=get_text('thread_id') or None,
+            parent_msgnum=_safe_to_int(get_text('parent_msgnum')),
+            confname=get_text('conference_name') or get_text('conference'),
+            bbs_name=get_text('bbs_name'),
+            source_file=get_text('source_file'),
+            attachments=attachments or None,
+        )
+        messages.append(msg)
+    return messages
+
+
 def _parse_csv_messages(data: Iterator[dict[str, Any]]) -> list[ParsedMessage]:
     """Convert CSV rows into ParsedMessage objects."""
     messages = []
     header_fields = {f.name for f in fields(MessageHeader)}
-
-    def to_int(v):
-        if v is None or v == "": return None
-        try: return int(v)
-        except (ValueError, TypeError): return None
 
     for row in data:
         header_dict = {k: v for k, v in row.items() if k in header_fields}
@@ -828,9 +871,9 @@ def _parse_csv_messages(data: Iterator[dict[str, Any]]) -> list[ParsedMessage]:
             refnum=header.refnum,
             confnum=header.confnum,
             header=header,
-            depth=to_int(row.get('depth', 0)),
+            depth=_safe_to_int(row.get('depth', 0)) or 0,
             thread_id=row.get('thread_id'),
-            parent_msgnum=to_int(row.get('parent_msgnum')),
+            parent_msgnum=_safe_to_int(row.get('parent_msgnum')),
             confname=row.get('conference_name') or row.get('conference'),
             bbs_name=row.get('bbs_name'),
             source_file=row.get('source_file'),
@@ -899,6 +942,26 @@ def load_data(
 
             board_dict.bbs_info = bbs_info
             return messages, board_dict
+
+    if input_path.lower().endswith('.xml'):
+        try:
+            tree = ET.parse(input_path)
+            root = tree.getroot()
+            messages = _parse_xml_messages(root)
+        except Exception as e:
+            raise ValueError(f"Failed to load XML archive: {e}")
+
+        # Reconstruct board_dict and bbs_info if possible
+        board_dict = ConferenceMap()
+        bbs_info = BBSInfo()
+        for msg in messages:
+            if msg.confnum is not None and msg.confname:
+                board_dict[msg.confnum] = msg.confname
+            if msg.bbs_name:
+                bbs_info.name = msg.bbs_name
+
+        board_dict.bbs_info = bbs_info
+        return messages, board_dict
 
     if input_path.lower().endswith('.csv'):
         with open(input_path, 'r', encoding='utf-8') as f:

--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -475,12 +475,13 @@ class QwkGuiApp:
 
     def open_file(self, _event: object | None = None) -> None:
         filetypes = [
-            ("All supported formats", "*.qwk *.rep *.json *.csv *.db *.sqlite"),
+            ("All supported formats", "*.qwk *.rep *.json *.csv *.db *.sqlite *.xml"),
             ("QWK archives", "*.qwk"),
             ("REP archives", "*.rep"),
             ("JSON archives", "*.json"),
             ("CSV archives", "*.csv"),
             ("SQLite databases", "*.db *.sqlite"),
+            ("XML archives", "*.xml"),
             ("messages.dat", "messages.dat"),
             ("All files", "*.*"),
         ]

--- a/tests/test_xml_import.py
+++ b/tests/test_xml_import.py
@@ -1,0 +1,141 @@
+import xml.etree.ElementTree as ET
+import logging
+from pathlib import Path
+import pytest
+from pyqwk.core import (
+    load_data,
+    process_file,
+    ProcessingSettings,
+    ParsedMessage,
+    MessageHeader
+)
+
+@pytest.fixture
+def baseline_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "testdata" / "messages.dat"
+
+@pytest.fixture
+def logger():
+    logger = logging.getLogger("pyqwk.tests")
+    logger.addHandler(logging.NullHandler())
+    return logger
+
+def _make_settings(**overrides):
+    defaults = dict(
+        verbose=False,
+        private=True,
+        no_header=False,
+        truncate_signatures=False,
+        cut_quoting=False,
+        individual_files=False,
+        threaded=False,
+        binaries_removal=False,
+        redact_pii=False,
+        format="text",
+        separator="auto",
+        output_mode="stdout",
+        output_path=None,
+        encoding="latin1",
+        quiet=True,
+    )
+    defaults.update(overrides)
+    return ProcessingSettings(**defaults)
+
+def test_xml_export_reimport_symmetry(tmp_path, baseline_path, logger):
+    """Test that messages exported to XML can be re-imported and processed."""
+    # 1. Export baseline to XML
+    xml_path = tmp_path / "archive.xml"
+    settings_export = _make_settings(
+        format="xml",
+        output_mode="file",
+        output_path=str(xml_path)
+    )
+    process_file(str(baseline_path), settings_export, logger)
+
+    assert xml_path.exists()
+
+    # 2. Re-import from XML
+    messages, board_dict = load_data(str(xml_path), logger)
+
+    assert isinstance(messages, list)
+    assert len(messages) > 0
+    assert isinstance(messages[0], ParsedMessage)
+
+    # Check that header data was preserved
+    # The first message in baseline is msgnum 28
+    assert messages[0].msgnum == 28
+    assert messages[0].header.msgnum == 28
+    assert messages[0].header.msgfrom.strip() == "GammaO #571 @0*1"
+
+    # 3. Process re-imported data (e.g., convert to HTML)
+    html_path = tmp_path / "archive.html"
+    settings_html = _make_settings(
+        format="html",
+        output_mode="file",
+        output_path=str(html_path)
+    )
+
+    # We can use process_file on the xml path directly now
+    process_file(str(xml_path), settings_html, logger)
+
+    assert html_path.exists()
+    html_content = html_path.read_text(encoding="utf-8")
+    assert "GammaO #571 @0*1" in html_content
+    assert "New User" in html_content # Subject
+
+def test_xml_import_with_missing_fields(tmp_path, logger):
+    """Test XML import handles missing or malformed fields gracefully."""
+    root = ET.Element("messages")
+    msg_el = ET.SubElement(root, "message")
+
+    header_el = ET.SubElement(msg_el, "header")
+    ET.SubElement(header_el, "msgfrom").text = "Test User"
+    ET.SubElement(header_el, "confnum").text = "100"
+
+    ET.SubElement(msg_el, "text").text = "Hello world"
+    ET.SubElement(msg_el, "conference_name").text = "Test Conf"
+
+    xml_path = tmp_path / "partial.xml"
+    ET.ElementTree(root).write(xml_path, encoding="utf-8", xml_declaration=True)
+
+    messages, board_dict = load_data(str(xml_path), logger)
+
+    assert len(messages) == 1
+    assert messages[0].header.msgfrom == "Test User"
+    assert messages[0].confnum == 100
+    assert messages[0].text == "Hello world"
+    assert 100 in board_dict
+    assert board_dict[100] == "Test Conf"
+
+def test_xml_import_with_threading_metadata(tmp_path, logger):
+    """Test XML import preserves threading metadata."""
+    root = ET.Element("messages")
+    msg_el = ET.SubElement(root, "message")
+
+    header_el = ET.SubElement(msg_el, "header")
+    ET.SubElement(header_el, "msgsubject").text = "Re: Test"
+    ET.SubElement(header_el, "confnum").text = "1"
+
+    ET.SubElement(msg_el, "depth").text = "2"
+    ET.SubElement(msg_el, "thread_id").text = "42"
+    ET.SubElement(msg_el, "parent_msgnum").text = "10"
+    ET.SubElement(msg_el, "text").text = "Reply content"
+
+    xml_path = tmp_path / "threaded.xml"
+    ET.ElementTree(root).write(xml_path, encoding="utf-8", xml_declaration=True)
+
+    messages, board_dict = load_data(str(xml_path), logger)
+
+    assert len(messages) == 1
+    assert messages[0].depth == 2
+    assert messages[0].thread_id == "42"
+    assert messages[0].parent_msgnum == 10
+    assert messages[0].text == "Reply content"
+
+def test_xml_import_invalid_xml(tmp_path, logger):
+    """Test that load_data raises ValueError for malformed XML."""
+    xml_path = tmp_path / "broken.xml"
+    xml_path.write_text("<messages><message>unclosed", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Failed to load XML archive"):
+        load_data(str(xml_path), logger)


### PR DESCRIPTION
This pull request adds support for importing message archives from XML files, providing symmetry with the existing XML export functionality. 

Key changes:
- **Core logic:** Implemented `_parse_xml_messages` and integrated it into `load_data`. The importer correctly reconstructs `ParsedMessage` objects along with their headers, threading metadata, and conference information.
- **CLI/GUI Integration:** XML files are now automatically discovered when processing directories and can be opened through the Graphical Reader's file dialog.
- **Maintenance:** Common integer parsing logic was refactored into a module-level helper to improve consistency across structured importers.
- **Testing:** Added `tests/test_xml_import.py` covering round-trip symmetry, partial data handling, and error scenarios. All 486 tests in the suite pass.

---
*PR created automatically by Jules for task [16397317612921909049](https://jules.google.com/task/16397317612921909049) started by @RainRat*