### PR TITLE
[UI/UX] Default to stdout merge for multiple CLI inputs

### DIFF
--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -439,9 +439,13 @@ def main() -> None:
         resolved_output_path = output_path
     elif len(input_paths) > 1 or has_directory_input:
         if not output_path:
-            parser.error("You must provide an output folder when processing more than one file.")
-        output_mode = 'file'
-        resolved_output_path = output_path
+            args.merge = True
+            output_mode = 'stdout'
+            resolved_output_path = None
+            logger.info("Multiple archives provided without an output path. Merging results to the screen.")
+        else:
+            output_mode = 'file'
+            resolved_output_path = output_path
     else:
         output_mode = 'stdout' if not output_path else 'file'
         resolved_output_path = output_path

--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -434,18 +434,15 @@ def main() -> None:
             parser.error("The output path must be a folder when saving messages as individual files.")
         output_mode = 'file'
         resolved_output_path = output_path
-    elif args.merge:
+    elif args.merge or (not output_path and (len(input_paths) > 1 or has_directory_input)):
+        if not args.merge:
+            args.merge = True
+            logger.info("Multiple archives provided without an output path. Merging results to the screen.")
         output_mode = 'stdout' if not output_path else 'file'
         resolved_output_path = output_path
     elif len(input_paths) > 1 or has_directory_input:
-        if not output_path:
-            args.merge = True
-            output_mode = 'stdout'
-            resolved_output_path = None
-            logger.info("Multiple archives provided without an output path. Merging results to the screen.")
-        else:
-            output_mode = 'file'
-            resolved_output_path = output_path
+        output_mode = 'file'
+        resolved_output_path = output_path
     else:
         output_mode = 'stdout' if not output_path else 'file'
         resolved_output_path = output_path

--- a/tests/test_cli_coverage_extra.py
+++ b/tests/test_cli_coverage_extra.py
@@ -3,6 +3,7 @@ import os
 import pytest
 import logging
 from pathlib import Path
+from unittest.mock import MagicMock
 from pyqwk.cli import main
 
 @pytest.fixture
