### PR TITLE
[FEAT] Keyword Analysis for Archive Statistics

### DIFF
--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -98,7 +98,7 @@ examples:
   # Extract attachments (UUE, yEnc, Base64) to an attachments/ folder
   qwk archive.qwk --extract-attachments
 
-  # Show detailed statistics about an archive
+  # Show detailed statistics about an archive (authors, conferences, keywords, etc.)
   qwk archive.qwk --stats
 """,
     )

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -111,6 +111,17 @@ RE_SUBJECT_PREFIX_PATTERN = re.compile(
 
 RE_ANSI_ESCAPE_PATTERN = re.compile(r'\x1b\[[0-?]*[ -/]*[@-~]')
 
+DEFAULT_STOP_WORDS = {
+    'the', 'and', 'for', 'that', 'this', 'with', 'from', 'have', 'was', 'were',
+    'but', 'not', 'are', 'you', 'your', 'his', 'her', 'they', 'them', 'their',
+    'will', 'can', 'has', 'had', 'been', 'which', 'who', 'how', 'when', 'where',
+    'all', 'any', 'some', 'there', 'what', 'about', 'just', 'more', 'very',
+    'than', 'then', 'also', 'only', 'even', 'into', 'most', 'well', 'would',
+    'could', 'should', 'these', 'those', 'much', 'many', 'once', 'here', 'back',
+    'still', 'over', 'must', 'does', 'made', 'said', 'went', 'came', 'down',
+    'give', 'take', 'find', 'look', 'work', 'part',
+}
+
 SIGNATURE_PATTERNS_EXACT = {
     "---",
     "___",
@@ -3277,6 +3288,7 @@ def show_stats(input_paths: list[str], settings: ProcessingSettings, logger: log
             "recipients": [],
             "conferences": [],
             "subjects": [],
+            "keywords": [],
             "attachments_count": 0,
             "day_of_week": {},
             "hour_of_day": {},
@@ -3293,6 +3305,7 @@ def show_stats(input_paths: list[str], settings: ProcessingSettings, logger: log
             recipient_counter = Counter()
             conf_counter = Counter()
             subject_counter = Counter()
+            keyword_counter = Counter()
             dow_counter = Counter()
             hour_counter = Counter()
 
@@ -3370,6 +3383,12 @@ def show_stats(input_paths: list[str], settings: ProcessingSettings, logger: log
                         found_binaries = extract_binaries(message.text)
                         attachments_count += len(found_binaries)
 
+                        # Keyword analysis
+                        words = re.findall(r'\b\w{3,}\b', message.text.lower())
+                        for word in words:
+                            if word not in DEFAULT_STOP_WORDS and not word.isdigit():
+                                keyword_counter[word] += 1
+
             stats_entry["total_messages"] = total_count
             stats_entry["matching_messages"] = processed_count
             stats_entry["private_count"] = private_count
@@ -3384,6 +3403,7 @@ def show_stats(input_paths: list[str], settings: ProcessingSettings, logger: log
             stats_entry["recipients"] = [{"name": n, "count": c} for n, c in recipient_counter.most_common(10)]
             stats_entry["conferences"] = [{"number": n, "name": board_dict.get(n, str(n)), "count": c} for n, c in conf_counter.most_common(10)]
             stats_entry["subjects"] = [{"subject": s, "count": c} for s, c in subject_counter.most_common(10)]
+            stats_entry["keywords"] = [{"word": w, "count": c} for w, c in keyword_counter.most_common(10)]
             stats_entry["day_of_week"] = dict(dow_counter)
             stats_entry["hour_of_day"] = {str(k): v for k, v in hour_counter.items()}
 
@@ -3420,6 +3440,22 @@ def show_stats(input_paths: list[str], settings: ProcessingSettings, logger: log
                         conf_name = conf['name'][:21]
                         bar = "#" * int(conf['count'] * 40 / max_conf_count) if max_conf_count > 0 else ""
                         print(f"    {conf['number']:3} {conf_name:21} : {conf['count']:4} {bar}")
+
+                if subject_counter:
+                    print(f"\n  {_colorize('Top Subjects:', BOLD)}")
+                    max_subj_count = max(subject_counter.values())
+                    for subj in stats_entry["subjects"]:
+                        subject_text = subj['subject'][:25]
+                        bar = "#" * int(subj['count'] * 40 / max_subj_count) if max_subj_count > 0 else ""
+                        print(f"    {subject_text:25} : {subj['count']:4} {bar}")
+
+                if keyword_counter:
+                    print(f"\n  {_colorize('Top Keywords:', BOLD)}")
+                    max_key_count = max(keyword_counter.values())
+                    for kw in stats_entry["keywords"]:
+                        keyword_text = kw['word'][:25]
+                        bar = "#" * int(kw['count'] * 40 / max_key_count) if max_key_count > 0 else ""
+                        print(f"    {keyword_text:25} : {kw['count']:4} {bar}")
 
                 if dow_counter:
                     print(f"\n  {_colorize('Day of Week Distribution:', BOLD)}")

--- a/tests/test_stats_enhanced.py
+++ b/tests/test_stats_enhanced.py
@@ -1,0 +1,114 @@
+import json
+from unittest.mock import MagicMock
+from pyqwk.core import show_stats, ProcessingSettings, ParsedMessage, MessageHeader, ConferenceMap
+
+def test_stats_enhanced_keywords(capsys):
+    # Setup mock data
+    msg1 = ParsedMessage(
+        text="Hello world, this is a test message about Bulletin Board Systems. BBS are cool.",
+        msgnum=1,
+        refnum=None,
+        confnum=1,
+        header=MessageHeader(
+            status=" ", msgnum=1, msgdate="01-01-90", msgtime="12:00",
+            msgto="All", msgfrom="Sysop", msgsubject="Welcome",
+            msgpassword="", refnum=None, numblocks=1, msgflag=" ",
+            confnum=1, lognum=1, nettag=""
+        )
+    )
+
+    msg2 = ParsedMessage(
+        text="The Bulletin Board System (BBS) was popular in the 80s and 90s.",
+        msgnum=2,
+        refnum=None,
+        confnum=1,
+        header=MessageHeader(
+            status=" ", msgnum=2, msgdate="01-01-90", msgtime="13:00",
+            msgto="All", msgfrom="User", msgsubject="History",
+            msgpassword="", refnum=None, numblocks=1, msgflag=" ",
+            confnum=1, lognum=1, nettag=""
+        )
+    )
+
+    # Mock load_data to return our pre-parsed messages
+    mock_logger = MagicMock()
+    board_dict = ConferenceMap({1: "General"})
+
+    import pyqwk.core
+    original_load_data = pyqwk.core.load_data
+    pyqwk.core.load_data = MagicMock(return_value=([msg1, msg2], board_dict))
+
+    settings = ProcessingSettings(
+        verbose=False, private=True, no_header=False, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False,
+        binaries_removal=False, redact_pii=False, format='json',
+        separator='none', output_mode='stdout', output_path=None,
+        encoding='cp437', quiet=True
+    )
+
+    try:
+        show_stats(["mock.qwk"], settings, mock_logger)
+        captured = capsys.readouterr()
+
+        # Parse JSON output
+        stats = json.loads(captured.out)
+
+        assert len(stats) == 1
+        entry = stats[0]
+
+        # Verify keywords
+        keywords = {kw['word']: kw['count'] for kw in entry['keywords']}
+        assert 'bulletin' in keywords
+        assert 'board' in keywords
+        assert 'system' in keywords
+        assert keywords['bulletin'] >= 2
+
+        # Verify subjects
+        subjects = {s['subject']: s['count'] for s in entry['subjects']}
+        assert 'welcome' in subjects
+        assert 'history' in subjects
+
+    finally:
+        pyqwk.core.load_data = original_load_data
+
+def test_stats_enhanced_terminal_output(capsys):
+    # Similar setup but for text format to check labels
+    msg = ParsedMessage(
+        text="Electronic mail is fast.",
+        msgnum=1,
+        refnum=None,
+        confnum=1,
+        header=MessageHeader(
+            status=" ", msgnum=1, msgdate="01-01-90", msgtime="12:00",
+            msgto="All", msgfrom="Sysop", msgsubject="Email",
+            msgpassword="", refnum=None, numblocks=1, msgflag=" ",
+            confnum=1, lognum=1, nettag=""
+        )
+    )
+
+    mock_logger = MagicMock()
+    board_dict = ConferenceMap({1: "General"})
+
+    import pyqwk.core
+    original_load_data = pyqwk.core.load_data
+    pyqwk.core.load_data = MagicMock(return_value=([msg], board_dict))
+
+    settings = ProcessingSettings(
+        verbose=False, private=True, no_header=False, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False,
+        binaries_removal=False, redact_pii=False, format='text',
+        separator='none', output_mode='stdout', output_path=None,
+        encoding='cp437', quiet=True
+    )
+
+    try:
+        show_stats(["mock.qwk"], settings, mock_logger)
+        captured = capsys.readouterr()
+
+        assert "Top Subjects:" in captured.out
+        assert "Top Keywords:" in captured.out
+        assert "electronic" in captured.out.lower()
+        assert "mail" in captured.out.lower()
+
+    finally:
+        pyqwk.core.load_data = original_load_data


### PR DESCRIPTION
This pull request introduces **Keyword Analysis** to the `pyqwk` statistics engine. By analyzing message bodies and filtering out common stop words, the tool now provides deeper insights into the primary topics of discussion within a QWK archive.

### Key Changes:
- **Keyword Extraction:** Added logic to tokenize message text and count significant terms (3+ characters, non-numeric, non-stop-word).
- **Expanded Stats UI:** The terminal output for `--stats` now includes "Top Subjects" (which was previously collected but not displayed) and the new "Top Keywords" section, both using the established ASCII bar chart style.
- **JSON Support:** The JSON export for statistics now includes a `keywords` field containing the top 10 most frequent terms and their counts.
- **Refined Stop Words:** Included a deduplicated set of common English stop words in `pyqwk/core.py`.
- **Testing:** Added `tests/test_stats_enhanced.py` to ensure correct calculation and formatting of the new statistics.

This feature enhances the analytical value of `pyqwk` for users exploring historical message archives.

---
*PR created automatically by Jules for task [17961853829423038818](https://jules.google.com/task/17961853829423038818) started by @RainRat*