### PR TITLE
Exclude structured formats from ANSI color highlighting

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -1665,6 +1665,7 @@ def process_merged_files(
 
     use_colors = (
         output_mode == 'stdout'
+        and settings.format == 'text'
         and hasattr(sys.stdout, 'isatty')
         and sys.stdout.isatty()
     )


### PR DESCRIPTION
The `use_colors` logic in `process_merged_files` was incorrectly triggering for structured formats (JSON, XML, CSV, etc.) when they were output to a terminal (stdout). This resulted in ANSI escape sequences for keyword highlighting being embedded within the structured data, breaking parsing for downstream tools.

This change ensures that visual highlighting is only applied when the output format is explicitly set to 'text'. External behavior for standard text output remains identical.


---
*PR created automatically by Jules for task [6430927803491441562](https://jules.google.com/task/6430927803491441562) started by @RainRat*