@@ -67,14 +68,20 @@ def test_multiple_inputs_without_output_directory(monkeypatch, testdata_dir, cap
     input1 = testdata_dir / "test1_qwk.zip"
     input2 = testdata_dir / "test2_qwk.zip"
 
-    # Missing -o option
+    # Missing -o option should now default to merging to stdout
     monkeypatch.setattr(sys, "argv", ["qwk", str(input1), str(input2)])
 
-    with pytest.raises(SystemExit):
+    import pyqwk.cli as cli
+    with monkeypatch.context() as m:
+        # Mock process_merged_files to avoid actual processing
+        mock_merge = MagicMock()
+        m.setattr(cli, "process_merged_files", mock_merge)
         main()
 
-    stderr = capsys.readouterr().err
-    assert "You must provide an output folder when processing more than one file." in stderr
+        mock_merge.assert_called_once()
+        settings = mock_merge.call_args[0][1]
+        assert settings.merge is True
+        assert settings.output_mode == 'stdout'
 
 def test_individual_eml_output_not_a_directory(monkeypatch, tmp_path, testdata_dir, capsys):
     input_file = testdata_dir / "messages.dat"

--- a/tests/test_cli_ux_multi_input.py
+++ b/tests/test_cli_ux_multi_input.py
@@ -1,0 +1,31 @@
+import os
+import sys
+from unittest.mock import patch, MagicMock
+import pytest
+from pyqwk.cli import main
+
+def test_cli_multi_input_no_output_defaults_to_merge_stdout(capsys):
+    """Test that providing multiple input files without -o defaults to merging to stdout."""
+    # Use real test files from testdata
+    test_file1 = "testdata/test1_qwk.zip"
+    test_file2 = "testdata/test2_qwk.zip"
+
+    # Mock sys.argv
+    test_args = ["pyqwk", test_file1, test_file2]
+
+    # Mock process_merged_files to avoid actually processing and printing large amounts of data
+    with patch("pyqwk.cli.process_merged_files") as mock_process_merged:
+        with patch.object(sys, 'argv', test_args):
+            # We expect it NOT to call sys.exit or parser.error
+            main()
+
+        # Check that process_merged_files was called
+        mock_process_merged.assert_called_once()
+
+        # Verify the settings passed to process_merged_files
+        args, kwargs = mock_process_merged.call_args
+        settings = args[1]
+
+        assert settings.merge is True
+        assert settings.output_mode == 'stdout'
+        assert settings.output_path is None

--- a/tests/test_qwk.py
+++ b/tests/test_qwk.py
@@ -5,6 +5,7 @@ import sys
 import json
 import zipfile
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -780,17 +781,17 @@ def test_cli_treats_multiple_positional_args_as_inputs(
     logging.basicConfig(level=logging.ERROR, force=True)
     output_path = tmp_path / "output.txt"
     # This simulates passing two files: baseline_path and output.txt (as a second input)
+    # This no longer errors but defaults to stdout merge
     monkeypatch.setattr(
         sys,
         "argv",
         ["prog", str(baseline_path), str(output_path)],
     )
 
-    with pytest.raises(SystemExit):
+    import pyqwk.cli as cli
+    with monkeypatch.context() as m:
+        m.setattr(cli, "process_merged_files", MagicMock())
         main()
-
-    stderr = capsys.readouterr().err
-    assert "You must provide an output folder when processing more than one file." in stderr
 
 
 def test_cli_treats_extra_positional_args_as_inputs_requiring_output_dir(
@@ -799,6 +800,7 @@ def test_cli_treats_extra_positional_args_as_inputs_requiring_output_dir(
     logging.basicConfig(level=logging.ERROR, force=True)
     output_dir = tmp_path / "output"
     # This simulates passing three inputs, the last one being the intended output dir but treated as input
+    # This no longer errors but defaults to stdout merge
     monkeypatch.setattr(
         sys,
         "argv",
@@ -810,11 +812,10 @@ def test_cli_treats_extra_positional_args_as_inputs_requiring_output_dir(
         ],
     )
 
-    with pytest.raises(SystemExit):
+    import pyqwk.cli as cli
+    with monkeypatch.context() as m:
+        m.setattr(cli, "process_merged_files", MagicMock())
         main()
-
-    stderr = capsys.readouterr().err
-    assert "You must provide an output folder when processing more than one file." in stderr
 
 
 def test_cli_rejects_invalid_log_level(

--- a/tests/test_ui_enhancements.py
+++ b/tests/test_ui_enhancements.py
@@ -4,6 +4,7 @@ from pyqwk.core import _highlight_quotes, ProcessingSettings, ParsedMessage, Mes
 import logging
 import io
 import sys
+from unittest.mock import MagicMock, patch
 
 def test_highlight_quotes_no_colors():
     text = "> This is a quote\nThis is not."
@@ -29,67 +30,64 @@ def test_highlight_quotes_with_prefix():
     assert "\x1b[32mJS> This is a quote\x1b[0m\n" in highlighted
     assert "\x1b[32m  > Indented quote\x1b[0m" in highlighted
 
-def test_process_merged_files_separator_colors(mocker):
+def test_process_merged_files_separator_colors():
     # Mock sys.stdout.isatty to True
-    mocker.patch('sys.stdout.isatty', return_value=True)
-    mocker.patch('shutil.get_terminal_size', return_value=mocker.Mock(columns=80))
-    # Mock load_data to return a simple message
-    header = MessageHeader(
-        status=' ', msgnum=1, msgdate='01-01-23', msgtime='12:00',
-        msgto='Alice', msgfrom='Bob', msgsubject='Test',
-        msgpassword='', refnum=None, numblocks=1, msgflag=' ',
-        confnum=1, lognum=1, nettag=''
-    )
-    msg = ParsedMessage(text="Hello", msgnum=1, refnum=None, confnum=1, header=header)
+    with patch('sys.stdout.isatty', return_value=True), \
+         patch('shutil.get_terminal_size', return_value=MagicMock(columns=80)):
+        # Mock load_data to return a simple message
+        header = MessageHeader(
+            status=' ', msgnum=1, msgdate='01-01-23', msgtime='12:00',
+            msgto='Alice', msgfrom='Bob', msgsubject='Test',
+            msgpassword='', refnum=None, numblocks=1, msgflag=' ',
+            confnum=1, lognum=1, nettag=''
+        )
+        msg = ParsedMessage(text="Hello", msgnum=1, refnum=None, confnum=1, header=header)
 
-    mocker.patch('pyqwk.core.load_data', return_value=([msg], {1: "General"}))
+        with patch('pyqwk.core.load_data', return_value=([msg], {1: "General"})):
+            settings = ProcessingSettings(
+                verbose=False, private=True, no_header=False, truncate_signatures=False,
+                cut_quoting=False, individual_files=False, threaded=False,
+                binaries_removal=False, redact_pii=False, format='text',
+                separator='auto', output_mode='stdout', output_path=None,
+                encoding='cp437', quiet=True
+            )
 
-    settings = ProcessingSettings(
-        verbose=False, private=True, no_header=False, truncate_signatures=False,
-        cut_quoting=False, individual_files=False, threaded=False,
-        binaries_removal=False, redact_pii=False, format='text',
-        separator='auto', output_mode='stdout', output_path=None,
-        encoding='cp437', quiet=True
-    )
+            # Capture stdout
+            stdout = io.StringIO()
+            stdout.isatty = lambda: True
+            with patch('sys.stdout', stdout):
+                process_merged_files(["dummy.qwk"], settings, logging.getLogger())
 
-    # Capture stdout
-    stdout = io.StringIO()
-    stdout.isatty = lambda: True
-    mocker.patch('sys.stdout', stdout)
+            output = stdout.getvalue()
+            # Check for dimmed separator
+            assert "\x1b[90m--------------------------------------------------------------------------------\r\n\x1b[0m" in output
 
-    process_merged_files(["dummy.qwk"], settings, logging.getLogger())
-
-    output = stdout.getvalue()
-    # Check for dimmed separator
-    assert "\x1b[90m--------------------------------------------------------------------------------\r\n\x1b[0m" in output
-
-def test_process_merged_files_quote_highlighting(mocker):
+def test_process_merged_files_quote_highlighting():
     # Mock sys.stdout.isatty to True
     stdout = io.StringIO()
     stdout.isatty = lambda: True
-    mocker.patch('sys.stdout', stdout)
+    with patch('sys.stdout', stdout):
+        # Mock load_data to return a message with a quote
+        header = MessageHeader(
+            status=' ', msgnum=1, msgdate='01-01-23', msgtime='12:00',
+            msgto='Alice', msgfrom='Bob', msgsubject='Test',
+            msgpassword='', refnum=None, numblocks=1, msgflag=' ',
+            confnum=1, lognum=1, nettag=''
+        )
+        # Fixed call to ParsedMessage
+        msg = ParsedMessage(text="> This is a quote\nHello", msgnum=1, refnum=None, confnum=1, header=header)
 
-    # Mock load_data to return a message with a quote
-    header = MessageHeader(
-        status=' ', msgnum=1, msgdate='01-01-23', msgtime='12:00',
-        msgto='Alice', msgfrom='Bob', msgsubject='Test',
-        msgpassword='', refnum=None, numblocks=1, msgflag=' ',
-        confnum=1, lognum=1, nettag=''
-    )
-    msg = ParsedMessage(text="> This is a quote\nHello", msgnum=1, refnum=None, confnum=1, header=header)
+        with patch('pyqwk.core.load_data', return_value=([msg], {1: "General"})):
+            settings = ProcessingSettings(
+                verbose=False, private=True, no_header=True, truncate_signatures=False,
+                cut_quoting=False, individual_files=False, threaded=False,
+                binaries_removal=False, redact_pii=False, format='text',
+                separator='none', output_mode='stdout', output_path=None,
+                encoding='cp437', quiet=True
+            )
 
-    mocker.patch('pyqwk.core.load_data', return_value=([msg], {1: "General"}))
+            process_merged_files(["dummy.qwk"], settings, logging.getLogger())
 
-    settings = ProcessingSettings(
-        verbose=False, private=True, no_header=True, truncate_signatures=False,
-        cut_quoting=False, individual_files=False, threaded=False,
-        binaries_removal=False, redact_pii=False, format='text',
-        separator='none', output_mode='stdout', output_path=None,
-        encoding='cp437', quiet=True
-    )
-
-    process_merged_files(["dummy.qwk"], settings, logging.getLogger())
-
-    output = stdout.getvalue()
-    # Check for green highlighted quote
-    assert "\x1b[32m> This is a quote\x1b[0m\r\n" in output
+            output = stdout.getvalue()
+            # Check for green highlighted quote
+            assert "\x1b[32m> This is a quote\x1b[0m\r\n" in output


### PR DESCRIPTION
* **Context:** CLI
* **Problem:** When a user provides multiple input files or a directory without an output path, the CLI previously raised an error requiring an output folder. This caused friction for users who just wanted to quickly view or search through multiple archives in their terminal.
* **Solution:** Changed the CLI logic to default to merging output to standard output (stdout) when multiple inputs are provided without an explicit output path. This makes the tool's behavior consistent across single and multiple file inputs and reduces the keystrokes required for common inspection tasks. Added a log message to inform the user of this default behavior.


---
*PR created automatically by Jules for task [5147735246919808846](https://jules.google.com/task/5147735246919808846) started by @RainRat*