### PR TITLE
[UI/UX] Add ASCII bar charts to CLI statistics output

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -3299,19 +3299,25 @@ def show_stats(input_paths: list[str], settings: ProcessingSettings, logger: log
 
                 if author_counter:
                     print(f"\n  {_colorize('Top Authors:', BOLD)}")
+                    max_author_count = max(author_counter.values())
                     for auth in stats_entry["authors"]:
-                        print(f"    {auth['name']:25} : {auth['count']}")
+                        bar = "#" * int(auth['count'] * 40 / max_author_count) if max_author_count > 0 else ""
+                        print(f"    {auth['name']:25} : {auth['count']:4} {bar}")
 
                 if recipient_counter:
                     print(f"\n  {_colorize('Top Recipients:', BOLD)}")
+                    max_recipient_count = max(recipient_counter.values())
                     for rcpt in stats_entry["recipients"]:
-                        print(f"    {rcpt['name']:25} : {rcpt['count']}")
+                        bar = "#" * int(rcpt['count'] * 40 / max_recipient_count) if max_recipient_count > 0 else ""
+                        print(f"    {rcpt['name']:25} : {rcpt['count']:4} {bar}")
 
                 if conf_counter:
                     print(f"\n  {_colorize('Top Conferences:', BOLD)}")
+                    max_conf_count = max(conf_counter.values())
                     for conf in stats_entry["conferences"]:
                         conf_name = conf['name'][:21]
-                        print(f"    {conf['number']:3} {conf_name:21} : {conf['count']}")
+                        bar = "#" * int(conf['count'] * 40 / max_conf_count) if max_conf_count > 0 else ""
+                        print(f"    {conf['number']:3} {conf_name:21} : {conf['count']:4} {bar}")
 
                 if dow_counter:
                     print(f"\n  {_colorize('Day of Week Distribution:', BOLD)}")

--- a/tests/test_stats_ui.py
+++ b/tests/test_stats_ui.py
@@ -1,0 +1,60 @@
+import logging
+import pyqwk.core as qwk
+from pyqwk.core import ProcessingSettings, show_stats, ParsedMessage, MessageHeader
+
+def test_show_stats_bar_charts(capsys, monkeypatch):
+    # Mock messages to have different counts for authors, recipients, and conferences
+    h1 = MessageHeader(
+        status=" ", msgnum=1, msgdate="01-01-23", msgtime="12:00",
+        msgto="Recipient A", msgfrom="Author A", msgsubject="Subj1",
+        msgpassword="", refnum=None, numblocks=2, msgflag=" ",
+        confnum=1, lognum=1, nettag="",
+    )
+    h2 = MessageHeader(
+        status=" ", msgnum=2, msgdate="01-01-23", msgtime="13:00",
+        msgto="Recipient A", msgfrom="Author B", msgsubject="Subj2",
+        msgpassword="", refnum=None, numblocks=2, msgflag=" ",
+        confnum=2, lognum=2, nettag="",
+    )
+    h3 = MessageHeader(
+        status=" ", msgnum=3, msgdate="01-01-23", msgtime="14:00",
+        msgto="Recipient B", msgfrom="Author A", msgsubject="Subj3",
+        msgpassword="", refnum=None, numblocks=2, msgflag=" ",
+        confnum=1, lognum=3, nettag="",
+    )
+
+    msgs = [
+        ParsedMessage(text="Msg 1", msgnum=1, refnum=None, confnum=1, header=h1),
+        ParsedMessage(text="Msg 2", msgnum=2, refnum=None, confnum=2, header=h2),
+        ParsedMessage(text="Msg 3", msgnum=3, refnum=None, confnum=1, header=h3),
+    ]
+
+    monkeypatch.setattr(qwk, "load_data", lambda *args, **kwargs: (bytearray(b'Produced \0' + b'\0'*119), {1: "General", 2: "Tech"}))
+    monkeypatch.setattr(qwk, "parse_messages", lambda *args, **kwargs: iter(msgs))
+
+    settings = ProcessingSettings(
+        verbose=False, private=True, no_header=False, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False, binaries_removal=False,
+        redact_pii=False, strip_ansi=False, format='text', separator='auto',
+        output_mode='stdout', output_path=None, encoding='cp437', quiet=True
+    )
+    logger = logging.getLogger("test")
+
+    show_stats(["dummy.qwk"], settings, logger)
+
+    captured = capsys.readouterr().out
+
+    # Check Top Authors
+    assert "Top Authors:" in captured
+    assert "Author A                  :    2 ########################################" in captured
+    assert "Author B                  :    1 ####################" in captured
+
+    # Check Top Recipients
+    assert "Top Recipients:" in captured
+    assert "Recipient A               :    2 ########################################" in captured
+    assert "Recipient B               :    1 ####################" in captured
+
+    # Check Top Conferences
+    assert "Top Conferences:" in captured
+    assert "  1 General               :    2 ########################################" in captured
+    assert "  2 Tech                  :    1 ####################" in captured


### PR DESCRIPTION
This PR improves the usability and visual hierarchy of the `pyqwk` CLI statistics output. 

Previously, the `--stats` command displayed numerical counts for the top authors, recipients, and conferences. While accurate, it lacked immediate visual clarity regarding the relative distribution of messages across these categories.

By introducing relative ASCII bar charts, users can now see at a glance which contributors or conferences are most active. The bars are scaled relative to the highest count in each specific section, maintaining a clean and consistent look.

**Changes:**
- Updated `show_stats` in `pyqwk/core.py` to calculate relative bar lengths and print ASCII bars.
- Improved the alignment of numerical counts in the statistics lists.
- Added `tests/test_stats_ui.py` to ensure the new visual format is correctly rendered and to prevent regressions.

**Screenshots/Example Output:**
```
Top Authors:
    Author A                  :    2 ########################################
    Author B                  :    1 ####################
```

---
*PR created automatically by Jules for task [2727485451805141667](https://jules.google.com/task/2727485451805141667) started by @RainRat*