### PR TITLE
[UI/UX] Add message counts to conference selector in GUI

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -2,6 +2,7 @@ import argparse
 import logging
 import os
 import tkinter as tk
+from collections import Counter
 from dataclasses import replace
 from tkinter import filedialog, messagebox, ttk, simpledialog
 
@@ -199,7 +200,10 @@ class QwkGuiApp:
 
     def clear_filters(self, _event: object | None = None) -> None:
         """Reset all filters to their default state."""
-        self.conf_combo.set("All Conferences")
+        try:
+            self.conf_combo.current(0)
+        except Exception:
+            self.conf_combo.set("All Conferences")
         self.has_attach_var.set(False)
         self.mine_var.set(False)
         self.on_this_day_var.set(False)
@@ -392,10 +396,12 @@ class QwkGuiApp:
     def _current_settings(self) -> ProcessingSettings:
         clean = self.clean_var.get()
         search_val = self.search_var.get().strip()
+        if not search_val:
+            search_val = None
 
         selected_conf_name = self.conf_combo.get()
         conferences = None
-        if selected_conf_name and selected_conf_name != "All Conferences":
+        if selected_conf_name and not selected_conf_name.startswith("All Conferences"):
             conf_id = self.conf_mapping.get(selected_conf_name)
             if conf_id is not None:
                 conferences = [str(conf_id)]
@@ -592,6 +598,12 @@ class QwkGuiApp:
         try:
             self.status_label.config(text="Loading...")
             self.root.update_idletasks()
+
+            # If opening a new file, clear stale conference mapping and selection
+            if self._cache.get('path') != path:
+                self.conf_mapping = {}
+                self.conf_combo.set("All Conferences")
+
             settings = self._current_settings()
 
             # Capture current selection to restore it later
@@ -640,13 +652,14 @@ class QwkGuiApp:
                     'file_data': file_data,
                     'board_dict': board_dict
                 }
-                # Populate conference selector
-                conf_list = ["All Conferences"]
-                for cid, name in sorted(board_dict.items()):
-                    conf_list.append(f"{cid}: {name}")
-                self.conf_combo['values'] = conf_list
-                self.conf_combo.set("All Conferences")
-                self.conf_mapping = {f"{cid}: {name}": cid for cid, name in board_dict.items()}
+                # Initial population if first time loading this file
+                if not self.conf_mapping:
+                    conf_list = ["All Conferences"]
+                    for cid, name in sorted(board_dict.items()):
+                        conf_list.append(f"{cid}: {name}")
+                    self.conf_combo['values'] = conf_list
+                    self.conf_combo.set("All Conferences")
+                    self.conf_mapping = {f"{cid}: {name}": cid for cid, name in board_dict.items()}
 
             file_data = self._cache['file_data']
             board_dict = self._cache['board_dict']
@@ -662,27 +675,57 @@ class QwkGuiApp:
             else:
                 messages_to_process = parse_messages(file_data, None, settings.encoding)
 
+            conf_counts = Counter()
+            # Create a settings object without conference filter for counting
+            count_settings = replace(settings, conferences=None)
+
             for parsed_message in messages_to_process:
                 total_count += 1
-                if not matches_filters(parsed_message, settings, allowed_conferences, user_name):
-                    continue
 
-                processed_buffer = process_message(
-                    parsed_message.text,
-                    settings.truncate_signatures,
-                    settings.cut_quoting,
-                    settings.binaries_removal,
-                    settings.redact_pii,
-                    settings.strip_ansi,
-                )
+                # Check if message matches filters ignoring the conference filter itself
+                if matches_filters(parsed_message, count_settings, set(), user_name):
+                    conf_counts[parsed_message.confnum] += 1
 
-                # Ensure attachments are detected for the status icon
-                attachments = parsed_message.attachments
-                if attachments is None and parsed_message.text:
-                    found = extract_binaries(parsed_message.text)
-                    attachments = [name for name, data in found]
+                    # Now apply the actual conference filter for the display list
+                    if not settings.conferences or parsed_message.confnum in allowed_conferences:
+                        processed_buffer = process_message(
+                            parsed_message.text,
+                            settings.truncate_signatures,
+                            settings.cut_quoting,
+                            settings.binaries_removal,
+                            settings.redact_pii,
+                            settings.strip_ansi,
+                        )
 
