### PR TITLE
[UI/UX] Add welcome screen to Graphical Reader

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -65,6 +65,40 @@ class QwkGuiApp:
         if initial_path:
             self.current_path = initial_path
             self.root.after(100, lambda: self.load_messages(initial_path))
+        else:
+            self.root.after(100, self._render_welcome_screen)
+
+    def _render_welcome_screen(self) -> None:
+        """Render a welcome screen with instructions and shortcuts."""
+        self.detail_text.config(state=tk.NORMAL)
+        self.detail_text.delete("1.0", tk.END)
+
+        self.detail_text.insert(tk.END, "Welcome to PyQWK\n\n", "header_subject")
+
+        self.detail_text.insert(tk.END, "Getting Started:\n", "header_label")
+        self.detail_text.insert(tk.END, "Use Ctrl+O or the 'Open' button in the toolbar to load a message archive.\n\n", "body")
+
+        self.detail_text.insert(tk.END, "Supported Formats:\n", "header_label")
+        formats = "QWK, REP, JSON, CSV, SQLite (.db), XML, mbox, EML, and MESSAGES.DAT"
+        self.detail_text.insert(tk.END, f"{formats}\n\n", "body")
+
+        self.detail_text.insert(tk.END, "Keyboard Shortcuts:\n", "header_label")
+        shortcuts = [
+            ("Ctrl + O", "Open Archive"),
+            ("Ctrl + S", "Export Current View"),
+            ("Ctrl + F", "Search / Find"),
+            ("Ctrl + G", "Go to Message Number"),
+            ("Ctrl + Q", "Quit Application"),
+            ("Esc", "Clear Search / Filters"),
+            ("J / N", "Next Message"),
+            ("K / P", "Previous Message"),
+        ]
+
+        for key, desc in shortcuts:
+            self.detail_text.insert(tk.END, f"{key:<12}", "header_label")
+            self.detail_text.insert(tk.END, f"{desc}\n", "body")
+
+        self.detail_text.config(state=tk.DISABLED)
 
     def _build_menu(self) -> None:
         menubar = tk.Menu(self.root)

--- a/tests/test_gui_welcome.py
+++ b/tests/test_gui_welcome.py
@@ -1,0 +1,65 @@
+import sys
+from unittest.mock import MagicMock, patch
+import pytest
+
+# Mock tkinter and ttk
+mock_tk = MagicMock()
+mock_ttk = MagicMock()
+
+# Ensure variables return mocks that don't need a root
+mock_tk.BooleanVar.return_value = MagicMock()
+mock_tk.StringVar.return_value = MagicMock()
+
+# Import QwkGuiApp with mocked modules
+with patch.dict(sys.modules, {
+    "tkinter": mock_tk,
+    "tkinter.ttk": mock_ttk,
+    "tkinter.filedialog": MagicMock(),
+    "tkinter.messagebox": MagicMock(),
+    "tkinter.simpledialog": MagicMock()
+}):
+    from pyqwk.gui import QwkGuiApp
+
+def test_welcome_screen_on_startup():
+    """Verify that the welcome screen is rendered when no archive is provided."""
+    mock_root = MagicMock()
+
+    # Pre-create the mock for Text to be used in QwkGuiApp
+    mock_detail_text = MagicMock()
+    mock_tk.Text.return_value = mock_detail_text
+
+    # Create instance
+    app = QwkGuiApp(mock_root)
+
+    # Ensure detail_text is what we expect
+    assert app.detail_text == mock_detail_text
+
+    # Manually trigger the welcome screen call
+    app._render_welcome_screen()
+
+    # Check that welcome text was inserted
+    found_welcome = False
+    for call in mock_detail_text.insert.call_args_list:
+        args, _ = call
+        # args[1] is the text content
+        if len(args) > 1 and "Welcome to PyQWK" in str(args[1]):
+            found_welcome = True
+            break
+
+    assert found_welcome, "Welcome screen text was not inserted into detail_text"
+
+    # Check for shortcuts section
+    found_shortcuts = False
+    for call in mock_detail_text.insert.call_args_list:
+        args, _ = call
+        if len(args) > 1 and "Keyboard Shortcuts:" in str(args[1]):
+            found_shortcuts = True
+            break
+    assert found_shortcuts, "Keyboard shortcuts section was not found in welcome screen"
+
+def test_no_welcome_screen_with_path():
+    """Verify that current_path is set when an initial path is provided."""
+    mock_root = MagicMock()
+    with patch("pyqwk.gui.load_data"): # Prevent actual loading
+        app = QwkGuiApp(mock_root, initial_path="test.qwk")
+        assert app.current_path == "test.qwk"


### PR DESCRIPTION
When the Graphical Reader is launched without an archive path, it now displays a helpful welcome screen in the detail view instead of remaining blank. This screen guides the user on how to open archives, lists supported formats (QWK, REP, JSON, CSV, SQLite, XML, mbox, EML), and provides a reference for common keyboard shortcuts. This improvement reduces user friction and improves the discoverability of features.

---
*PR created automatically by Jules for task [6311757305772879393](https://jules.google.com/task/6311757305772879393) started by @RainRat*