### PR TITLE
[FEAT] Add "Go to Message" functionality to Graphical Reader

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -893,7 +893,7 @@ def _parse_csv_messages(data: Iterator[dict[str, Any]]) -> list[ParsedMessage]:
     return messages
 
 
-<def _reconstruct_metadata(messages: list[ParsedMessage]) -> ConferenceMap:
+def _reconstruct_metadata(messages: list[ParsedMessage]) -> ConferenceMap:
     """Reconstruct board_dict and bbs_info from a list of messages."""
     board_dict = ConferenceMap()
     bbs_info = BBSInfo()

--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -3,7 +3,7 @@ import logging
 import os
 import tkinter as tk
 from dataclasses import replace
-from tkinter import filedialog, messagebox, ttk
+from tkinter import filedialog, messagebox, ttk, simpledialog
 
 from pyqwk.core import (
     ProcessingSettings,
@@ -88,6 +88,11 @@ class QwkGuiApp:
             accelerator="Ctrl+F",
         )
         edit_menu.add_command(
+            label="Go to Message...",
+            command=self.prompt_jump_to_message,
+            accelerator="Ctrl+G",
+        )
+        edit_menu.add_command(
             label="Clear Search", command=self.clear_search, accelerator="Esc"
         )
         menubar.add_cascade(label="Edit", menu=edit_menu)
@@ -97,6 +102,7 @@ class QwkGuiApp:
         # Bind keyboard shortcuts
         self.root.bind("<Control-o>", self.open_file)
         self.root.bind("<Control-s>", self.export_messages)
+        self.root.bind("<Control-g>", self.prompt_jump_to_message)
         self.root.bind("<Control-q>", self.quit_app)
         self.root.bind("<Escape>", self.clear_search)
         self.root.bind("j", lambda e: self._select_relative_message(1))
@@ -796,16 +802,55 @@ class QwkGuiApp:
         except Exception as exc:
             messagebox.showerror("Export Failed", str(exc))
 
+    def prompt_jump_to_message(self, _event: object | None = None) -> None:
+        """Prompt the user for a message number and jump to it."""
+        if not self.messages:
+            return
+
+        msgnum = simpledialog.askinteger("Jump to Message", "Enter message number:")
+        if msgnum is None:
+            return
+
+        # Try to find it in the current conference first if something is selected
+        current_conf = None
+        current_selection = self.message_list.selection()
+        if current_selection:
+            try:
+                idx = int(current_selection[0])
+                current_conf = self.messages[idx].header.confnum
+            except (ValueError, IndexError):
+                pass
+
+        if current_conf is not None:
+            for i, m in enumerate(self.messages):
+                if m.header.msgnum == msgnum and m.header.confnum == current_conf:
+                    self._select_by_index(i)
+                    return
+
+        # Otherwise just find the first match
+        for i, m in enumerate(self.messages):
+            if m.header.msgnum == msgnum:
+                self._select_by_index(i)
+                return
+
+        messagebox.showinfo(
+            "Not Found", f"Message #{msgnum} was not found in the current view."
+        )
+
+    def _select_by_index(self, index: int) -> None:
+        """Select a message by its index in the current message list."""
+        iid = str(index)
+        if self.message_list.exists(iid):
+            self.message_list.selection_set(iid)
+            self.message_list.see(iid)
+            self.message_list.focus(iid)
+
     def jump_to_message(self, confnum: int, msgnum: int) -> None:
         """Find and select a message by conference and message number."""
         for i, m in enumerate(self.messages):
             if m.header.confnum == confnum and m.header.msgnum == msgnum:
