### PR TITLE
[DOCS] Correct --oneline output field description

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,7 +346,7 @@ for msg in messages:
 | `--organize` | Organize individual files into subfolders by conference. |
 | `-F, --format [type]` | Choose format: `text`, `html`, `json`, `xml`, `markdown`, `csv`, `mbox`, `eml`, `sqlite`. |
 | `-T`, `--threaded` | Group replies together into conversations. |
-| `--oneline` | Show each message as a single-line summary (Conference, Date, From, Subject). |
+| `--oneline` | Show each message as a single-line summary (Conference, Date, From, To, Subject). |
 | `-m`, `--merge` | Combine multiple inputs into a single output file. |
 | `-u`, `--unique` | Only include unique messages (removes duplicates when merging archives). |
 | `-S`, `--search [term]` | Search for a keyword in author, recipient, subject, and message text. |

--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -226,7 +226,7 @@ def main() -> None:
     format_group.add_argument(
         '-1',
         '--oneline',
-        help='Show each message as a single line summary (Conference, Date, From, Subject).',
+        help='Show each message as a single line summary (Conference, Date, From, To, Subject).',
         action='store_true',
     )
     format_group.add_argument(


### PR DESCRIPTION
The documentation for the `--oneline` flag was missing the "To" (recipient) field in its summary description. This PR updates both the `README.md` and the internal CLI help strings in `pyqwk/cli.py` to correctly list the fields as (Conference, Date, From, To, Subject).

- **Type:** Documentation / Internal Help
- **What:** Updated `--oneline` help text in `README.md` and `pyqwk/cli.py`.
- **Why:** To ensure the documentation accurately matches the actual behavior of the tool.

---
*PR created automatically by Jules for task [6033259300485692689](https://jules.google.com/task/6033259300485692689) started by @RainRat*