### PR TITLE
[FEAT] Multi-archive support in Graphical Reader and Merged Statistics

### DIFF
--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -9,6 +9,7 @@ from pyqwk.core import (
     PROCESSING_EXCEPTIONS,
     ProcessingSettings,
     __version__,
+    expand_paths,
     process_file,
     process_merged_files,
     process_multiple_files,
@@ -17,21 +18,6 @@ from pyqwk.core import (
     show_info,
     show_stats,
 )
-
-
-def _expand_directories(paths: list[str]) -> list[str]:
-    """Recursively find supported QWK files in directories."""
-    expanded_paths = []
-    for path in paths:
-        if os.path.isdir(path):
-            for root, _, files in os.walk(path):
-                for file in files:
-                    lower_file = file.lower()
-                    if lower_file.endswith(('.qwk', '.zip', '.rep', '.json', '.csv', '.db', '.sqlite', '.xml', '.mbox', '.eml')) or lower_file == 'messages.dat':
-                        expanded_paths.append(os.path.join(root, file))
-        else:
-            expanded_paths.append(path)
-    return sorted(expanded_paths)
 
 
 def _parse_msgnum_ranges(msgnum_str: str | None) -> set[int] | None:
@@ -401,6 +387,11 @@ examples:
         help='Show message stats like timing, reply rates, and common keywords. This respects your filters. Use --format json for JSON output.',
     )
     parser.add_argument(
+        '--merge-stats',
+        action='store_true',
+        help='When used with multiple archives and --stats, show a single merged report instead of individual ones.',
+    )
+    parser.add_argument(
         '-V',
         '--version',
         action='version',
@@ -425,7 +416,7 @@ examples:
     logger = logging.getLogger(__name__)
 
     has_directory_input = any(os.path.isdir(p) for p in args.input_paths)
-    input_paths = _expand_directories(args.input_paths)
+    input_paths = expand_paths(args.input_paths)
     output_path = args.output_path
 
     if not input_paths:
@@ -528,6 +519,7 @@ examples:
         has_attachments=args.has_attachments,
         mine=args.mine,
         on_this_day=args.on_this_day,
+        merge_stats=args.merge_stats,
     )
 
     if args.organize_by_bbs:

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -33,6 +33,20 @@ MESSAGES_FILENAME = 'messages.dat'
 REPLY_FILENAME = 'reply.dat'
 CONTROL_FILENAME = 'control.dat'
 
