### PR TITLE
Refactor redundant RFC 822 serialization wrappers

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -1849,9 +1849,9 @@ def process_merged_files(
                     is_regex=settings.regex,
                 ).encode(target_encoding)
             elif settings.format == 'mbox':
-                encoded_buffer = _serialize_message_mbox(temp_msg).encode(target_encoding)
+                encoded_buffer = _serialize_rfc822(temp_msg, include_mbox_header=True).encode(target_encoding)
             elif settings.format == 'eml':
-                encoded_buffer = _serialize_message_eml(temp_msg).encode(target_encoding)
+                encoded_buffer = _serialize_rfc822(temp_msg, include_mbox_header=False).encode(target_encoding)
             else:
                 encoded_buffer = processed_buffer.encode(target_encoding)
 
@@ -2590,16 +2590,6 @@ def _serialize_rfc822(message: ProcessedMessage, include_mbox_header: bool = Tru
     return "\n".join(parts)
 
 
-def _serialize_message_mbox(message: ProcessedMessage) -> str:
-    """Serialize a message to mbox format with threading and extra headers."""
-    return _serialize_rfc822(message, include_mbox_header=True)
-
-
-def _serialize_message_eml(message: ProcessedMessage) -> str:
-    """Serialize a message to EML format (RFC 822)."""
-    return _serialize_rfc822(message, include_mbox_header=False)
-
-
 def _write_mbox(
     messages: list[ProcessedMessage],
     output_path: str | None,
@@ -2610,7 +2600,7 @@ def _write_mbox(
     """Write messages to an mbox file."""
     parts = []
     for message in messages:
-        parts.append(_serialize_message_mbox(message))
+        parts.append(_serialize_rfc822(message, include_mbox_header=True))
 
     _write_text_output("\n".join(parts), output_path, encoding=encoding)
 
@@ -2629,7 +2619,7 @@ def _write_eml(
     """
     parts = []
     for message in messages:
-        parts.append(_serialize_message_eml(message))
+        parts.append(_serialize_rfc822(message, include_mbox_header=False))
 
     _write_text_output("\n\n".join(parts), output_path, encoding=encoding)
 

--- a/tests/test_coverage_final_gaps.py
+++ b/tests/test_coverage_final_gaps.py
@@ -154,13 +154,13 @@ def test_decode_yenc_exception_coverage():
     assert _decode_yenc(None) == b""
 
 def test_eml_serialize_no_from_header_coverage(message_factory):
-    from pyqwk.core import _serialize_message_eml
+    from pyqwk.core import _serialize_rfc822
 
     msg = message_factory(1, None, "Test")
     msg.text = "Body"
 
-    result = _serialize_message_eml(msg)
-    # _serialize_message_eml does not have the mbox "From " separator
+    result = _serialize_rfc822(msg, include_mbox_header=False)
+    # RFC 822 (EML) serialization does not have the mbox "From " separator
     assert not result.startswith("From ")
     assert "From: " in result
     assert "Subject: Test" in result

--- a/tests/test_mbox_output.py
+++ b/tests/test_mbox_output.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from pyqwk.core import _write_mbox, _serialize_message_mbox, ProcessedMessage, MessageHeader
+from pyqwk.core import _write_mbox, _serialize_rfc822, ProcessedMessage, MessageHeader
 
 @pytest.fixture
 def sample_message():
@@ -40,7 +40,7 @@ def test_serialize_message_mbox_format(sample_message):
     # But since we will implement date parsing, we expect it to parse 01-01-90 correctly.
     # 01-01-90 -> Jan 1, 1990 (or 2090?). Let's assume 1990 for now or whatever datetime defaults to.
 
-    mbox_content = _serialize_message_mbox(sample_message)
+    mbox_content = _serialize_rfc822(sample_message, include_mbox_header=True)
 
     lines = mbox_content.splitlines()
 
@@ -65,7 +65,7 @@ def test_serialize_message_mbox_with_metadata(sample_message):
     sample_message.header.status = "*"
     sample_message.header.msgflag = " "
 
-    mbox_content = _serialize_message_mbox(sample_message)
+    mbox_content = _serialize_rfc822(sample_message, include_mbox_header=True)
 
     assert "X-QWK-Conference-Name: Main Board" in mbox_content
     assert "X-QWK-Message-Number: 123" in mbox_content
@@ -74,7 +74,7 @@ def test_serialize_message_mbox_with_metadata(sample_message):
 
 def test_serialize_message_mbox_threading(sample_message):
     sample_message.parent_msgnum = 100
-    mbox_content = _serialize_message_mbox(sample_message)
+    mbox_content = _serialize_rfc822(sample_message, include_mbox_header=True)
 
     assert "In-Reply-To: <1.100@qwk>" in mbox_content
     assert "References: <1.100@qwk>" in mbox_content
@@ -94,7 +94,7 @@ def test_write_mbox_multiple(tmp_path, sample_message):
 def test_mbox_body_quoting(sample_message):
     sample_message.text = "From the beginning...\r\nThis line starts with From usually."
 
-    mbox_content = _serialize_message_mbox(sample_message)
+    mbox_content = _serialize_rfc822(sample_message, include_mbox_header=True)
 
     # "From " at start of line in body should be escaped
     assert "\n>From the beginning..." in mbox_content or "\r\n>From the beginning..." in mbox_content


### PR DESCRIPTION
Removed the redundant private wrapper functions `_serialize_message_mbox` and `_serialize_message_eml` in `pyqwk/core.py`. These were thin wrappers around `_serialize_rfc822`. Call sites in `process_merged_files`, `_write_mbox`, and `_write_eml` now call `_serialize_rfc822` directly with the appropriate `include_mbox_header` flag. Updated `tests/test_mbox_output.py` and `tests/test_coverage_final_gaps.py` to test `_serialize_rfc822` directly.

This change reduces code duplication and simplifies the module structure by removing unnecessary levels of abstraction. The external behavior remains identical, as verified by the existing test suite.

---
*PR created automatically by Jules for task [16589566471138772001](https://jules.google.com/task/16589566471138772001) started by @RainRat*