-                messages.append(replace(parsed_message, text=processed_buffer, attachments=attachments))
+                        # Ensure attachments are detected for the status icon
+                        attachments = parsed_message.attachments
+                        if attachments is None and parsed_message.text:
+                            found = extract_binaries(parsed_message.text)
+                            attachments = [name for name, data in found]
+
+                        messages.append(replace(parsed_message, text=processed_buffer, attachments=attachments))
+
+            # Re-populate conference selector with dynamic counts
+            total_filtered = sum(conf_counts.values())
+            conf_list = [f"All Conferences ({total_filtered})"]
+            new_conf_mapping = {}
+
+            # Map for reverse lookup to preserve the current selection
+            old_selection = self.conf_combo.get()
+            selected_conf_id = self.conf_mapping.get(old_selection)
+            new_selection = conf_list[0]
+
+            for cid, name in sorted(board_dict.items()):
+                count = conf_counts.get(cid, 0)
+                display_str = f"{cid}: {name} ({count})"
+                conf_list.append(display_str)
+                new_conf_mapping[display_str] = cid
+                if cid == selected_conf_id:
+                    new_selection = display_str
+
+            self.conf_combo['values'] = conf_list
+            self.conf_mapping = new_conf_mapping
+            self.conf_combo.set(new_selection)
 
             if settings.threaded:
                 messages = _order_messages_by_thread(messages)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -159,7 +159,7 @@ class TestQwkGui:
         app.mine_var.get.return_value = True
         with patch.object(app, 'reload_messages') as mock_reload:
             app.clear_filters()
-            app.conf_combo.set.assert_called_with("All Conferences")
+            app.conf_combo.current.assert_called_with(0)
             app.has_attach_var.set.assert_called_with(False)
             app.mine_var.set.assert_called_with(False)
             mock_reload.assert_called_once()
@@ -254,9 +254,9 @@ class TestQwkGui:
             mock_load_data.return_value = (bytearray(), {1: "General", 2: "Tech"})
             mock_parse_messages.return_value = []
             app.load_messages("test.qwk")
-            expected_values = ["All Conferences", "1: General", "2: Tech"]
+            expected_values = ["All Conferences (0)", "1: General (0)", "2: Tech (0)"]
             mock_gui_deps["combo"].__setitem__.assert_any_call('values', expected_values)
-            assert app.conf_mapping == {"1: General": 1, "2: Tech": 2}
+            assert app.conf_mapping == {"1: General (0)": 1, "2: Tech (0)": 2}
 
     def test_caching_mechanism(self, mock_gui_deps):
         app = get_app()
@@ -695,10 +695,10 @@ class TestQwkGui:
             app.load_messages("test.qwk")
 
             # Check if Conf 99 was added to dropdown
-            # Values are ["All Conferences", "1: General", "99: Conference 99"]
-            expected_values = ["All Conferences", "1: General", "99: Conference 99"]
+            # Values are ["All Conferences (1)", "1: General (0)", "99: Conference 99 (1)"]
+            expected_values = ["All Conferences (1)", "1: General (0)", "99: Conference 99 (1)"]
             mock_gui_deps["combo"].__setitem__.assert_any_call('values', expected_values)
-            assert app.conf_mapping["99: Conference 99"] == 99
+            assert app.conf_mapping["99: Conference 99 (1)"] == 99
 
             # Test exception handling in discovery phase
             # Reset cache to force a new load_data call

