### PR TITLE
[FEAT] Enhanced Contextual Actions and Selectable Text in Graphical Reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ qwk-gui archive.eml
 **Key Features:**
 - **Search:** Quickly find messages by keyword. Use the **Regex** checkbox to search with advanced patterns (regular expressions). Results are highlighted in the text.
 - **Filtering:** View messages from specific conferences, include private messages, filter by the presence of attachments, or only show messages from/to yourself.
+- **Context Menus:** Right-click on any message in the list to copy its metadata (Subject, From, To) or instantly filter the entire archive by that author or conference. You can also right-click in the message text to copy selected sections.
 - **Exporting:** Save your current filtered and sorted view to any supported format (HTML, Markdown, JSON, etc.).
 - **Viewing Options:** Toggle between **Clean** view (removes formatting), **Hide Personal Info** (hides emails and phone numbers), and **Remove Colors**.
 - **Threading:** Group replies together to follow the flow of a conversation.

--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -88,9 +88,79 @@ class QwkGuiApp:
         else:
             self.root.after(100, self._render_welcome_screen)
 
+    def _show_list_context_menu(self, event: tk.Event) -> None:
+        """Display a context menu for the message list."""
+        iid = self.message_list.identify_row(event.y)
+        if not iid:
+            return
+
+        self.message_list.selection_set(iid)
+        self.message_list.focus(iid)
+
+        try:
+            idx = int(iid)
+            msg = self.messages[idx]
+        except (ValueError, IndexError):
+            return
+
+        menu = tk.Menu(self.root, tearoff=0)
+
+        # Copy section
+        menu.add_command(label="Copy Subject", command=lambda: self._copy_to_clipboard(msg.header.msgsubject.strip()))
+        menu.add_command(label="Copy From", command=lambda: self._copy_to_clipboard(msg.header.msgfrom.strip()))
+        menu.add_command(label="Copy To", command=lambda: self._copy_to_clipboard(msg.header.msgto.strip()))
+        menu.add_command(label="Copy Num", command=lambda: self._copy_to_clipboard(str(msg.header.msgnum or "")))
+        menu.add_separator()
+
+        # Filter pivoting
+        menu.add_command(label=f"Filter by Author: {msg.header.msgfrom.strip()[:20]}...",
+                         command=lambda: self._pivot_filter(author=msg.header.msgfrom.strip()))
+
+        conf_name = self.board_dict.get(msg.confnum, str(msg.confnum))
+        menu.add_command(label=f"Filter by Conference: {conf_name[:20]}...",
+                         command=lambda: self._pivot_filter(conf_num=msg.confnum))
+
+        menu.post(event.x_root, event.y_root)
+
+    def _show_text_context_menu(self, event: tk.Event) -> None:
+        """Display a context menu for the detail viewer."""
+        menu = tk.Menu(self.root, tearoff=0)
+        menu.add_command(label="Copy", command=lambda: self.detail_text.event_generate("<<Copy>>"))
+        menu.add_command(label="Select All", command=lambda: self.detail_text.tag_add("sel", "1.0", tk.END))
+        menu.post(event.x_root, event.y_root)
+
+    def _copy_to_clipboard(self, text: str) -> None:
+        """Copy the given text to the system clipboard."""
+        self.root.clipboard_clear()
+        self.root.clipboard_append(text)
+
+    def _pivot_filter(self, author: str | None = None, conf_num: int | None = None) -> None:
+        """Update filters to pivot the view around a specific attribute."""
+        if author:
+            self.search_var.set(author)
+
+        if conf_num is not None:
+            # Find exact match in combobox
+            for i, val in enumerate(self.conf_combo['values']):
+                if val.startswith(f"{conf_num}:"):
+                    self.conf_combo.current(i)
+                    break
+
+        self.reload_messages()
+
+    def _block_text_input(self, event: tk.Event) -> str | None:
+        """Block keyboard input in the detail view while allowing common shortcuts."""
+        # Allow Control+C (copy) and Control+A (select all)
+        if event.state & 0x4:  # Control mask
+            if event.keysym.lower() in ('c', 'a'):
+                return None
+        # Allow navigation keys
+        if event.keysym in ('Up', 'Down', 'Left', 'Right', 'Prior', 'Next', 'Home', 'End'):
+            return None
+        return "break"
+
     def _render_welcome_screen(self) -> None:
         """Render a welcome screen with instructions and shortcuts."""
