### PR TITLE
[UI/UX] Add usage examples to CLI help output

### DIFF
--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -79,7 +79,28 @@ def _parse_cli_date(date_str: str | None, end_of_day: bool = False) -> datetime.
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="A tool to read and convert old Bulletin Board System (BBS) message packets (QWK, REP, JSON, CSV, XML, MBOX, EML, and SQLite) into modern formats like Text, HTML, Markdown, CSV, and more."
+        description="A tool to read and convert old Bulletin Board System (BBS) message packets (QWK, REP, JSON, CSV, XML, MBOX, EML, and SQLite) into modern formats like Text, HTML, Markdown, CSV, and more.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+examples:
+  # Show a one-line summary of all messages in an archive
+  qwk archive.qwk --oneline
+
+  # Convert an archive to a single, searchable HTML file
+  qwk archive.qwk --format html -o messages.html
+
+  # Save each message as an individual EML file in a folder
+  qwk archive.qwk --format eml -o ./output/
+
+  # Search for a keyword and show matching messages with headers only
+  qwk archive.qwk --search "vintage computing" --headers-only
+
+  # Extract attachments (UUE, yEnc, Base64) to an attachments/ folder
+  qwk archive.qwk --extract-attachments
+
+  # Show detailed statistics about an archive
+  qwk archive.qwk --stats
+""",
     )
     parser.add_argument(
         'input_paths',


### PR DESCRIPTION
**PR Title:** [UI/UX] Add usage examples to CLI help output

**Description:**
* **Context:** CLI
* **Problem:** Users may find it difficult to discover the full range of pyqwk's capabilities (like HTML conversion, threading, or attachment extraction) without consulting the README, creating friction for first-time or infrequent users.
* **Solution:** Added a categorized "examples:" section directly to the CLI help output (`--help`). By using `argparse.RawDescriptionHelpFormatter`, we ensure that these multi-line examples maintain their intended indentation and spacing, providing clear, copy-pasteable guidance for common workflows.

**Changes:**
- Updated `pyqwk/cli.py` to include an `epilog` in the `ArgumentParser` containing examples for one-line summaries, HTML/EML exports, keyword searching, attachment extraction, and statistics gathering.
- Configured the CLI parser to use `RawDescriptionHelpFormatter`.


---
*PR created automatically by Jules for task [16698170844702863416](https://jules.google.com/task/16698170844702863416) started by @RainRat*