-                iid = str(i)
-                if self.message_list.exists(iid):
-                    self.message_list.selection_set(iid)
-                    self.message_list.see(iid)
-                    self.message_list.focus(iid)
-                    return
+                self._select_by_index(i)
+                return
         messagebox.showinfo(
             "Not Found",
             f"Referenced message #{msgnum} was not found in the current view.",

--- a/tests/test_gui_jump_to_message.py
+++ b/tests/test_gui_jump_to_message.py
@@ -1,0 +1,96 @@
+import sys
+from unittest.mock import MagicMock, patch
+import pytest
+
+# Mock tkinter before any pyqwk.gui imports
+mock_tk = MagicMock()
+mock_ttk = MagicMock()
+sys.modules["tkinter"] = mock_tk
+sys.modules["tkinter.filedialog"] = MagicMock()
+sys.modules["tkinter.messagebox"] = MagicMock()
+sys.modules["tkinter.ttk"] = mock_ttk
+sys.modules["tkinter.simpledialog"] = MagicMock()
+
+from pyqwk.gui import QwkGuiApp
+from pyqwk.core import ParsedMessage, MessageHeader
+
+@pytest.fixture
+def app_with_messages():
+    root = MagicMock()
+    with patch("pyqwk.gui.tk"), patch("pyqwk.gui.ttk"), patch("pyqwk.gui.simpledialog"):
+        app = QwkGuiApp(root)
+
+        # Create some dummy messages
+        h1 = MessageHeader(" ", 101, "01-01-23", "12:00", "To1", "From1", "Subj1", "", None, 1, " ", 1, 1, "")
+        h2 = MessageHeader(" ", 102, "01-01-23", "12:05", "To2", "From2", "Subj2", "", None, 1, " ", 1, 1, "")
+        h3 = MessageHeader(" ", 103, "01-01-23", "12:10", "To3", "From3", "Subj3", "", None, 1, " ", 2, 1, "")
+
+        app.messages = [
+            ParsedMessage("Text 1", 101, None, 1, h1),
+            ParsedMessage("Text 2", 102, None, 1, h2),
+            ParsedMessage("Text 3", 103, None, 2, h3),
+        ]
+
+        # Mock message_list behavior
+        app.message_list.exists.return_value = True
+
+        return app
+
+def test_prompt_jump_to_message_success(app_with_messages):
+    app = app_with_messages
+
+    with patch("pyqwk.gui.simpledialog.askinteger", return_value=102):
+        app.prompt_jump_to_message()
+
+    # Should select message with index 1 (msgnum 102)
+    app.message_list.selection_set.assert_called_with("1")
+    app.message_list.see.assert_called_with("1")
+
+def test_prompt_jump_to_message_not_found(app_with_messages):
+    app = app_with_messages
+
+    with patch("pyqwk.gui.simpledialog.askinteger", return_value=999), \
+         patch("pyqwk.gui.messagebox.showinfo") as mock_info:
+        app.prompt_jump_to_message()
+
+    mock_info.assert_called_once()
+    assert "999" in mock_info.call_args[0][1]
+
+def test_prompt_jump_to_message_cancel(app_with_messages):
+    app = app_with_messages
+
+    with patch("pyqwk.gui.simpledialog.askinteger", return_value=None):
+        app.prompt_jump_to_message()
+
+    app.message_list.selection_set.assert_not_called()
+
+def test_prompt_jump_to_message_prefer_current_conf(app_with_messages):
+    app = app_with_messages
+
+    # Add another message with same msgnum but different conf
+    h4 = MessageHeader(" ", 102, "01-01-23", "12:15", "To4", "From4", "Subj4", "", None, 1, " ", 2, 1, "")
+    app.messages.append(ParsedMessage("Text 4", 102, None, 2, h4))
+
+    # Set current selection to a message in conf 2 (index 2)
+    app.message_list.selection.return_value = ["2"]
+
+    with patch("pyqwk.gui.simpledialog.askinteger", return_value=102):
+        app.prompt_jump_to_message()
+
+    # Should prefer message 102 in conf 2 (which is index 3)
+    app.message_list.selection_set.assert_called_with("3")
+
+def test_jump_to_message_explicit(app_with_messages):
+    app = app_with_messages
+
+    app.jump_to_message(2, 103)
+    app.message_list.selection_set.assert_called_with("2")
+
+def test_jump_to_message_explicit_not_found(app_with_messages):
+    app = app_with_messages
+
+    with patch("pyqwk.gui.messagebox.showinfo") as mock_info:
+        app.jump_to_message(1, 999)
+
+    mock_info.assert_called_once()
+    assert "999" in mock_info.call_args[0][1]


### PR DESCRIPTION
This PR introduces a highly useful "Go to Message" feature to the PyQWK Graphical Reader, allowing users to quickly jump to a specific message number. 

### Features:
- **Menu and Shortcut:** Added "Go to Message..." to the Edit menu and bound it to `Ctrl+G`.
- **Smart Search:** The search prioritizes finding the message number within the currently selected conference, falling back to a global search if no match is found in the current conference.
- **Refactoring:** Improved internal selection logic by introducing the `_select_by_index` helper.
- **Bug Fix:** Corrected a syntax error in `pyqwk/core.py` discovered during development.

### Testing:
- Added a new test suite `tests/test_gui_jump_to_message.py` which mocks Tkinter components to verify:
    - Successful navigation to a message number.
    - Graceful handling of non-existent message numbers.
    - Proper handling of the "Cancel" action in the prompt.
    - Correct conference-level prioritization when multiple matches exist.
- Verified that the full existing test suite (502 tests) passes.

---
*PR created automatically by Jules for task [7742402897247261867](https://jules.google.com/task/7742402897247261867) started by @RainRat*