### PR TITLE
[FEAT] Add BBS metadata awareness, filtering, and statistics

### DIFF
--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -280,6 +280,12 @@ examples:
         help='Filter messages by conference name or number (can be used multiple times).',
     )
     filter_group.add_argument(
+        '--bbs',
+        dest='bbs_names',
+        action='append',
+        help='Filter messages by BBS name or ID (can be used multiple times).',
+    )
+    filter_group.add_argument(
         '-f',
         '--from',
         dest='authors',
@@ -350,8 +356,8 @@ examples:
     )
     filter_group.add_argument(
         '--sort',
-        help='Sort results by field (date, author, to, subject, num, or conference).',
-        choices=['date', 'author', 'to', 'subject', 'num', 'conference'],
+        help='Sort results by field (date, author, to, subject, num, conference, or bbs).',
+        choices=['date', 'author', 'to', 'subject', 'num', 'conference', 'bbs'],
         default=None,
     )
     filter_group.add_argument(

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -357,6 +357,7 @@ class ProcessingSettings:
     extract_attachments: bool = False
     msgnum_filters: set[int] | None = None
     conferences: list[str] | None = None
+    bbs_names: list[str] | None = None
     authors: list[str] | None = None
     recipients: list[str] | None = None
     subjects: list[str] | None = None
@@ -1567,26 +1568,6 @@ def matches_filters(
     Returns:
         True if the message matches all filters, False otherwise.
     """
-    # 1. Private/Password Check
-    if (not settings.private and message.header.is_private) or message.header.is_password:
-        return False
-
-    # 2. Conference Filter
-    if settings.conferences and message.confnum not in allowed_conferences:
-        return False
-
-    # 2b. Mine Filter
-    if settings.mine and user_name:
-        is_from_me = user_name.lower() in message.header.msgfrom.lower()
-        is_to_me = user_name.lower() in message.header.msgto.lower()
-        if not (is_from_me or is_to_me):
-            return False
-
-    # 3. Message Number Filter
-    if settings.msgnum_filters and message.msgnum is not None:
-        if message.msgnum not in settings.msgnum_filters:
-            return False
-
     def check_str_match(pattern: str, text: str) -> bool:
         if settings.regex:
             try:
@@ -1605,6 +1586,33 @@ def matches_filters(
             return True
 
         return any(check_str_match(p, text) for p in pattern_list)
+
+    # 1. Private/Password Check
+    if (not settings.private and message.header.is_private) or message.header.is_password:
+        return False
+
+    # 2. Conference Filter
+    if settings.conferences and message.confnum not in allowed_conferences:
+        return False
+
+    # 2b. BBS Filter
+    if settings.bbs_names:
+        match_name = any_match(settings.bbs_names, message.bbs_name or "")
+        match_id = any_match(settings.bbs_names, message.bbs_id or "")
+        if not (match_name or match_id):
+            return False
+
+    # 2c. Mine Filter
+    if settings.mine and user_name:
+        is_from_me = user_name.lower() in message.header.msgfrom.lower()
+        is_to_me = user_name.lower() in message.header.msgto.lower()
+        if not (is_from_me or is_to_me):
+            return False
+
+    # 3. Message Number Filter
+    if settings.msgnum_filters and message.msgnum is not None:
+        if message.msgnum not in settings.msgnum_filters:
+            return False
 
     # 4. Author Filter
     if not any_match(settings.authors, message.header.msgfrom):
@@ -2038,6 +2046,8 @@ def process_merged_files(
                 sort_buffer.sort(key=lambda x: (x[0].confnum, x[0].msgnum or 0))
             elif settings.sort == 'conference':
                 sort_buffer.sort(key=lambda x: (x[0].confnum, _parse_qwk_date(x[0].header.msgdate, x[0].header.msgtime)))
+            elif settings.sort == 'bbs':
+                sort_buffer.sort(key=lambda x: (x[0].bbs_name or "", x[0].bbs_id or "", _parse_qwk_date(x[0].header.msgdate, x[0].header.msgtime)))
 
         if settings.reverse:
             sort_buffer.reverse()
@@ -3319,6 +3329,7 @@ def calculate_archive_stats(
         "authors": [],
         "recipients": [],
         "conferences": [],
+        "bbses": [],
         "subjects": [],
         "keywords": [],
         "attachments_count": 0,
@@ -3335,6 +3346,7 @@ def calculate_archive_stats(
     author_counter: Counter = Counter()
     recipient_counter: Counter = Counter()
     conf_counter: Counter = Counter()
+    bbs_counter: Counter = Counter()
     conf_names: dict[int, str] = {}
     subject_counter: Counter = Counter()
     keyword_counter: Counter = Counter()
@@ -3385,6 +3397,14 @@ def calculate_archive_stats(
                     progress_bar.update(1)
                 total_count += 1
 
+                message = replace(
+                    message,
+                    confname=message.confname or board_dict.get(message.confnum),
+                    bbs_name=message.bbs_name or (bbs_info.name if bbs_info else None),
+                    bbs_id=message.bbs_id or (bbs_info.bbs_id if bbs_info else None),
+                    source_file=message.source_file or os.path.basename(input_path),
+                )
+
                 if not matches_filters(message, settings, allowed_conferences, user_name):
                     continue
 
@@ -3407,6 +3427,10 @@ def calculate_archive_stats(
                 author_counter[message.header.msgfrom.strip()] += 1
                 recipient_counter[message.header.msgto.strip()] += 1
                 conf_counter[message.confnum] += 1
+
+                bbs_display = message.bbs_name or message.bbs_id or "Unknown BBS"
+                bbs_counter[bbs_display] += 1
+
                 subject_counter[_normalize_subject(message.header.msgsubject)] += 1
 
                 dow_counter[dt.strftime('%A')] += 1
@@ -3453,6 +3477,7 @@ def calculate_archive_stats(
     stats_entry["authors"] = [{"name": n, "count": c} for n, c in author_counter.most_common(10)]
     stats_entry["recipients"] = [{"name": n, "count": c} for n, c in recipient_counter.most_common(10)]
     stats_entry["conferences"] = [{"number": n, "name": conf_names.get(n, str(n)), "count": c} for n, c in conf_counter.most_common(10)]
+    stats_entry["bbses"] = [{"name": n, "count": c} for n, c in bbs_counter.most_common(10)]
     stats_entry["subjects"] = [{"subject": s, "count": c} for s, c in subject_counter.most_common(10)]
     stats_entry["keywords"] = [{"word": w, "count": c} for w, c in keyword_counter.most_common(10)]
     stats_entry["day_of_week"] = dict(dow_counter)
@@ -3503,6 +3528,9 @@ def render_stats_as_text(stats: dict[str, Any], use_colors: bool = False) -> str
 
     parts.extend(_render_stats_bar_chart('Top Authors:', [(a["name"], a["count"]) for a in stats['authors']], use_colors=use_colors))
     parts.extend(_render_stats_bar_chart('Top Recipients:', [(r["name"], r["count"]) for r in stats['recipients']], use_colors=use_colors))
+
+    if stats.get('bbses'):
+        parts.extend(_render_stats_bar_chart('Top BBSes:', [(b["name"], b["count"]) for b in stats['bbses']], use_colors=use_colors))
 
     if stats['conferences']:
         items = [(f"{c['number']:3} {c['name']}", c["count"]) for c in stats['conferences']]

--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -60,7 +60,8 @@ class QwkGuiApp:
             "From": "From",
             "To": "To",
             "Date": "Date",
-            "Conference": "Conference",
+            "Conference": "Conf",
+            "BBS": "BBS",
         }
 
         self.clean_var = tk.BooleanVar(value=False)
@@ -337,7 +338,7 @@ class QwkGuiApp:
         # Treeview setup
         self.message_list = ttk.Treeview(
             list_frame,
-            columns=("Flags", "Num", "From", "To", "Date", "Conference"),
+            columns=("Flags", "Num", "From", "To", "Date", "Conference", "BBS"),
             selectmode="browse",
         )
 
@@ -362,7 +363,8 @@ class QwkGuiApp:
         self.message_list.column("From", minwidth=80, width=150)
         self.message_list.column("To", minwidth=80, width=150)
         self.message_list.column("Date", minwidth=80, width=120)
-        self.message_list.column("Conference", minwidth=80, width=100)
+        self.message_list.column("Conference", minwidth=50, width=60)
+        self.message_list.column("BBS", minwidth=80, width=100)
 
         scrollbar = ttk.Scrollbar(
             list_frame, orient=tk.VERTICAL, command=self.message_list.yview
@@ -484,6 +486,8 @@ class QwkGuiApp:
         insert_field("Date", f"{header.msgdate} {header.msgtime}")
         insert_field("Conf", conf_name, last_in_row=True)
 
+        if message.bbs_name:
+            insert_field("BBS", message.bbs_name)
         if message.source_file:
             insert_field("Source", message.source_file, last_in_row=True)
 
@@ -731,8 +735,13 @@ class QwkGuiApp:
                 for parsed_message in messages_to_process:
                     total_count += 1
 
-                    # Add source file metadata
-                    parsed_message = replace(parsed_message, source_file=os.path.basename(path))
+                    # Add BBS and source file metadata
+                    parsed_message = replace(
+                        parsed_message,
+                        bbs_name=bbs_info.name if bbs_info else None,
+                        bbs_id=bbs_info.bbs_id if bbs_info else None,
+                        source_file=os.path.basename(path)
+                    )
 
                     # Check if message matches filters ignoring the conference filter itself
                     if matches_filters(parsed_message, count_settings, set(), user_name):
@@ -831,6 +840,7 @@ class QwkGuiApp:
                         header.msgto.strip(),
                         f"{header.msgdate} {header.msgtime}",
                         conf_name,
+                        message.bbs_name or message.bbs_id or "",
                     ),
                     open=True,  # Expand by default
                     tags=tuple(item_tags)
@@ -1135,6 +1145,9 @@ class QwkGuiApp:
 
             render_gui_bar_chart('Top Authors', [(a["name"], a["count"]) for a in stats['authors']])
             render_gui_bar_chart('Top Recipients', [(r["name"], r["count"]) for r in stats['recipients']])
+
+            if stats.get('bbses'):
+                render_gui_bar_chart('Top BBSes', [(b["name"], b["count"]) for b in stats['bbses']])
 
             if stats['conferences']:
                 items = [(f"{c['number']:3} {c['name']}", c["count"]) for c in stats['conferences']]

--- a/tests/test_bbs_filter.py
+++ b/tests/test_bbs_filter.py
@@ -1,0 +1,46 @@
+from dataclasses import replace
+import pytest
+from pyqwk.core import ParsedMessage, MessageHeader, ProcessingSettings, matches_filters
+
+def test_bbs_filter():
+    header = MessageHeader(
+        status=" ", msgnum=1, msgdate="01-01-24", msgtime="12:00",
+        msgto="To", msgfrom="From", msgsubject="Subj", msgpassword="",
+        refnum=None, numblocks=1, msgflag=" ", confnum=1, lognum=1, nettag=""
+    )
+
+    msg1 = ParsedMessage(
+        text="Hello", msgnum=1, refnum=None, confnum=1, header=header,
+        bbs_name="Vintage BBS", bbs_id="VINTAGE"
+    )
+
+    msg2 = ParsedMessage(
+        text="World", msgnum=2, refnum=None, confnum=1, header=header,
+        bbs_name="Other BBS", bbs_id="OTHER"
+    )
+
+    # Base settings
+    settings = ProcessingSettings(
+        verbose=False, private=True, no_header=True, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False,
+        binaries_removal=False, redact_pii=False, format="text",
+        separator="none", output_mode="stdout", output_path=None, encoding="cp437"
+    )
+
+    # Filter by name
+    settings_name = replace_settings(settings, bbs_names=["Vintage"])
+    assert matches_filters(msg1, settings_name, set()) is True
+    assert matches_filters(msg2, settings_name, set()) is False
+
+    # Filter by ID
+    settings_id = replace_settings(settings, bbs_names=["OTHER"])
+    assert matches_filters(msg1, settings_id, set()) is False
+    assert matches_filters(msg2, settings_id, set()) is True
+
+    # Filter by either (multi)
+    settings_multi = replace_settings(settings, bbs_names=["Vintage", "OTHER"])
+    assert matches_filters(msg1, settings_multi, set()) is True
+    assert matches_filters(msg2, settings_multi, set()) is True
+
+def replace_settings(settings, **kwargs):
+    return replace(settings, **kwargs)

--- a/tests/test_bbs_stats.py
+++ b/tests/test_bbs_stats.py
@@ -1,0 +1,53 @@
+import pytest
+from pyqwk.core import ParsedMessage, MessageHeader, ProcessingSettings, calculate_archive_stats
+import logging
+
+def test_bbs_stats(tmp_path):
+    # Create a dummy QWK archive structure (json format is easier to mock for calculate_archive_stats)
+    import json
+
+    header = {
+        "status": " ", "msgnum": 1, "msgdate": "01-01-24", "msgtime": "12:00",
+        "msgto": "To", "msgfrom": "From", "msgsubject": "Subj", "msgpassword": "",
+        "refnum": 0, "numblocks": 1, "msgflag": " ", "confnum": 1, "lognum": 1, "nettag": ""
+    }
+
+    data = [
+        {
+            "header": header,
+            "text": "Message 1",
+            "conference": "General",
+            "bbs_name": "BBS A",
+            "bbs_id": "ID_A"
+        },
+        {
+            "header": {**header, "msgnum": 2},
+            "text": "Message 2",
+            "conference": "General",
+            "bbs_name": "BBS B",
+            "bbs_id": "ID_B"
+        }
+    ]
+
+    archive_path = tmp_path / "archive.json"
+    archive_path.write_text(json.dumps(data))
+
+    settings = ProcessingSettings(
+        verbose=False, private=True, no_header=True, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False,
+        binaries_removal=False, redact_pii=False, format="json",
+        separator="none", output_mode="stdout", output_path=None, encoding="cp437",
+        quiet=True
+    )
+
+    logger = logging.getLogger("test")
+    stats = calculate_archive_stats([str(archive_path)], settings, logger)
+
+    assert "bbses" in stats
+    bbs_names = [b["name"] for b in stats["bbses"]]
+    assert "BBS A" in bbs_names
+    assert "BBS B" in bbs_names
+
+    counts = {b["name"]: b["count"] for b in stats["bbses"]}
+    assert counts["BBS A"] == 1
+    assert counts["BBS B"] == 1


### PR DESCRIPTION
This PR introduces **BBS Metadata Awareness** to pyqwk, enhancing its utility when dealing with merged archives from multiple sources.

### Key Changes:
1. **Filtering**: Added a new `--bbs` flag to the CLI (and core `matches_filters`) allowing users to filter messages by the human-readable BBS name or BBS ID.
2. **Statistics**: Archive statistics now include a "Top BBSes" section, providing a clear breakdown of message distribution across different boards. This is available in both the text-based CLI report and the Graphical Reader's statistics window.
3. **Sorting**: Added `bbs` as a valid sorting field for both the CLI and Graphical Reader.
4. **GUI Enhancements**:
   - The message list Treeview now includes a "BBS" column.
   - The message detail view displays the "BBS" name alongside other headers.
   - Message metadata is enriched with BBS information during loading and analysis.

### Implementation Details:
- Updated `ProcessingSettings` to include `bbs_names`.
- Enhanced `calculate_archive_stats` to track BBS distribution and ensure message objects are enriched with BBS metadata during processing.
- Updated `render_stats_as_text` and `QwkGuiApp.show_stats_window` to render the new statistics.
- Modified `QwkGuiApp.load_messages` to populate BBS metadata from the archive's `bbs_info`.

This feature provides logical symmetry with existing conference and author filters, making it significantly easier to manage large collections of BBS history.

---
*PR created automatically by Jules for task [3747523563325050145](https://jules.google.com/task/3747523563325050145) started by @RainRat*