### PR TITLE
[FEAT] Lossless SQLite Archival with BBS and Conference Metadata

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -730,8 +730,8 @@ class LogFormatter(logging.Formatter):
         return formatter.format(record)
 
 
-def _parse_sqlite_messages(db_path: str) -> list[ParsedMessage]:
-    """Import messages from a pyqwk SQLite database."""
+def _parse_sqlite_messages(db_path: str) -> tuple[list[ParsedMessage], ConferenceMap]:
+    """Import messages and metadata from a pyqwk SQLite database."""
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
     cursor = conn.cursor()
@@ -742,6 +742,29 @@ def _parse_sqlite_messages(db_path: str) -> list[ParsedMessage]:
         conn.close()
         raise ValueError(f"SQLite database is missing the 'messages' table: {e}")
 
+    # Try to load BBS Info
+    bbs_info = BBSInfo()
+    try:
+        cursor.execute("SELECT * FROM bbs_info LIMIT 1")
+        row = cursor.fetchone()
+        if row:
+            for field in fields(BBSInfo):
+                if field.name in row.keys():
+                    setattr(bbs_info, field.name, row[field.name])
+    except sqlite3.OperationalError:
+        pass
+
+    # Try to load Conferences
+    board_dict = ConferenceMap()
+    board_dict.bbs_info = bbs_info
+    try:
+        cursor.execute("SELECT * FROM conferences")
+        for row in cursor.fetchall():
+            board_dict[row['number']] = row['name']
+    except sqlite3.OperationalError:
+        pass
+
+    cursor.execute("SELECT * FROM messages")
     messages = []
     for row in cursor.fetchall():
         # Reconstruct header dict
@@ -776,15 +799,20 @@ def _parse_sqlite_messages(db_path: str) -> list[ParsedMessage]:
             thread_id=row['thread_id'],
             parent_msgnum=row['parent_message_number'],
             confname=row['conference_name'],
-            bbs_name=row['bbs_name'],
-            bbs_id=row['bbs_id'] if 'bbs_id' in row.keys() else None,
+            bbs_name=row['bbs_name'] or bbs_info.name,
+            bbs_id=(row['bbs_id'] if 'bbs_id' in row.keys() else None) or bbs_info.bbs_id,
             source_file=row['source_file'],
             attachments=attachments,
         )
         messages.append(msg)
 
     conn.close()
-    return messages
+
+    # If board_dict is empty, we reconstruct it from messages for backward compatibility
+    if not board_dict:
+        board_dict = _reconstruct_metadata(messages)
+
+    return messages, board_dict
 
 
 def _parse_json_messages(data: list[dict[str, Any]]) -> list[ParsedMessage]:
