### PR TITLE
Fix logic bug in date parsing for time strings with seconds

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -2568,7 +2568,10 @@ def _parse_qwk_date(msgdate: str, msgtime: str) -> datetime.datetime:
         msgdate = msgdate.replace('/', '-')
 
         month, day, year = map(int, msgdate.split('-'))
-        hour, minute = map(int, msgtime.split(':'))
+        time_parts = list(map(int, msgtime.split(':')))
+        hour = time_parts[0]
+        minute = time_parts[1]
+        second = time_parts[2] if len(time_parts) > 2 else 0
 
         # Handle Year 2000 problem using a sliding window.
         # BBS activity peaked in the 1980s and 1990s. We use 80 as a cutoff:
@@ -2579,8 +2582,8 @@ def _parse_qwk_date(msgdate: str, msgtime: str) -> datetime.datetime:
             else:
                 year += 1900
 
-        return datetime.datetime(year, month, day, hour, minute)
-    except ValueError:
+        return datetime.datetime(year, month, day, hour, minute, second)
+    except (ValueError, IndexError):
         # Fallback for invalid dates
         return datetime.datetime(1970, 1, 1, 0, 0)
 

--- a/tests/test_date_parsing.py
+++ b/tests/test_date_parsing.py
@@ -67,9 +67,7 @@ class TestDateParsing:
         dt = _parse_qwk_date("01-01-90", "12")
         assert dt == datetime.datetime(1970, 1, 1, 0, 0)
 
-    def test_extra_time_components_fallback(self):
-        # Time string with seconds (HH:MM:SS) - function expects only HH:MM splitting
-        # map(int, "12:34:56".split(':')) -> map over 3 items.
-        # hour, minute = map(...) -> ValueError: too many values to unpack
+    def test_parse_with_seconds(self):
+        # Time string with seconds (HH:MM:SS)
         dt = _parse_qwk_date("01-01-90", "12:34:56")
-        assert dt == datetime.datetime(1970, 1, 1, 0, 0)
+        assert dt == datetime.datetime(1990, 1, 1, 12, 34, 56)


### PR DESCRIPTION
* **What**: Updated `_parse_qwk_date` in `pyqwk/core.py` to support time strings containing seconds (e.g., "HH:MM:SS"). Previously, it strictly expected "HH:MM" and would fall back to 1970-01-01 if seconds were present.
* **Why**: This improves the robustness of the date parsing logic, allowing it to correctly handle more precise time formats often found in reconstructed or modern exports of message data. No breaking changes were introduced, as standard "HH:MM" strings continue to be parsed correctly with seconds defaulting to 0. Updated existing tests to verify correct parsing of three-component time strings.

---
*PR created automatically by Jules for task [18362870946974521151](https://jules.google.com/task/18362870946974521151) started by @RainRat*