### PR TITLE
[UI/UX] Improve CLI informational workflow consistency

### DIFF
--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -420,7 +420,7 @@ def main() -> None:
     if args.organize_by_bbs:
         output_mode = 'file'
         resolved_output_path = None
-    elif args.info:
+    elif args.info or args.stats:
         output_mode = 'stdout'
         resolved_output_path = None
     elif args.individualfiles:

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -893,7 +893,7 @@ def _parse_csv_messages(data: Iterator[dict[str, Any]]) -> list[ParsedMessage]:
     return messages
 
 
-<def _reconstruct_metadata(messages: list[ParsedMessage]) -> ConferenceMap:
+def _reconstruct_metadata(messages: list[ParsedMessage]) -> ConferenceMap:
     """Reconstruct board_dict and bbs_info from a list of messages."""
     board_dict = ConferenceMap()
     bbs_info = BBSInfo()

--- a/tests/test_cli_stats_multi.py
+++ b/tests/test_cli_stats_multi.py
@@ -1,0 +1,43 @@
+import pytest
+import sys
+import os
+from pyqwk.cli import main
+
+def test_stats_multiple_files_no_output(monkeypatch, capsys):
+    """Test that --stats works with multiple files without requiring -o."""
+    # testdata/test1_qwk.zip and testdata/test2_qwk.zip exist
+    test1 = "testdata/test1_qwk.zip"
+    test2 = "testdata/test2_qwk.zip"
+
+    # Simulate: qwk.py testdata/test1_qwk.zip testdata/test2_qwk.zip --stats
+    monkeypatch.setattr(sys, "argv", ["qwk.py", test1, test2, "--stats", "--quiet"])
+
+    # Should not raise SystemExit(2) from argparse.error
+    try:
+        main()
+    except SystemExit as e:
+        if e.code != 0:
+            pytest.fail(f"main() exited with code {e.code}")
+
+    captured = capsys.readouterr()
+    assert "Statistics for: testdata/test1_qwk.zip" in captured.out
+    assert "Statistics for: testdata/test2_qwk.zip" in captured.out
+    assert "Messages: 1 matching / 1 total" in captured.out
+    assert "Messages: 2 matching / 2 total" in captured.out
+
+def test_info_multiple_files_no_output(monkeypatch, capsys):
+    """Test that --info already works with multiple files without requiring -o (baseline)."""
+    test1 = "testdata/test1_qwk.zip"
+    test2 = "testdata/test2_qwk.zip"
+
+    monkeypatch.setattr(sys, "argv", ["qwk.py", test1, test2, "--info", "--quiet"])
+
+    try:
+        main()
+    except SystemExit as e:
+        if e.code != 0:
+            pytest.fail(f"main() exited with code {e.code}")
+
+    captured = capsys.readouterr()
+    assert "File: testdata/test1_qwk.zip" in captured.out
+    assert "File: testdata/test2_qwk.zip" in captured.out


### PR DESCRIPTION
Improved usability and consistency of informational CLI commands. Previously, using `--stats` on multiple files would error out unless an output directory was provided, even though the command only outputs to standard output. This has been rectified to mirror the `--info` command's behavior. Additionally, a stray syntax error in the core library was corrected.

---
*PR created automatically by Jules for task [17333498421759846503](https://jules.google.com/task/17333498421759846503) started by @RainRat*