### PR TITLE
[DOCS] Refine CLI help strings and API docstrings for clarity

### DIFF
--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -90,7 +90,7 @@ examples:
     )
     parser.add_argument(
         'input_paths',
-        help='The archives or folders to read. Supports QWK, REP, JSON, CSV, XML, MBOX, EML, and SQLite.',
+        help='Path to one or more message archives or folders. Supports QWK, REP, JSON, CSV, XML, MBOX, EML, and SQLite formats.',
         nargs='+',
     )
 
@@ -122,14 +122,14 @@ examples:
     io_group.add_argument(
         '-E',
         '--encoding',
-        help='The text encoding of the input files (default is cp437).',
+        help="The character set of the input files. Default is 'cp437' (standard for DOS-based BBSs).",
         default='cp437',
     )
 
     content_group = parser.add_argument_group('Content Processing')
     content_group.add_argument(
         '--clean',
-        help='Remove signatures, quotes, attachments, and color codes.',
+        help='Clean up messages by removing signatures, quoted replies, attachments, and color codes.',
         action='store_true',
     )
     content_group.add_argument(
@@ -171,7 +171,7 @@ examples:
         '-A',
         '--strip-ansi',
         dest='stripansi',
-        help='Remove color codes and formatting symbols from the text.',
+        help='Remove color codes and other formatting symbols to make the text easier to read.',
         action='store_true',
     )
     content_group.add_argument(
@@ -308,11 +308,11 @@ examples:
     filter_group.add_argument(
         '--regex',
         action='store_true',
-        help='Use regular expressions for searching and filtering.',
+        help='Treat search and filter terms as regular expressions (advanced patterns).',
     )
     filter_group.add_argument(
         '--after',
-        help='Only show messages from this date or later (YYYY-MM-DD).',
+        help='Filter messages sent on or after this date (use YYYY-MM-DD format).',
         default=None,
     )
     filter_group.add_argument(
@@ -325,14 +325,14 @@ examples:
     )
     filter_group.add_argument(
         '--before',
-        help='Only show messages from this date or earlier (YYYY-MM-DD).',
+        help='Filter messages sent on or before this date (use YYYY-MM-DD format).',
         default=None,
     )
     filter_group.add_argument(
         '-N',
         '--msgnum',
         dest='msgnum_filter',
-        help="Only show messages with these numbers (e.g., '100', '200-300', '10,20,50-100').",
+        help="Filter by specific message numbers or ranges (for example: '100', '200-300', or '10,20,50-100').",
     )
     filter_group.add_argument(
         '-L',

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -168,11 +168,16 @@ def _is_binary_line(
 ) -> tuple[bool, bool, bool, bool]:
     """Check if a line of text is part of an attachment (like an image).
 
+    This function uses a simple state machine to identify the start, data, and end
+    of common binary attachment formats (yEnc, UUE, and Base64) embedded in
+    plain text messages.
+
     Returns a group of four values:
     - A boolean that is True if the line should be hidden.
     - Three booleans representing if we are currently inside a specific type of attachment (yEnc, UUE, or Base64).
     """
     stripped_line = line.strip()
+
     if in_base64_block:
         if RE_BASE64_LOOSE_PATTERN.match(stripped_line):
             return True, in_yenc_block, in_uue_block, True
@@ -377,7 +382,11 @@ class ProcessingSettings:
 
 @dataclass
 class BBSInfo:
-    """Information about the BBS that generated the QWK packet."""
+    """Metadata about the Bulletin Board System (BBS) that created the archive.
+
+    This information is typically extracted from the 'CONTROL.DAT' file in
+    QWK packets or preserved in the header of structured formats like SQLite.
+    """
     name: str = ""
     location: str = ""
     phone: str = ""
@@ -399,6 +408,11 @@ class ConferenceMap(dict):
 
 @dataclass
 class ParsedMessage:
+    """A fully parsed and processed message from an archive.
+
+    This class contains the message body text, conference details, and
+    threading metadata used for organizing conversations.
+    """
     text: str
     msgnum: int | None
     refnum: int | None
@@ -421,6 +435,11 @@ ProcessedMessage = ParsedMessage
 
 @dataclass
 class MessageHeader:
+    """The metadata header for a single message in the QWK format.
+
+    These fields correspond to the fixed-length record structure used in
+    traditional BBS message packets.
+    """
     status: str
     msgnum: int | None
     msgdate: str
@@ -1063,22 +1082,25 @@ def _parse_eml_messages(path: str) -> list[ParsedMessage]:
 def load_data(
     input_path: str, logger: logging.Logger, encoding: str = 'cp437'
 ) -> tuple[bytearray | list[ParsedMessage], ConferenceMap]:
-    """Load message and conference information from a QWK packet or raw file.
+    """Load message data and conference mappings from an archive file.
+
+    This function handles both raw legacy formats (QWK, REP) and modern
+    structured formats (JSON, SQLite, XML, CSV, mbox, EML).
 
     Args:
-        input_path: Path to either a ``messages.dat`` file or a QWK archive.
-        logger: Logger used to report warnings when optional information is missing.
-        encoding: The text format to use when reading information.
+        input_path: Path to the archive file or a raw 'MESSAGES.DAT' file.
+        logger: Logger for reporting warnings and informational messages.
+        encoding: The character set used to decode legacy text (default is 'cp437').
 
     Returns:
-        A tuple ``(file_data, board_dict)`` where ``file_data`` contains the
-        contents of ``messages.dat`` and ``board_dict`` maps conference numbers
-        to their names. If conference names are not found, the names will just
-        be the conference numbers.
+        A tuple of (file_data, board_dict):
+        - file_data: A 'bytearray' of raw records for QWK/REP files, or
+          a list of 'ParsedMessage' objects for modern structured formats.
+        - board_dict: A 'ConferenceMap' linking conference numbers to names,
+          which may also include BBS metadata.
 
-        Note: If you provide a path to a raw ``MESSAGES.DAT`` file, this function
-        will also look for an accompanying ``CONTROL.DAT`` file in the same directory
-        to automatically load conference information.
+        Note: When loading a raw 'MESSAGES.DAT' file, it automatically searches
+        for a corresponding 'CONTROL.DAT' in the same folder to load conference names.
     """
     board_dict: dict[int, str] = {}
 


### PR DESCRIPTION
This PR improves the project's documentation by refining user-facing CLI help strings and internal API docstrings. 

**Changes:**
- **CLI Help Strings (`pyqwk/cli.py`):** Updated several flags (e.g., `--encoding`, `--clean`, `--strip-ansi`, `--regex`, `--after`, `--before`, `--msgnum`) to use clearer, Plain English descriptions. For example, `--encoding` now explicitly mentions its relevance to DOS-based BBSs.
- **API Docstrings (`pyqwk/core.py`):** Added or refined docstrings for key data structures (`ParsedMessage`, `MessageHeader`, `BBSInfo`) and the `load_data` function. The `load_data` docstring now accurately describes its dual return type (raw bytearray vs. structured message list) and its automatic search for `CONTROL.DAT`.
- **Style Alignment:** Ensured all text uses active voice, short sentences, and avoids technical jargon or redundant mechanics-focused comments.

All 561 tests passed successfully.

---
*PR created automatically by Jules for task [8206894884634326817](https://jules.google.com/task/8206894884634326817) started by @RainRat*