### PR TITLE
Fix syntax error in _reconstruct_metadata function

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -893,7 +893,7 @@ def _parse_csv_messages(data: Iterator[dict[str, Any]]) -> list[ParsedMessage]:
     return messages
 
 
-<def _reconstruct_metadata(messages: list[ParsedMessage]) -> ConferenceMap:
+def _reconstruct_metadata(messages: list[ParsedMessage]) -> ConferenceMap:
     """Reconstruct board_dict and bbs_info from a list of messages."""
     board_dict = ConferenceMap()
     bbs_info = BBSInfo()


### PR DESCRIPTION
* **What:** Removed a stray `<` character preceding the `def` keyword for the `_reconstruct_metadata` function in `pyqwk/core.py`.
* **Why:** This syntax error prevented the `pyqwk.core` module from being imported, causing a `SyntaxError` and making the entire package unusable. Fixing it restores the module to a valid state. No breaking changes were introduced.

---
*PR created automatically by Jules for task [13968826560975439003](https://jules.google.com/task/13968826560975439003) started by @RainRat*