### PR TITLE
[FEAT] Extend organize-by-bbs to support all archive formats

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -3526,34 +3526,40 @@ def _order_messages_by_thread(messages: list[ProcessedMessage]) -> list[Processe
 
 
 def organize_by_bbs(input_paths: list[str], settings: ProcessingSettings, logger: logging.Logger) -> None:
-    """Organize QWK files into directories based on their BBS name."""
+    """Organize archive files into directories based on their BBS name and ID."""
+    supported_extensions = ('.qwk', '.rep', '.json', '.csv', '.xml', '.db', '.sqlite', '.mbox', '.eml')
+
     for input_path in input_paths:
         if not os.path.isfile(input_path):
             continue
 
-        if not input_path.lower().endswith('.qwk'):
+        if not input_path.lower().endswith(supported_extensions) and os.path.basename(input_path).lower() != 'messages.dat':
             continue
 
         try:
             _, board_dict = load_data(input_path, logger, settings.encoding)
             bbs_info = getattr(board_dict, 'bbs_info', None)
-            if bbs_info and bbs_info.name:
-                bbs_name = bbs_info.name.strip()
-                safe_bbs_name = "".join([c for c in bbs_name if c.isalnum() or c in (' ', '.', '_', '-')]).strip()
+
+            if bbs_info and (bbs_info.name or bbs_info.bbs_id):
+                name_part = bbs_info.name.strip() if bbs_info.name else "Unknown BBS"
+                id_part = f" ({bbs_info.bbs_id.strip()})" if bbs_info.bbs_id else ""
+
+                folder_name = f"{name_part}{id_part}"
+                safe_folder_name = "".join([c for c in folder_name if c.isalnum() or c in (' ', '.', '_', '-', '(', ')')]).strip()
                 
-                if not safe_bbs_name:
-                    safe_bbs_name = "Unknown_BBS"
+                if not safe_folder_name:
+                    safe_folder_name = "Unknown_BBS"
                 
                 if settings.dry_run:
-                    logger.info("Dry run: Would move %s to %s/", input_path, safe_bbs_name)
+                    logger.info("Dry run: Would move %s to %s/", input_path, safe_folder_name)
                     continue
 
-                if not os.path.exists(safe_bbs_name):
-                    os.makedirs(safe_bbs_name)
+                if not os.path.exists(safe_folder_name):
+                    os.makedirs(safe_folder_name)
                 
-                shutil.move(input_path, os.path.join(safe_bbs_name, os.path.basename(input_path)))
-                logger.info("Moved %s to %s/", input_path, safe_bbs_name)
+                shutil.move(input_path, os.path.join(safe_folder_name, os.path.basename(input_path)))
+                logger.info("Moved %s to %s/", input_path, safe_folder_name)
             else:
-                logger.warning("Could not find BBS name in %s", input_path)
+                logger.warning("Could not find BBS information in %s", input_path)
         except Exception as e:
-            logger.error("Error processing %s: %s", input_path, e)
+            logger.error("Error organizing %s: %s", input_path, e)

--- a/tests/test_organize_by_bbs.py
+++ b/tests/test_organize_by_bbs.py
@@ -45,6 +45,40 @@ def test_organize_by_bbs_success(tmp_path, mock_settings, logger):
         mock_makedirs.assert_called_once_with("My Awesome BBS")
         mock_move.assert_called_once_with(str(qwk_file), os.path.join("My Awesome BBS", "TEST.QWK"))
 
+def test_organize_by_bbs_with_id(tmp_path, mock_settings, logger):
+    json_file = tmp_path / "archive.json"
+    json_file.write_text("[]")
+
+    board_dict = ConferenceMap()
+    board_dict.bbs_info = BBSInfo(name="The Board", bbs_id="BOARDID")
+
+    with patch("pyqwk.core.load_data", return_value=([], board_dict)), \
+         patch("shutil.move") as mock_move, \
+         patch("os.makedirs") as mock_makedirs:
+
+        organize_by_bbs([str(json_file)], mock_settings, logger)
+
+        expected_folder = "The Board (BOARDID)"
+        mock_makedirs.assert_called_once_with(expected_folder)
+        mock_move.assert_called_once_with(str(json_file), os.path.join(expected_folder, "archive.json"))
+
+def test_organize_by_bbs_only_id(tmp_path, mock_settings, logger):
+    db_file = tmp_path / "archive.db"
+    db_file.write_text("sqlite")
+
+    board_dict = ConferenceMap()
+    board_dict.bbs_info = BBSInfo(name="", bbs_id="ONLYID")
+
+    with patch("pyqwk.core.load_data", return_value=([], board_dict)), \
+         patch("shutil.move") as mock_move, \
+         patch("os.makedirs") as mock_makedirs:
+
+        organize_by_bbs([str(db_file)], mock_settings, logger)
+
+        expected_folder = "Unknown BBS (ONLYID)"
+        mock_makedirs.assert_called_once_with(expected_folder)
+        mock_move.assert_called_once_with(str(db_file), os.path.join(expected_folder, "archive.db"))
+
 def test_organize_by_bbs_dry_run(tmp_path, mock_settings, logger):
     qwk_file = tmp_path / "TEST.QWK"
     qwk_file.write_text("dummy content")
@@ -74,12 +108,29 @@ def test_organize_by_bbs_missing_bbs_info(tmp_path, mock_settings, logger, caplo
         with caplog.at_level(logging.WARNING):
             organize_by_bbs([str(qwk_file)], mock_settings, logger)
 
-        assert "Could not find BBS name" in caplog.text
+        assert "Could not find BBS information" in caplog.text
         mock_move.assert_not_called()
+
+def test_organize_by_bbs_supported_extensions(tmp_path, mock_settings, logger):
+    extensions = ['.qwk', '.rep', '.json', '.csv', '.xml', '.db', '.sqlite', '.mbox', '.eml']
+
+    for ext in extensions:
+        test_file = tmp_path / f"test{ext}"
+        test_file.write_text("dummy")
+
+        board_dict = ConferenceMap()
+        board_dict.bbs_info = BBSInfo(name="BBS")
+
+        with patch("pyqwk.core.load_data", return_value=([], board_dict)), \
+             patch("shutil.move") as mock_move, \
+             patch("os.makedirs"):
+
+            organize_by_bbs([str(test_file)], mock_settings, logger)
+            mock_move.assert_called_once()
 
 def test_organize_by_bbs_invalid_extension(tmp_path, mock_settings, logger):
     txt_file = tmp_path / "test.txt"
-    txt_file.write_text("not a qwk")
+    txt_file.write_text("not supported")
 
     with patch("pyqwk.core.load_data") as mock_load:
         organize_by_bbs([str(txt_file)], mock_settings, logger)
@@ -100,7 +151,7 @@ def test_organize_by_bbs_exception_handling(tmp_path, mock_settings, logger, cap
         with caplog.at_level(logging.ERROR):
             organize_by_bbs([str(qwk_file)], mock_settings, logger)
 
-        assert "Error processing" in caplog.text
+        assert "Error organizing" in caplog.text
         assert "Boom" in caplog.text
         mock_move.assert_not_called()
 


### PR DESCRIPTION
Updated `organize_by_bbs` in `pyqwk/core.py` to support all archive formats (QWK, REP, JSON, CSV, XML, SQLite, MBOX, EML).
Improved folder naming logic to include BBS ID when available (e.g., "BBS Name (ID)").
Broadened character set for folder sanitization to include parentheses.
Updated `tests/test_organize_by_bbs.py` with comprehensive test coverage.

---
*PR created automatically by Jules for task [12209532414805869357](https://jules.google.com/task/12209532414805869357) started by @RainRat*