-        self.detail_text.config(state=tk.NORMAL)
         self.detail_text.delete("1.0", tk.END)
 
         self.detail_text.insert(tk.END, "Welcome to PyQWK\n\n", "header_subject")
@@ -118,8 +188,6 @@ class QwkGuiApp:
         for key, desc in shortcuts:
             self.detail_text.insert(tk.END, f"{key:<12}", "header_label")
             self.detail_text.insert(tk.END, f"{desc}\n", "body")
-
-        self.detail_text.config(state=tk.DISABLED)
 
     def _build_menu(self) -> None:
         menubar = tk.Menu(self.root)
@@ -383,6 +451,10 @@ class QwkGuiApp:
 
         self.message_list.bind("<<TreeviewSelect>>", self.on_message_selected)
 
+        # Context menu for list
+        self.message_list.bind("<Button-3>", self._show_list_context_menu)
+        self.message_list.bind("<Control-Button-1>", self._show_list_context_menu)
+
         self.detail_text = tk.Text(
             detail_frame,
             wrap=tk.WORD,
@@ -400,7 +472,14 @@ class QwkGuiApp:
 
         detail_scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
         self.detail_text.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
-        self.detail_text.config(state=tk.DISABLED)
+        self.detail_text.config(state=tk.NORMAL)
+
+        # Intercept key events to allow selection/copy but block editing
+        self.detail_text.bind("<Key>", self._block_text_input)
+
+        # Context menu for text
+        self.detail_text.bind("<Button-3>", self._show_text_context_menu)
+        self.detail_text.bind("<Control-Button-1>", self._show_text_context_menu)
 
         # Configure tags for visual hierarchy
         self.detail_text.tag_configure(
@@ -469,7 +548,6 @@ class QwkGuiApp:
         header = message.header
         conf_name = self.board_dict.get(header.confnum, str(header.confnum))
 
-        self.detail_text.config(state=tk.NORMAL)
         self.detail_text.delete("1.0", tk.END)
 
         # Apply header area background
@@ -563,8 +641,6 @@ class QwkGuiApp:
             self.detail_text.tag_raise("search_highlight")
             if first_match_pos:
                 self.detail_text.see(first_match_pos)
-
-        self.detail_text.config(state=tk.DISABLED)
 
     def open_file(self, _event: object | None = None) -> None:
         filetypes = [
@@ -911,10 +987,8 @@ class QwkGuiApp:
             messagebox.showerror("Failed to load QWK", str(exc))
 
     def _set_detail_text(self, text: str) -> None:
-        self.detail_text.config(state=tk.NORMAL)
         self.detail_text.delete("1.0", tk.END)
         self.detail_text.insert(tk.END, text)
-        self.detail_text.config(state=tk.DISABLED)
 
     def export_messages(self, _event: object | None = None) -> None:
         """Export the currently filtered and sorted messages to a file."""

--- a/tests/test_gui_ux_enhancements.py
+++ b/tests/test_gui_ux_enhancements.py
@@ -1,0 +1,101 @@
+
+import sys
+from unittest.mock import MagicMock, patch
+
+# Mock tkinter before any pyqwk.gui imports
+mock_tk = MagicMock()
+mock_ttk = MagicMock()
+sys.modules["tkinter"] = mock_tk
+sys.modules["tkinter.filedialog"] = MagicMock()
+sys.modules["tkinter.messagebox"] = MagicMock()
+sys.modules["tkinter.simpledialog"] = MagicMock()
+sys.modules["tkinter.ttk"] = mock_ttk
+
+import pytest
+from pyqwk.gui import QwkGuiApp
+from pyqwk.core import ParsedMessage, MessageHeader
+
+@pytest.fixture
+def app():
+    root = MagicMock()
+    root.after = MagicMock()
+    # Mock search_var as it's initialized with tk.StringVar()
+    with patch('tkinter.StringVar'), patch('tkinter.BooleanVar'):
+        app = QwkGuiApp(root)
+        app.search_var = MagicMock()
+        return app
+
+def test_block_text_input_logic(app):
+    """Verify that _block_text_input allows specific shortcuts and blocks others."""
+    # Control+C
+    event_c = MagicMock(state=0x4, keysym='c')
+    assert app._block_text_input(event_c) is None
+
+    # Control+A
+    event_a = MagicMock(state=0x4, keysym='a')
+    assert app._block_text_input(event_a) is None
+
+    # Navigation key
+    event_up = MagicMock(state=0, keysym='Up')
+    assert app._block_text_input(event_up) is None
+
+    # Regular key (typing 'x')
+    event_x = MagicMock(state=0, keysym='x')
+    assert app._block_text_input(event_x) == "break"
+
+def test_pivot_filter_author(app):
+    """Verify that pivoting by author updates the search variable and reloads."""
+    app.reload_messages = MagicMock()
+    app._pivot_filter(author="Sysop")
+    app.search_var.set.assert_called_once_with("Sysop")
+    app.reload_messages.assert_called_once()
+
+def test_pivot_filter_conference(app):
+    """Verify that pivoting by conference updates the combobox and reloads."""
+    app.reload_messages = MagicMock()
+    app.conf_combo = MagicMock()
+    app.conf_combo.__getitem__.return_value = ["All Conferences (10)", "1: General (5)", "2: Tech (5)"]
+
+    app._pivot_filter(conf_num=1)
+    app.conf_combo.current.assert_called_once_with(1)
+    app.reload_messages.assert_called_once()
+
+def test_copy_to_clipboard(app):
+    """Verify clipboard interaction."""
+    app.root.clipboard_clear = MagicMock()
+    app.root.clipboard_append = MagicMock()
+
+    app._copy_to_clipboard("test text")
+    app.root.clipboard_clear.assert_called_once()
+    app.root.clipboard_append.assert_called_once_with("test text")
+
+def test_show_list_context_menu(app):
+    """Verify that right-clicking the list triggers menu posting."""
+    event = MagicMock(x_root=100, y_root=100, y=50)
+    app.message_list.identify_row.return_value = "0"
+
+    # Setup messages so indexing works
+    header = MessageHeader(
+        status=' ', msgnum=1, msgdate='01-01-23', msgtime='12:00',
+        msgto='Alice', msgfrom='Bob', msgsubject='Test',
+        msgpassword='', refnum=None, numblocks=1, msgflag=' ',
+        confnum=1, lognum=1, nettag=''
+    )
+    app.messages = [ParsedMessage(text="Hello", msgnum=1, refnum=None, confnum=1, header=header)]
+    app.board_dict = {1: "General"}
+
+    with patch("pyqwk.gui.tk.Menu") as mock_menu_class:
+        mock_menu_instance = mock_menu_class.return_value
+        app._show_list_context_menu(event)
+
+        app.message_list.selection_set.assert_called_with("0")
+        mock_menu_instance.post.assert_called_once_with(100, 100)
+
+def test_show_text_context_menu(app):
+    """Verify that right-clicking the text triggers menu posting."""
+    event = MagicMock(x_root=200, y_root=200)
+
+    with patch("pyqwk.gui.tk.Menu") as mock_menu_class:
+        mock_menu_instance = mock_menu_class.return_value
+        app._show_text_context_menu(event)
+        mock_menu_instance.post.assert_called_once_with(200, 200)


### PR DESCRIPTION
I've identified a significant UX gap in the Graphical Reader: users were unable to select message text or quickly perform common actions (like copying an author's name or filtering by a specific conference) without manual typing.

This PR implements **Enhanced Contextual Actions**, adding standard desktop affordances like right-click menus and text selection. I've refactored the detail view to use a "Read-Only but Selectable" pattern, which is much more user-friendly than the previous hard-disabled state. I also added "Filter Pivoting," which allows users to instantly narrow their view based on the metadata of a message they find interesting.

---
*PR created automatically by Jules for task [6648480713565027441](https://jules.google.com/task/6648480713565027441) started by @RainRat*