+def expand_paths(paths: list[str]) -> list[str]:
+    """Recursively find supported QWK files in directories."""
+    expanded_paths = []
+    for path in paths:
+        if os.path.isdir(path):
+            for root, _, files in os.walk(path):
+                for file in files:
+                    lower_file = file.lower()
+                    if lower_file.endswith(('.qwk', '.zip', '.rep', '.json', '.csv', '.db', '.sqlite', '.xml', '.mbox', '.eml')) or lower_file == 'messages.dat':
+                        expanded_paths.append(os.path.join(root, file))
+        else:
+            expanded_paths.append(path)
+    return sorted(expanded_paths)
+
 FORMAT_EXTENSIONS = {
     'text': '.txt',
     'json': '.json',
@@ -358,6 +372,7 @@ class ProcessingSettings:
     mine: bool = False
     on_this_day: bool = False
     reference_date: datetime.datetime | None = None
+    merge_stats: bool = False
 
 
 @dataclass
@@ -3277,13 +3292,13 @@ def show_info(input_paths: list[str], settings: ProcessingSettings, logger: logg
 
 
 def calculate_archive_stats(
-    input_path: str,
+    input_paths: list[str],
     settings: ProcessingSettings,
     logger: logging.Logger
 ) -> dict[str, Any]:
-    """Calculate detailed statistics for a single archive."""
+    """Calculate detailed statistics for one or more archives."""
     stats_entry: dict[str, Any] = {
-        "file": input_path,
+        "file": input_paths[0] if len(input_paths) == 1 else "Multiple Archives",
         "total_messages": 0,
         "matching_messages": 0,
         "dates": {"earliest": None, "latest": None},
@@ -3303,14 +3318,10 @@ def calculate_archive_stats(
         "avg_message_length": 0.0,
     }
 
-    file_data, board_dict = load_data(input_path, logger, settings.encoding)
-    bbs_info = getattr(board_dict, 'bbs_info', None)
-    user_name = bbs_info.user_name if bbs_info else None
-    allowed_conferences = get_allowed_conferences(settings.conferences, board_dict)
-
     author_counter: Counter = Counter()
     recipient_counter: Counter = Counter()
     conf_counter: Counter = Counter()
+    conf_names: dict[int, str] = {}
     subject_counter: Counter = Counter()
     keyword_counter: Counter = Counter()
     dow_counter: Counter = Counter()
@@ -3328,79 +3339,89 @@ def calculate_archive_stats(
     reply_count = 0
     total_chars = 0
 
-    desc = f"Analyzing {os.path.basename(input_path)}"
-    need_body = True
+    for input_path in input_paths:
+        file_data, board_dict = load_data(input_path, logger, settings.encoding)
+        bbs_info = getattr(board_dict, 'bbs_info', None)
+        user_name = bbs_info.user_name if bbs_info else None
+        allowed_conferences = get_allowed_conferences(settings.conferences, board_dict)
 
-    is_structured = isinstance(file_data, list)
-    total_progress = len(file_data)
+        for num, name in board_dict.items():
+            if num not in conf_names:
+                conf_names[num] = name
 
-    with _create_progress_bar(total_progress, settings.quiet, desc=desc) as progress_bar:
-        if is_structured:
-            messages_to_process = file_data
-            if progress_bar is not None:
-                progress_bar.unit = 'msg'
-                progress_bar.unit_scale = False
-        else:
-            messages_to_process = parse_messages(
-                file_data, progress_bar, settings.encoding, headers_only=not need_body
-            )
+        desc = f"Analyzing {os.path.basename(input_path)}"
+        need_body = True
 
-        for message in messages_to_process:
-            if is_structured and progress_bar is not None:
-                progress_bar.update(1)
-            total_count += 1
+        is_structured = isinstance(file_data, list)
+        total_progress = len(file_data)
 
-            if not matches_filters(message, settings, allowed_conferences, user_name):
-                continue
+        with _create_progress_bar(total_progress, settings.quiet, desc=desc) as progress_bar:
+            if is_structured:
+                messages_to_process = file_data
+                if progress_bar is not None:
+                    progress_bar.unit = 'msg'
+                    progress_bar.unit_scale = False
+            else:
+                messages_to_process = parse_messages(
+                    file_data, progress_bar, settings.encoding, headers_only=not need_body
+                )
 
-            matching_count += 1
+            for message in messages_to_process:
+                if is_structured and progress_bar is not None:
+                    progress_bar.update(1)
+                total_count += 1
 
-            if settings.skip is not None and matching_count <= settings.skip:
-                continue
+                if not matches_filters(message, settings, allowed_conferences, user_name):
+                    continue
 
-            if settings.limit is not None and processed_count >= settings.limit:
-                break
-            processed_count += 1
+                matching_count += 1
 
-            # Date/Time
-            dt = _parse_qwk_date(message.header.msgdate, message.header.msgtime)
-            if earliest_dt is None or dt < earliest_dt:
-                earliest_dt = dt
-            if latest_dt is None or dt > latest_dt:
-                latest_dt = dt
+                if settings.skip is not None and matching_count <= settings.skip:
+                    continue
 
-            author_counter[message.header.msgfrom.strip()] += 1
-            recipient_counter[message.header.msgto.strip()] += 1
-            conf_counter[message.confnum] += 1
-            subject_counter[_normalize_subject(message.header.msgsubject)] += 1
+                if settings.limit is not None and processed_count >= settings.limit:
+                    break
+                processed_count += 1
 
-            dow_counter[dt.strftime('%A')] += 1
-            hour_counter[dt.hour] += 1
-            year_counter[dt.year] += 1
-            month_counter[dt.strftime('%Y-%m')] += 1
+                # Date/Time
+                dt = _parse_qwk_date(message.header.msgdate, message.header.msgtime)
+                if earliest_dt is None or dt < earliest_dt:
+                    earliest_dt = dt
+                if latest_dt is None or dt > latest_dt:
+                    latest_dt = dt
 
-            if message.header.is_private:
-                private_count += 1
+                author_counter[message.header.msgfrom.strip()] += 1
+                recipient_counter[message.header.msgto.strip()] += 1
+                conf_counter[message.confnum] += 1
+                subject_counter[_normalize_subject(message.header.msgsubject)] += 1
 
-            # Detect if it's a reply
-            is_reply = (
-                (message.header.refnum is not None and message.header.refnum != 0)
-                or RE_SUBJECT_PREFIX_PATTERN.match(message.header.msgsubject)
-            )
-            if is_reply:
-                reply_count += 1
+                dow_counter[dt.strftime('%A')] += 1
+                hour_counter[dt.hour] += 1
+                year_counter[dt.year] += 1
+                month_counter[dt.strftime('%Y-%m')] += 1
 
-            # Check for attachments in the full message
-            if message.text:
-                total_chars += len(message.text)
-                found_binaries = extract_binaries(message.text)
-                attachments_count += len(found_binaries)
+                if message.header.is_private:
+                    private_count += 1
 
-                # Keyword analysis
-                words = re.findall(r'\b\w{3,}\b', message.text.lower())
-                for word in words:
-                    if word not in DEFAULT_STOP_WORDS and not word.isdigit():
-                        keyword_counter[word] += 1
+                # Detect if it's a reply
+                is_reply = (
+                    (message.header.refnum is not None and message.header.refnum != 0)
+                    or RE_SUBJECT_PREFIX_PATTERN.match(message.header.msgsubject)
+                )
+                if is_reply:
+                    reply_count += 1
+
+                # Check for attachments in the full message
+                if message.text:
+                    total_chars += len(message.text)
+                    found_binaries = extract_binaries(message.text)
+                    attachments_count += len(found_binaries)
+
+                    # Keyword analysis
+                    words = re.findall(r'\b\w{3,}\b', message.text.lower())
+                    for word in words:
+                        if word not in DEFAULT_STOP_WORDS and not word.isdigit():
+                            keyword_counter[word] += 1
 
     stats_entry["total_messages"] = total_count
     stats_entry["matching_messages"] = processed_count
@@ -3417,7 +3438,7 @@ def calculate_archive_stats(
     # Top 10
     stats_entry["authors"] = [{"name": n, "count": c} for n, c in author_counter.most_common(10)]
     stats_entry["recipients"] = [{"name": n, "count": c} for n, c in recipient_counter.most_common(10)]
-    stats_entry["conferences"] = [{"number": n, "name": board_dict.get(n, str(n)), "count": c} for n, c in conf_counter.most_common(10)]
+    stats_entry["conferences"] = [{"number": n, "name": conf_names.get(n, str(n)), "count": c} for n, c in conf_counter.most_common(10)]
     stats_entry["subjects"] = [{"subject": s, "count": c} for s, c in subject_counter.most_common(10)]
     stats_entry["keywords"] = [{"word": w, "count": c} for w, c in keyword_counter.most_common(10)]
     stats_entry["day_of_week"] = dict(dow_counter)
@@ -3513,14 +3534,23 @@ def show_stats(input_paths: list[str], settings: ProcessingSettings, logger: log
         and sys.stdout.isatty()
     )
 
-    for input_path in input_paths:
+    if settings.merge_stats:
         try:
-            stats_entry = calculate_archive_stats(input_path, settings, logger)
+            stats_entry = calculate_archive_stats(input_paths, settings, logger)
             if settings.format != 'json':
                 print(render_stats_as_text(stats_entry, use_colors=use_colors))
             all_stats.append(stats_entry)
         except PROCESSING_EXCEPTIONS as e:
-            logger.error(f"Error calculating stats for {input_path}: {e}")
+            logger.error(f"Error calculating merged stats: {e}")
+    else:
+        for input_path in input_paths:
+            try:
+                stats_entry = calculate_archive_stats([input_path], settings, logger)
+                if settings.format != 'json':
+                    print(render_stats_as_text(stats_entry, use_colors=use_colors))
+                all_stats.append(stats_entry)
+            except PROCESSING_EXCEPTIONS as e:
+                logger.error(f"Error calculating stats for {input_path}: {e}")
 
     if settings.format == 'json':
         print(json.dumps(all_stats, indent=4, ensure_ascii=False))

--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -21,10 +21,24 @@ from pyqwk.core import (
     extract_binaries,
     calculate_archive_stats,
     render_stats_as_text,
+    expand_paths,
+    ConferenceMap,
 )
 
 
 class QwkGuiApp:
+    @property
+    def current_path(self) -> str | None:
+        """Return the first path in current_paths for backward compatibility."""
+        return self.current_paths[0] if self.current_paths else None
+
+    @current_path.setter
+    def current_path(self, value: str | None) -> None:
+        if value is None:
+            self.current_paths = []
+        else:
+            self.current_paths = [value]
+
     def __init__(self, root: tk.Tk, initial_path: str | None = None) -> None:
         self.root = root
         self.root.title("PyQWK Reader")
@@ -34,7 +48,7 @@ class QwkGuiApp:
 
         self.messages = []
         self.board_dict: dict[int, str] = {}
-        self.current_path: str | None = None
+        self.current_paths: list[str] = []
         self._cache = {}
         self.conf_mapping = {}
 
@@ -67,8 +81,8 @@ class QwkGuiApp:
         self._build_layout()
 
         if initial_path:
-            self.current_path = initial_path
-            self.root.after(100, lambda: self.load_messages(initial_path))
+            self.current_paths = [initial_path]
+            self.root.after(100, lambda: self.load_messages(self.current_paths))
         else:
             self.root.after(100, self._render_welcome_screen)
 
@@ -109,7 +123,10 @@ class QwkGuiApp:
         menubar = tk.Menu(self.root)
         file_menu = tk.Menu(menubar, tearoff=0)
         file_menu.add_command(
-            label="Open...", command=self.open_file, accelerator="Ctrl+O"
+            label="Open Archive(s)...", command=self.open_file, accelerator="Ctrl+O"
+        )
+        file_menu.add_command(
+            label="Open Folder...", command=self.open_folder
         )
         file_menu.add_command(
             label="Export Current View...",
@@ -239,6 +256,7 @@ class QwkGuiApp:
         actions_frame.pack(side=tk.LEFT, padx=5)
         ttk.Label(actions_frame, text="File:").pack(side=tk.LEFT)
         ttk.Button(actions_frame, text="Open", command=self.open_file).pack(side=tk.LEFT, padx=(5, 2))
+        ttk.Button(actions_frame, text="Folder", command=self.open_folder).pack(side=tk.LEFT, padx=2)
         ttk.Button(actions_frame, text="Export", command=self.export_messages).pack(side=tk.LEFT, padx=2)
         ttk.Button(actions_frame, text="Stats", command=self.show_stats_window).pack(side=tk.LEFT, padx=2)
 
@@ -465,6 +483,9 @@ class QwkGuiApp:
         insert_field("Date", f"{header.msgdate} {header.msgtime}")
         insert_field("Conf", conf_name, last_in_row=True)
 
+        if message.source_file:
+            insert_field("Source", message.source_file, last_in_row=True)
+
         if header.msgnum is not None or message.refnum:
             if header.msgnum is not None:
                 self.detail_text.insert(tk.END, "Msg #: ", "header_label")
@@ -551,14 +572,28 @@ class QwkGuiApp:
             ("messages.dat", "messages.dat"),
             ("All files", "*.*"),
         ]
-        path = filedialog.askopenfilename(
-            title="Open QWK archive",
+        paths = filedialog.askopenfilenames(
+            title="Open Archive(s)",
             filetypes=filetypes,
         )
-        if not path:
+        if not paths:
             return
-        self.current_path = path
-        self.load_messages(path)
+        self.current_paths = list(paths)
+        self.load_messages(self.current_paths)
+
+    def open_folder(self, _event: object | None = None) -> None:
+        """Open all archives in a selected directory."""
+        folder = filedialog.askdirectory(title="Select Folder with Archives")
+        if not folder:
+            return
+
+        paths = expand_paths([folder])
+        if not paths:
+            messagebox.showinfo("Open Folder", "No supported message archives found in the selected folder.")
+            return
+
+        self.current_paths = paths
+        self.load_messages(self.current_paths)
 
     def _on_search_changed(self, *args: object) -> None:
         """Handle search term changes with debouncing to improve UI responsiveness."""
@@ -576,8 +611,8 @@ class QwkGuiApp:
             self.root.after_cancel(self._search_timer)
             self._search_timer = None
 
-        if self.current_path:
-            self.load_messages(self.current_path)
+        if self.current_paths:
+            self.load_messages(self.current_paths)
 
     def _reset_column_headers(self) -> None:
         """Reset all column headers to their original labels without sort indicators."""
@@ -596,21 +631,32 @@ class QwkGuiApp:
                 command=lambda c=col: self.sort_column(c, False)
             )
 
-    def load_messages(self, path: str) -> None:
+    def load_messages(self, paths: str | list[str]) -> None:
+        if isinstance(paths, str):
+            paths = [paths]
+
         # Save current state for potential restoration on failure
         old_messages = self.messages
         old_board_dict = self.board_dict
         old_cache = self._cache
-        old_path = self.current_path
+        old_paths = self.current_paths
 
         try:
             self.status_label.config(text="Loading...")
             self.root.update_idletasks()
 
-            # If opening a new file, clear stale conference mapping and selection
-            if self._cache.get('path') != path:
+            # For now, we only cache single file loads. Multi-file loads are re-processed.
+            # In a future version, we could cache per path.
+            if len(paths) == 1:
+                path = paths[0]
+                # If opening a new file, clear stale conference mapping and selection
+                if self._cache.get('path') != path:
+                    self.conf_mapping = {}
+                    self.conf_combo.set("All Conferences")
+            else:
                 self.conf_mapping = {}
                 self.conf_combo.set("All Conferences")
+                self._cache = {}
 
             settings = self._current_settings()
 
@@ -631,12 +677,24 @@ class QwkGuiApp:
             # Reset headers to remove any previous sort indicators
             self._reset_column_headers()
 
-            # Cache file data to improve responsiveness during filtering
-            if self._cache.get('path') != path:
-                file_data, board_dict = load_data(path, self.logger, settings.encoding)
+            all_messages = []
+            merged_board_dict = ConferenceMap()
+            total_count = 0
+            conf_counts = Counter()
 
-                # Ensure all conferences present in the data are in the dropdown,
-                # even if CONTROL.DAT is missing or incomplete.
+            for path in paths:
+                if len(paths) == 1 and self._cache.get('path') == path:
+                    file_data = self._cache['file_data']
+                    board_dict = self._cache['board_dict']
+                else:
+                    file_data, board_dict = load_data(path, self.logger, settings.encoding)
+
+                bbs_info = getattr(board_dict, "bbs_info", None)
+                if not merged_board_dict.bbs_info:
+                    merged_board_dict.bbs_info = bbs_info
+                user_name = bbs_info.user_name if bbs_info else None
+
+                # Reconstruct/Discovery of conferences
                 try:
                     found_confs = set()
                     if isinstance(file_data, list):
@@ -648,70 +706,63 @@ class QwkGuiApp:
                         ):
                             found_confs.add(parsed_message.confnum)
 
-                    for cid in sorted(found_confs):
+                    for cid in found_confs:
                         if cid not in board_dict:
                             board_dict[cid] = f"Conference {cid}"
                 except Exception:
-                    # If discovery fails, we proceed with whatever load_data found
                     pass
 
+                # Merge into global board dict
+                for cid, name in board_dict.items():
+                    if cid not in merged_board_dict:
+                        merged_board_dict[cid] = name
+
+                allowed_conferences = get_allowed_conferences(settings.conferences, board_dict)
+
+                if isinstance(file_data, list):
+                    messages_to_process = file_data
+                else:
+                    messages_to_process = parse_messages(file_data, None, settings.encoding)
+
+                # Create a settings object without conference filter for counting
+                count_settings = replace(settings, conferences=None)
+
+                for parsed_message in messages_to_process:
+                    total_count += 1
+
+                    # Add source file metadata
+                    parsed_message = replace(parsed_message, source_file=os.path.basename(path))
+
+                    # Check if message matches filters ignoring the conference filter itself
+                    if matches_filters(parsed_message, count_settings, set(), user_name):
+                        conf_counts[parsed_message.confnum] += 1
+
+                        # Now apply the actual conference filter for the display list
+                        if not settings.conferences or parsed_message.confnum in allowed_conferences:
+                            processed_buffer = process_message(
+                                parsed_message.text,
+                                settings.truncate_signatures,
+                                settings.cut_quoting,
+                                settings.binaries_removal,
+                                settings.redact_pii,
+                                settings.strip_ansi,
+                            )
+
+                            # Ensure attachments are detected for the status icon
+                            attachments = parsed_message.attachments
+                            if attachments is None and parsed_message.text:
+                                found = extract_binaries(parsed_message.text)
+                                attachments = [name for name, data in found]
+
+                            all_messages.append(replace(parsed_message, text=processed_buffer, attachments=attachments))
+
+            # Update cache if it was a single file
+            if len(paths) == 1:
                 self._cache = {
-                    'path': path,
-                    'file_data': file_data,
+                    'path': paths[0],
+                    'file_data': file_data, # From the last iteration
                     'board_dict': board_dict
                 }
-                # Initial population if first time loading this file
-                if not self.conf_mapping:
-                    conf_list = ["All Conferences"]
-                    for cid, name in sorted(board_dict.items()):
-                        conf_list.append(f"{cid}: {name}")
-                    self.conf_combo['values'] = conf_list
-                    self.conf_combo.set("All Conferences")
-                    self.conf_mapping = {f"{cid}: {name}": cid for cid, name in board_dict.items()}
-
-            file_data = self._cache['file_data']
-            board_dict = self._cache['board_dict']
-
-            messages = []
-            total_count = 0
-            allowed_conferences = get_allowed_conferences(settings.conferences, board_dict)
-            bbs_info = getattr(board_dict, "bbs_info", None)
-            user_name = bbs_info.user_name if bbs_info else None
-
-            if isinstance(file_data, list):
-                messages_to_process = file_data
-            else:
-                messages_to_process = parse_messages(file_data, None, settings.encoding)
-
-            conf_counts = Counter()
-            # Create a settings object without conference filter for counting
-            count_settings = replace(settings, conferences=None)
-
-            for parsed_message in messages_to_process:
-                total_count += 1
-
-                # Check if message matches filters ignoring the conference filter itself
-                if matches_filters(parsed_message, count_settings, set(), user_name):
-                    conf_counts[parsed_message.confnum] += 1
-
-                    # Now apply the actual conference filter for the display list
-                    if not settings.conferences or parsed_message.confnum in allowed_conferences:
-                        processed_buffer = process_message(
-                            parsed_message.text,
-                            settings.truncate_signatures,
-                            settings.cut_quoting,
-                            settings.binaries_removal,
-                            settings.redact_pii,
-                            settings.strip_ansi,
-                        )
-
-                        # Ensure attachments are detected for the status icon
-                        attachments = parsed_message.attachments
-                        if attachments is None and parsed_message.text:
-                            found = extract_binaries(parsed_message.text)
-                            attachments = [name for name, data in found]
-
-                        messages.append(replace(parsed_message, text=processed_buffer, attachments=attachments))
 
             # Re-populate conference selector with dynamic counts
             total_filtered = sum(conf_counts.values())
@@ -723,7 +774,7 @@ class QwkGuiApp:
             selected_conf_id = self.conf_mapping.get(old_selection)
             new_selection = conf_list[0]
 
-            for cid, name in sorted(board_dict.items()):
+            for cid, name in sorted(merged_board_dict.items()):
                 count = conf_counts.get(cid, 0)
                 display_str = f"{cid}: {name} ({count})"
                 conf_list.append(display_str)
@@ -736,11 +787,11 @@ class QwkGuiApp:
             self.conf_combo.set(new_selection)
 
             if settings.threaded:
-                messages = _order_messages_by_thread(messages)
+                all_messages = _order_messages_by_thread(all_messages)
 
-            self.messages = messages
-            self.board_dict = board_dict
-            self.current_path = path
+            self.messages = all_messages
+            self.board_dict = merged_board_dict
+            self.current_paths = paths
 
             self.message_list.delete(*self.message_list.get_children())
             parent_at_depth = {-1: ""}
@@ -794,9 +845,9 @@ class QwkGuiApp:
                 source_display = os.path.basename(path)
 
             self.status_label.config(
-                text=f"Showing {len(self.messages)} of {total_count} messages from {source_display}"
+                text=f"Showing {len(self.messages)} of {total_count} messages from {source_display if len(paths) == 1 else str(len(paths)) + ' archives'}"
             )
-            self.root.title(f"{source_display} - PyQWK Reader")
+            self.root.title(f"{source_display if len(paths) == 1 else str(len(paths)) + ' archives'} - PyQWK Reader")
 
             # Restore selection if possible
             new_iid_to_select = None
@@ -822,10 +873,10 @@ class QwkGuiApp:
             self.messages = old_messages
             self.board_dict = old_board_dict
             self._cache = old_cache
-            self.current_path = old_path
+            self.current_paths = old_paths
             
             # Reset status and show error
-            if self.current_path:
+            if self.current_paths:
                 source_display = self.root.title().split(" - ")[0]
                 self.status_label.config(
                     text=f"Showing {len(self.messages)} messages from {source_display}"
@@ -988,8 +1039,8 @@ class QwkGuiApp:
         )
 
     def show_stats_window(self, _event: object | None = None) -> None:
-        """Calculate and display statistics for the current archive and filters."""
-        if not self.current_path:
+        """Calculate and display statistics for the current archives and filters."""
+        if not self.current_paths:
             messagebox.showwarning("Statistics", "Please open an archive first.")
             return
 
@@ -999,12 +1050,14 @@ class QwkGuiApp:
 
             settings = self._current_settings()
             # Ensure stats are calculated correctly by using the same logic as the CLI
-            stats = calculate_archive_stats(self.current_path, settings, self.logger)
+            # calculate_archive_stats now expects a list of paths
+            stats = calculate_archive_stats(self.current_paths, settings, self.logger)
             report = render_stats_as_text(stats, use_colors=False)
 
             # Create a new window for the report
             stats_win = tk.Toplevel(self.root)
-            stats_win.title(f"Statistics - {os.path.basename(self.current_path)}")
+            title_suffix = os.path.basename(self.current_paths[0]) if len(self.current_paths) == 1 else f"{len(self.current_paths)} archives"
+            stats_win.title(f"Statistics - {title_suffix}")
             stats_win.geometry("700x600")
 
             frame = ttk.Frame(stats_win, padding=10)

--- a/tests/test_cli_stats_multi.py
+++ b/tests/test_cli_stats_multi.py
@@ -40,3 +40,25 @@ def test_info_multiple_files_no_output(monkeypatch, capsys):
     captured = capsys.readouterr()
     assert "File: testdata/test1_qwk.zip" in captured.out
     assert "File: testdata/test2_qwk.zip" in captured.out
+
+def test_merge_stats_multiple_files(monkeypatch, capsys):
+    """Test that --merge-stats produces a single merged report."""
+    test1 = "testdata/test1_qwk.zip"
+    test2 = "testdata/test2_qwk.zip"
+
+    # Simulate: qwk.py testdata/test1_qwk.zip testdata/test2_qwk.zip --stats --merge-stats
+    monkeypatch.setattr(sys, "argv", ["qwk.py", test1, test2, "--stats", "--merge-stats", "--quiet"])
+
+    try:
+        main()
+    except SystemExit as e:
+        if e.code != 0:
+            pytest.fail(f"main() exited with code {e.code}")
+
+    captured = capsys.readouterr()
+    assert "Statistics for: Multiple Archives" in captured.out
+    # test1 has 1 msg, test2 has 2 msgs -> 3 total
+    assert "Messages: 3 matching / 3 total" in captured.out
+    # Individual file sections should NOT be present if merged correctly
+    assert "Statistics for: testdata/test1_qwk.zip" not in captured.out
+    assert "Statistics for: testdata/test2_qwk.zip" not in captured.out

--- a/tests/test_directory_expansion.py
+++ b/tests/test_directory_expansion.py
@@ -6,10 +6,10 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from pyqwk.cli import _expand_directories
+from pyqwk.core import expand_paths as _expand_directories
 
 class TestDirectoryExpansion:
-    """Tests for the _expand_directories function."""
+    """Tests for the expand_paths function."""
 
     def test_expand_flat_directory_valid_files(self, tmp_path):
         """Test finding supported files in a flat directory."""

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -186,17 +186,17 @@ class TestQwkGui:
 
     def test_open_file_cancel(self, mock_gui_deps):
         app = get_app()
-        mock_gui_deps["filedialog"].askopenfilename.return_value = ""
+        mock_gui_deps["filedialog"].askopenfilenames.return_value = []
         app.open_file()
         assert app.current_path is None
 
     def test_open_file_select(self, mock_gui_deps):
         app = get_app()
-        mock_gui_deps["filedialog"].askopenfilename.return_value = "selected.qwk"
+        mock_gui_deps["filedialog"].askopenfilenames.return_value = ["selected.qwk"]
         with patch.object(app, 'load_messages') as mock_load:
             app.open_file()
             assert app.current_path == "selected.qwk"
-            mock_load.assert_called_with("selected.qwk")
+            mock_load.assert_called_with(["selected.qwk"])
 
     def test_sort_column(self, mock_gui_deps):
         app = get_app()
@@ -412,7 +412,7 @@ class TestQwkGui:
             app.reload_messages()
             app.root.after_cancel.assert_called_with("timer2")
             assert app._search_timer is None
-            mock_load.assert_called_with("path")
+            mock_load.assert_called_with(["path"])
 
     def test_quit_app(self, mock_gui_deps):
         app = get_app()

--- a/tests/test_lead_qa_coverage_expansion_v2.py
+++ b/tests/test_lead_qa_coverage_expansion_v2.py
@@ -38,6 +38,7 @@ def _make_settings(**kwargs):
         quiet=False, headers_only=False, oneline=False,
         extract_attachments=False, limit=None, skip=None,
         sort=None, reverse=False, merge=True, unique=False, organize=False,
+        merge_stats=False,
         organize_by_bbs=False, include_toc=False,
         has_attachments=False, mine=False, on_this_day=False
     )

--- a/tests/test_multi_archive_gui.py
+++ b/tests/test_multi_archive_gui.py
@@ -1,0 +1,98 @@
+import sys
+from unittest.mock import MagicMock, patch, ANY
+import pytest
+import os
+
+# Mock tkinter before any pyqwk.gui imports
+mock_tk = MagicMock()
+mock_ttk = MagicMock()
+mock_fd = MagicMock()
+mock_mb = MagicMock()
+sys.modules["tkinter"] = mock_tk
+sys.modules["tkinter.filedialog"] = mock_fd
+sys.modules["tkinter.messagebox"] = mock_mb
+sys.modules["tkinter.ttk"] = mock_ttk
+sys.modules["tkinter.simpledialog"] = MagicMock()
+
+from pyqwk.gui import QwkGuiApp
+
+@pytest.fixture
+def app():
+    root = MagicMock()
+    # Avoid initial load by passing None
+    app = QwkGuiApp(root, initial_path=None)
+    # Mock some widgets
+    app.message_list = MagicMock()
+    app.status_label = MagicMock()
+    app.conf_combo = MagicMock()
+    app.detail_text = MagicMock()
+    return app
+
+def test_open_file_multiple(app):
+    """Test selecting multiple files in the open dialog."""
+    with patch("pyqwk.gui.filedialog.askopenfilenames") as mock_ask:
+        mock_ask.return_value = ["test1.qwk", "test2.qwk"]
+        with patch.object(app, 'load_messages') as mock_load:
+            app.open_file()
+            mock_load.assert_called_once_with(["test1.qwk", "test2.qwk"])
+            assert app.current_paths == ["test1.qwk", "test2.qwk"]
+
+def test_open_folder(app):
+    """Test opening a folder of archives."""
+    with patch("pyqwk.gui.filedialog.askdirectory") as mock_ask_dir, \
+         patch("pyqwk.gui.expand_paths") as mock_expand:
+        mock_ask_dir.return_value = "/some/path"
+        mock_expand.return_value = ["/some/path/a.qwk", "/some/path/b.rep"]
+
+        with patch.object(app, 'load_messages') as mock_load:
+            app.open_folder()
+            mock_expand.assert_called_once_with(["/some/path"])
+            mock_load.assert_called_once_with(["/some/path/a.qwk", "/some/path/b.rep"])
+            assert app.current_paths == ["/some/path/a.qwk", "/some/path/b.rep"]
+
+def test_load_messages_multi_merge(app):
+    """Test that load_messages merges data from multiple paths."""
+    paths = ["path1.qwk", "path2.qwk"]
+
+    # Mock data for load_data
+    from pyqwk.core import ParsedMessage, MessageHeader
+
+    def create_msg(conf, msgnum, text, subject):
+        header = MessageHeader(" ", msgnum, "01-01-23", "12:00", "To", "From", subject, "", None, 1, " ", conf, 0, "")
+        return ParsedMessage(text, msgnum, None, conf, header)
+
+    m1 = create_msg(1, 101, "Text 1", "Subj 1")
+    m2 = create_msg(2, 201, "Text 2", "Subj 2")
+
+    mock_data = {
+        "path1.qwk": ([m1], {1: "Conf 1"}),
+        "path2.qwk": ([m2], {2: "Conf 2"})
+    }
+
+    with patch("pyqwk.gui.load_data") as mock_load_data, \
+         patch("pyqwk.gui.matches_filters") as mock_matches:
+        mock_load_data.side_effect = lambda path, logger, enc: mock_data[path]
+        mock_matches.return_value = True
+
+        app.load_messages(paths)
+
+        assert len(app.messages) == 2
+        assert app.messages[0].source_file == "path1.qwk"
+        assert app.messages[1].source_file == "path2.qwk"
+        assert app.board_dict == {1: "Conf 1", 2: "Conf 2"}
+
+def test_show_stats_multi(app):
+    """Test that stats window handles multiple paths."""
+    app.current_paths = ["a.qwk", "b.qwk"]
+
+    with patch("pyqwk.gui.calculate_archive_stats") as mock_calc, \
+         patch("pyqwk.gui.render_stats_as_text") as mock_render, \
+         patch("pyqwk.gui.tk.Toplevel") as mock_top:
+
+        mock_calc.return_value = {"some": "stats"}
+        mock_render.return_value = "Report Content"
+
+        app.show_stats_window()
+
+        mock_calc.assert_called_once_with(["a.qwk", "b.qwk"], ANY, app.logger)
+        mock_top.assert_called_once()

--- a/tests/test_qwk.py
+++ b/tests/test_qwk.py
@@ -100,6 +100,7 @@ def _make_settings(**overrides) -> ProcessingSettings:
         mine=False,
         on_this_day=False,
         reference_date=None,
+        merge_stats=False,
     )
     defaults.update(overrides)
     return ProcessingSettings(**defaults)
@@ -153,6 +154,7 @@ def _make_cli_namespace(**overrides: object) -> argparse.Namespace:
         msgnum_filter=None,
         mine=False,
         on_this_day=False,
+        merge_stats=False,
     )
     base.update(overrides)
     return argparse.Namespace(**base)


### PR DESCRIPTION
This feature expands the Graphical Reader and CLI to handle multiple message archives simultaneously.

### Key Changes:
1.  **Multi-File & Folder Support in GUI**: The "Open" dialog now allows multiple selections, and a new "Open Folder..." option has been added to the File menu and toolbar. Messages from all selected sources are merged into a single searchable view.
2.  **Merged Statistics**: The `calculate_archive_stats` function now accepts a list of paths, providing a consolidated report of BBS activity (top authors, keywords, activity trends) across any number of archives. This can be accessed in the CLI via the new `--merge-stats` flag.
3.  **Source Tracking**: Each message now tracks its `source_file`, which is displayed in the GUI detail view to maintain context when multiple archives are open.
4.  **Robust Refactoring**: Path expansion logic was moved to a core utility. The GUI maintains backward compatibility through a `current_path` property that bridges existing tests and single-file logic to the new multi-path internal state.
5.  **Testing**: Added `tests/test_multi_archive_gui.py` and updated the existing suite to ensure no regressions in single-file or stats workflows.

This is a significant UX improvement for users managing large collections of historical BBS packets.

---
*PR created automatically by Jules for task [3929363289736109225](https://jules.google.com/task/3929363289736109225) started by @RainRat*