@@ -1047,11 +1075,10 @@ def load_data(
 
     if input_path.lower().endswith(('.db', '.sqlite')):
         try:
-            messages = _parse_sqlite_messages(input_path)
+            messages, board_dict = _parse_sqlite_messages(input_path)
         except Exception as e:
             raise ValueError(f"Failed to load SQLite archive: {e}")
 
-        board_dict = _reconstruct_metadata(messages)
         return messages, board_dict
 
     if input_path.lower().endswith('.json'):
@@ -1694,6 +1721,7 @@ def process_merged_files(
     sort_buffer: list[tuple[ParsedMessage, dict[int, str]]] = []
     collected_for_index: list[dict[str, Any]] = []
     bbs_info_to_use = None
+    board_dict_to_use = None
     total_attachments = 0
 
     include_header = not settings.no_header and settings.format == 'text'
@@ -1919,6 +1947,8 @@ def process_merged_files(
         user_name = bbs_info.user_name if bbs_info else None
         if bbs_info and not bbs_info_to_use:
             bbs_info_to_use = bbs_info
+        if board_dict and not board_dict_to_use:
+            board_dict_to_use = board_dict
         bbs_key = f"{bbs_info.name}|{bbs_info.bbs_id}" if bbs_info else ""
 
         allowed_conferences = get_allowed_conferences(settings.conferences, board_dict)
@@ -2028,7 +2058,7 @@ def process_merged_files(
                 else collected_messages
             )
             write_messages(
-                ordered_messages, resolved_output_path, settings, bbs_info_to_use
+                ordered_messages, resolved_output_path, settings, bbs_info_to_use, board_dict_to_use
             )
         else:
             potential_files = 1
@@ -2104,6 +2134,7 @@ def _write_json(
     encoding: str = 'utf-8',
     settings: ProcessingSettings | None = None,
     bbs_info: BBSInfo | None = None,
+    board_dict: Mapping[int, str] | None = None,
 ) -> None:
     output_data = [_message_to_dict(msg) for msg in messages]
     output_json = json.dumps(output_data, indent=4, ensure_ascii=False)
@@ -2163,6 +2194,7 @@ def _write_xml(
     encoding: str = 'utf-8',
     settings: ProcessingSettings | None = None,
     bbs_info: BBSInfo | None = None,
+    board_dict: Mapping[int, str] | None = None,
 ) -> None:
     root = ET.Element('messages')
     for message in messages:
@@ -2347,6 +2379,7 @@ def _write_html(
     encoding: str = 'utf-8',
     settings: ProcessingSettings | None = None,
     bbs_info: BBSInfo | None = None,
+    board_dict: Mapping[int, str] | None = None,
 ) -> None:
     title = 'QWK Messages'
     if bbs_info and bbs_info.name:
@@ -2427,6 +2460,7 @@ def _write_markdown(
     encoding: str = 'utf-8',
     settings: ProcessingSettings | None = None,
     bbs_info: BBSInfo | None = None,
+    board_dict: Mapping[int, str] | None = None,
 ) -> None:
     title = 'QWK Messages'
     if bbs_info and bbs_info.name:
@@ -2617,6 +2651,7 @@ def _write_mbox(
     encoding: str = 'utf-8',
     settings: ProcessingSettings | None = None,
     bbs_info: BBSInfo | None = None,
+    board_dict: Mapping[int, str] | None = None,
 ) -> None:
     """Write messages to an mbox file."""
     parts = []
@@ -2632,6 +2667,7 @@ def _write_eml(
     encoding: str = 'utf-8',
     settings: ProcessingSettings | None = None,
     bbs_info: BBSInfo | None = None,
+    board_dict: Mapping[int, str] | None = None,
 ) -> None:
     """Write messages as EML.
 
@@ -2651,6 +2687,7 @@ def _write_text(
     encoding: str = 'utf-8',
     settings: ProcessingSettings | None = None,
     bbs_info: BBSInfo | None = None,
+    board_dict: Mapping[int, str] | None = None,
 ) -> None:
     """Write messages to text format with indentation for threads."""
     parts = []
@@ -2740,6 +2777,7 @@ def _write_csv(
     encoding: str = 'utf-8',
     settings: ProcessingSettings | None = None,
     bbs_info: BBSInfo | None = None,
+    board_dict: Mapping[int, str] | None = None,
 ) -> None:
     output = io.StringIO()
 
@@ -2775,6 +2813,7 @@ def _write_sqlite(
     encoding: str = 'utf-8',
     settings: ProcessingSettings | None = None,
     bbs_info: BBSInfo | None = None,
+    board_dict: Mapping[int, str] | None = None,
 ) -> None:
     if output_path is None:
         raise ValueError("Output path is required for SQLite export.")
@@ -2804,6 +2843,54 @@ def _write_sqlite(
             attachments TEXT
         )
     ''')
+
+    c.execute('''
+        CREATE TABLE IF NOT EXISTS bbs_info (
+            name TEXT,
+            location TEXT,
+            phone TEXT,
+            sysop TEXT,
+            serial_number TEXT,
+            bbs_id TEXT,
+            user_name TEXT,
+            packet_at TEXT,
+            total_messages INTEGER,
+            num_conferences INTEGER
+        )
+    ''')
+
+    if bbs_info:
+        c.execute('''
+            INSERT INTO bbs_info (
+                name, location, phone, sysop, serial_number, bbs_id,
+                user_name, packet_at, total_messages, num_conferences
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ''', (
+            bbs_info.name,
+            bbs_info.location,
+            bbs_info.phone,
+            bbs_info.sysop,
+            bbs_info.serial_number,
+            bbs_info.bbs_id,
+            bbs_info.user_name,
+            bbs_info.packet_at,
+            bbs_info.total_messages,
+            bbs_info.num_conferences,
+        ))
+
+    c.execute('''
+        CREATE TABLE IF NOT EXISTS conferences (
+            number INTEGER PRIMARY KEY,
+            name TEXT
+        )
+    ''')
+
+    if board_dict:
+        for conf_num, conf_name in board_dict.items():
+            c.execute('''
+                INSERT OR REPLACE INTO conferences (number, name)
+                VALUES (?, ?)
+            ''', (conf_num, conf_name))
 
     for msg in messages:
         header = msg.header
@@ -2846,6 +2933,7 @@ def write_messages(
     output_path: str | None,
     settings: ProcessingSettings,
     bbs_info: BBSInfo | None = None,
+    board_dict: Mapping[int, str] | None = None,
 ) -> None:
     """Save a list of messages to a file or print them to the screen.
 
@@ -2855,7 +2943,7 @@ def write_messages(
     writers: dict[
         str,
         Callable[
-            [list[ProcessedMessage], str | None, str, ProcessingSettings, BBSInfo | None],
+            [list[ProcessedMessage], str | None, str, ProcessingSettings, BBSInfo | None, Mapping[int, str] | None],
             None,
         ],
     ] = {
@@ -2875,7 +2963,7 @@ def write_messages(
     if settings.format == 'text':
         output_encoding = settings.encoding
 
-    writer(messages, output_path, output_encoding, settings, bbs_info)
+    writer(messages, output_path, output_encoding, settings, bbs_info, board_dict)
 
 
 def _write_index(

--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -838,7 +838,7 @@ class QwkGuiApp:
                 except (ValueError, IndexError):
                     continue
 
-            write_messages(export_list, path, settings, bbs_info)
+            write_messages(export_list, path, settings, bbs_info, self.board_dict)
 
             messagebox.showinfo(
                 "Export Successful",

--- a/tests/test_sqlite_metadata.py
+++ b/tests/test_sqlite_metadata.py
@@ -1,0 +1,161 @@
+import sqlite3
+import logging
+from pathlib import Path
+import pytest
+from pyqwk.core import (
+    load_data,
+    process_file,
+    ProcessingSettings,
+    ParsedMessage,
+    BBSInfo,
+    ConferenceMap
+)
+
+@pytest.fixture
+def baseline_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "testdata" / "messages.dat"
+
+@pytest.fixture
+def logger():
+    logger = logging.getLogger("pyqwk.tests")
+    logger.addHandler(logging.NullHandler())
+    return logger
+
+def _make_settings(**overrides):
+    defaults = dict(
+        verbose=True,
+        private=True,
+        no_header=False,
+        truncate_signatures=False,
+        cut_quoting=False,
+        individual_files=False,
+        threaded=False,
+        binaries_removal=False,
+        redact_pii=False,
+        format="text",
+        separator="auto",
+        output_mode="stdout",
+        output_path=None,
+        encoding="latin1",
+        quiet=True,
+    )
+    defaults.update(overrides)
+    return ProcessingSettings(**defaults)
+
+def test_sqlite_metadata_preservation(tmp_path, baseline_path, logger):
+    """Test that BBS info and conference names are preserved in SQLite round-trip."""
+    # 1. Create a mock BBSInfo and ConferenceMap
+    bbs = BBSInfo(
+        name="Test BBS",
+        sysop="John Doe",
+        bbs_id="TESTBBS",
+        packet_at="2023-10-27"
+    )
+    boards = ConferenceMap({
+        1: "General Chat",
+        2: "Tech Support",
+        3: "Antique Computers"
+    })
+    boards.bbs_info = bbs
+
+    # 2. Export to SQLite
+    db_path = tmp_path / "metadata_test.db"
+    settings_export = _make_settings(
+        format="sqlite",
+        output_mode="file",
+        output_path=str(db_path)
+    )
+
+    # We need to manually call load_data then write_messages to use our custom metadata
+    # Or mock the environment. Easier: use the existing baseline but ensure its metadata is set.
+    # Actually, process_file will call load_data which finds messages.dat and (optionally) control.dat.
+    # To test OUR metadata, let's write a small helper that uses write_messages directly.
+
+    from pyqwk.core import parse_messages, write_messages
+
+    with open(baseline_path, 'rb') as f:
+        file_data = bytearray(f.read())
+
+    messages = list(parse_messages(file_data, None))
+    # Tag messages with conference names for export consistency
+    for m in messages:
+        m.confname = boards.get(m.confnum)
+
+    write_messages(messages, str(db_path), settings_export, bbs, boards)
+
+    assert db_path.exists()
+
+    # 3. Verify tables exist in the database
+    conn = sqlite3.connect(str(db_path))
+    cursor = conn.cursor()
+
+    cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='bbs_info'")
+    assert cursor.fetchone() is not None
+
+    cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='conferences'")
+    assert cursor.fetchone() is not None
+
+    cursor.execute("SELECT name, sysop, bbs_id FROM bbs_info")
+    row = cursor.fetchone()
+    assert row[0] == "Test BBS"
+    assert row[1] == "John Doe"
+    assert row[2] == "TESTBBS"
+
+    cursor.execute("SELECT name FROM conferences WHERE number=3")
+    row = cursor.fetchone()
+    assert row[0] == "Antique Computers"
+
+    conn.close()
+
+    # 4. Re-import and verify reconstruction
+    imported_messages, imported_boards = load_data(str(db_path), logger)
+
+    assert imported_boards.bbs_info.name == "Test BBS"
+    assert imported_boards.bbs_info.sysop == "John Doe"
+    assert imported_boards[1] == "General Chat"
+    assert imported_boards[3] == "Antique Computers"
+
+    # Ensure messages also have the metadata
+    assert imported_messages[0].bbs_name == "Test BBS"
+    assert imported_messages[0].confname == "Antique Computers" # baseline msg 28 is conf 3
+
+def test_sqlite_backward_compatibility(tmp_path, baseline_path, logger):
+    """Test that SQLite files without metadata tables are still readable."""
+    db_path = tmp_path / "legacy.db"
+
+    # Create a minimal SQLite file with only messages table
+    conn = sqlite3.connect(str(db_path))
+    conn.execute('''
+        CREATE TABLE messages (
+            conference_number INTEGER,
+            message_number INTEGER,
+            date TEXT,
+            author TEXT,
+            recipient TEXT,
+            subject TEXT,
+            status TEXT,
+            text TEXT,
+            reference_number INTEGER,
+            thread_id TEXT,
+            depth INTEGER,
+            parent_message_number INTEGER,
+            conference_name TEXT,
+            bbs_name TEXT,
+            bbs_id TEXT,
+            source_file TEXT,
+            attachments TEXT
+        )
+    ''')
+    conn.execute('''
+        INSERT INTO messages (conference_number, message_number, author, subject, text)
+        VALUES (10, 100, 'Old User', 'Hello', 'Old message body')
+    ''')
+    conn.commit()
+    conn.close()
+
+    # load_data should still work and reconstruct metadata from messages
+    messages, board_dict = load_data(str(db_path), logger)
+
+    assert len(messages) == 1
+    assert messages[0].header.msgfrom == 'Old User'
+    assert board_dict[10] == 'Conference 10' # Default reconstruction


### PR DESCRIPTION
This change implements lossless SQLite archival for QWK packets. Previously, exporting to SQLite only preserved individual messages, losing the BBS context and the full list of conference names.

Key enhancements:
- The SQLite schema now includes `bbs_info` and `conferences` tables.
- The `load_data` and `_parse_sqlite_messages` functions now faithfully reconstruct the `BBSInfo` and `ConferenceMap` (including conference names for conferences without messages) when reading from SQLite.
- All internal message writers and the `write_messages` dispatcher now accept an optional `board_dict` to ensure structural metadata is available during export.
- The Graphical Reader's export feature now correctly passes conference metadata to the writers.
- Backward compatibility is preserved: the tool still reads older SQLite exports by falling back to message-based metadata reconstruction.

Verified with a new test suite (`tests/test_sqlite_metadata.py`) and by running the full 529-item test suite.

---
*PR created automatically by Jules for task [11575196115962688942](https://jules.google.com/task/11575196115962688942) started by @RainRat*