### PR TITLE
[TEST] Fix threading indentation in one-line summary output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 htmlcov/
 *.egg-info/
 .pytest_cache/
+build/

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -2718,17 +2718,29 @@ def _write_text(
         parts.append(separator_line)
 
     for message in messages:
-        text = message.text
+        if settings and settings.oneline:
+            # Re-format oneline summary to account for threading depth
+            text = message.header.format_oneline(
+                {},  # board_dict not needed when conf_name is provided
+                use_colors=use_colors,
+                highlight_term=settings.search_term,
+                is_regex=settings.regex,
+                verbose=settings.verbose,
+                depth=message.depth,
+                conf_name=message.confname,
+            )
+        else:
+            text = message.text
 
-        # Apply quote highlighting for terminal output
-        text = _highlight_quotes(text, use_colors)
+            # Apply quote highlighting for terminal output
+            text = _highlight_quotes(text, use_colors)
 
-        # Apply indentation only if NOT in oneline mode (oneline mode handles depth internally)
-        if message.depth > 0 and not (settings and settings.oneline):
-            indent = "  " * message.depth
-            lines = text.splitlines(keepends=True)
-            indented_lines = [indent + line for line in lines]
-            text = "".join(indented_lines)
+            # Apply indentation for threads
+            if message.depth > 0:
+                indent = "  " * message.depth
+                lines = text.splitlines(keepends=True)
+                indented_lines = [indent + line for line in lines]
+                text = "".join(indented_lines)
         parts.append(text)
 
     _write_text_output("".join(parts), output_path, encoding=encoding)

--- a/tests/test_oneline.py
+++ b/tests/test_oneline.py
@@ -90,7 +90,7 @@ def test_write_text_oneline():
     assert "From" in output
     assert "Subject" in output
     assert "----------------" in output
-    assert "Oneline summary" in output
+    assert "Test Subject" in output
 
 def test_cli_oneline(tmp_path):
     # This is a bit harder to test without running the actual CLI,
@@ -110,3 +110,87 @@ def test_cli_oneline(tmp_path):
             args, kwargs = mock_process.call_args
             settings = args[1]
             assert settings.oneline is True
+
+
+def test_write_text_threaded_oneline():
+    header1 = MessageHeader(
+        status=" ",
+        msgnum=1,
+        msgdate="01-01-24",
+        msgtime="12:00",
+        msgto="All",
+        msgfrom="Alice",
+        msgsubject="Parent",
+        msgpassword="",
+        refnum=None,
+        numblocks=1,
+        msgflag="",
+        confnum=1,
+        lognum=0,
+        nettag="",
+    )
+    header2 = MessageHeader(
+        status=" ",
+        msgnum=2,
+        msgdate="01-01-24",
+        msgtime="12:05",
+        msgto="Alice",
+        msgfrom="Bob",
+        msgsubject="Parent",
+        msgpassword="",
+        refnum=1,
+        numblocks=1,
+        msgflag="",
+        confnum=1,
+        lognum=0,
+        nettag="",
+    )
+
+    msg1 = ParsedMessage(
+        text="Parent text",
+        msgnum=1,
+        refnum=None,
+        confnum=1,
+        header=header1,
+        confname="General",
+        depth=0
+    )
+    msg2 = ParsedMessage(
+        text="Child text",
+        msgnum=2,
+        refnum=1,
+        confnum=1,
+        header=header2,
+        confname="General",
+        depth=1
+    )
+
+    settings = ProcessingSettings(
+        verbose=False,
+        private=True,
+        no_header=False,
+        truncate_signatures=False,
+        cut_quoting=False,
+        individual_files=False,
+        threaded=True,
+        binaries_removal=False,
+        redact_pii=False,
+        format="text",
+        separator="none",
+        output_mode="stdout",
+        output_path=None,
+        encoding="cp437",
+        oneline=True
+    )
+
+    old_stdout = sys.stdout
+    sys.stdout = StringIO()
+    try:
+        _write_text([msg1, msg2], None, settings=settings)
+        output = sys.stdout.getvalue()
+    finally:
+        sys.stdout = old_stdout
+
+    assert "General" in output
+    assert "Parent" in output
+    assert "└ Parent" in output


### PR DESCRIPTION
- **Type:** Bug Fix / New Coverage
- **What:** Re-renders one-line summaries in `_write_text` to include threading indentation. Added regression tests in `tests/test_oneline.py`. Updated `.gitignore` to exclude `build/`.
- **Why:** The initial rendering of one-line summaries occurred before threading depth was determined, leading to missing branch characters (└) in the final output. Excluded build artifacts to maintain repository hygiene.

---
*PR created automatically by Jules for task [15427478242935667778](https://jules.google.com/task/15427478242935667778) started by @RainRat*