### PR TITLE
Optimize calculate_archive_stats to respect limit across archives

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -3354,6 +3354,8 @@ def calculate_archive_stats(
     total_chars = 0
 
     for input_path in input_paths:
+        if settings.limit is not None and processed_count >= settings.limit:
+            break
         file_data, board_dict = load_data(input_path, logger, settings.encoding)
         bbs_info = getattr(board_dict, 'bbs_info', None)
         user_name = bbs_info.user_name if bbs_info else None


### PR DESCRIPTION
In `calculate_archive_stats`, the message processing loop correctly respects `settings.limit`, but the outer loop iterating over `input_paths` continued to call `load_data` for all archives even if the limit had already been satisfied. This change adds a check to break the outer loop when `processed_count >= settings.limit`.

This optimization reduces unnecessary I/O and processing time when a user specifies a limit while analyzing multiple archives. No breaking changes were introduced, and existing tests pass.

---
*PR created automatically by Jules for task [1631693250580327382](https://jules.google.com/task/1631693250580327382) started by @RainRat*