--- a/tests/test_gui_conf_counts.py
+++ b/tests/test_gui_conf_counts.py
@@ -1,0 +1,92 @@
+import pytest
+from unittest.mock import MagicMock, patch
+from pyqwk.core import ParsedMessage, MessageHeader
+
+# Re-use setup from test_gui if possible, but for simplicity we'll do a quick mock here
+# since we only need to test load_messages and counts.
+
+@pytest.fixture
+def mock_gui_deps():
+    with patch("pyqwk.gui.tk") as mock_tk, \
+         patch("pyqwk.gui.ttk") as mock_ttk, \
+         patch("pyqwk.gui.filedialog") as mock_fd, \
+         patch("pyqwk.gui.messagebox") as mock_mb:
+
+        def make_var(value=None):
+            m = MagicMock()
+            m.get.return_value = value
+            return m
+
+        mock_tk.BooleanVar.side_effect = lambda value=False, **kwargs: make_var(value)
+        mock_tk.StringVar.side_effect = lambda value="", **kwargs: make_var(value)
+        mock_tk.IntVar.side_effect = lambda value=0, **kwargs: make_var(value)
+
+        yield {
+            "tk": mock_tk,
+            "ttk": mock_ttk,
+            "combo": mock_ttk.Combobox.return_value
+        }
+
+def test_gui_conference_counts(mock_gui_deps):
+    from pyqwk.gui import QwkGuiApp
+    root = MagicMock()
+    app = QwkGuiApp(root)
+
+    # Mock data
+    h1 = MessageHeader(' ', 1, "01-01-90", "12:00", "To", "From", "Sub", "", None, 1, " ", 1, 1, "")
+    h2 = MessageHeader(' ', 2, "01-01-90", "12:00", "To", "From", "Sub", "", None, 1, " ", 2, 2, "")
+    h3 = MessageHeader('*', 3, "01-01-90", "12:00", "To", "From", "Sub", "", None, 1, " ", 1, 3, "") # Private
+
+    msgs = [
+        ParsedMessage("M1", 1, None, 1, h1),
+        ParsedMessage("M2", 2, None, 2, h2),
+        ParsedMessage("M3", 3, None, 1, h3),
+    ]
+
+    mock_board_dict = {1: "General", 2: "Tech"}
+
+    with patch("pyqwk.gui.load_data", return_value=(bytearray(), mock_board_dict)), \
+         patch("pyqwk.gui.parse_messages", return_value=msgs), \
+         patch("pyqwk.gui.process_message", side_effect=lambda t, *args: t), \
+         patch.object(app, "on_message_selected"):
+
+        # 1. Test with Private=True (default in init)
+        app.private_var.get.return_value = True
+        app.load_messages("test.qwk")
+
+        # All Conferences (3), General (2), Tech (1)
+        expected_values = ["All Conferences (3)", "1: General (2)", "2: Tech (1)"]
+        mock_gui_deps["combo"].__setitem__.assert_any_call('values', expected_values)
+
+        # 2. Test with Private=False
+        app.private_var.get.return_value = False
+        app.load_messages("test.qwk")
+
+        # All Conferences (2), General (1), Tech (1)
+        expected_values_no_private = ["All Conferences (2)", "1: General (1)", "2: Tech (1)"]
+        mock_gui_deps["combo"].__setitem__.assert_any_call('values', expected_values_no_private)
+
+def test_gui_selection_preservation(mock_gui_deps):
+    from pyqwk.gui import QwkGuiApp
+    root = MagicMock()
+    app = QwkGuiApp(root)
+
+    h1 = MessageHeader(' ', 1, "01-01-90", "12:00", "To", "From", "Sub", "", None, 1, " ", 1, 1, "")
+    msgs = [ParsedMessage("M1", 1, None, 1, h1)]
+    mock_board_dict = {1: "General"}
+
+    with patch("pyqwk.gui.load_data", return_value=(bytearray(), mock_board_dict)), \
+         patch("pyqwk.gui.parse_messages", return_value=msgs), \
+         patch("pyqwk.gui.process_message", side_effect=lambda t, *args: t), \
+         patch.object(app, "on_message_selected"):
+
+        # Initial load
+        app.load_messages("test.qwk")
+        mock_gui_deps["combo"].set.assert_called_with("All Conferences (1)")
+
+        # Select "General"
+        app.conf_combo.get.return_value = "1: General (1)"
+        app.load_messages("test.qwk") # Reload (e.g. toggled a filter)
+
+        # Should preserve selection
+        mock_gui_deps["combo"].set.assert_called_with("1: General (1)")


### PR DESCRIPTION
This improvement adds dynamic message counts to the conference selector in the Graphical Reader. 

- **Context:** GUI (Tkinter)
- **Problem:** When browsing a BBS archive, many conferences may be empty or contain very few messages. Users previously had to select each conference manually to check for content.
- **Solution:** The conference dropdown now displays the number of matching messages next to each conference name (e.g., "General (42)"). This provides immediate "information scent," allowing users to see where the active discussions are without trial and error. The counts update dynamically as filters (like Search or "Include Private") are toggled.

Technical changes include:
- Refactoring `load_messages` to perform a single pass for both counting and filtering.
- Updating state management to ensure the user's selection is preserved even when display strings change.
- Enhancing robustness of the "All Conferences" detection and filter reset logic.
- Expanded test coverage to verify count accuracy and UI stability.

---
*PR created automatically by Jules for task [2207865826108855841](https://jules.google.com/task/2207865826108855841) started by @RainRat*