### PR TITLE
[TEST] Add coverage for archive statistics limit logic

### DIFF
--- a/tests/test_lead_qa_core_stats_limit.py
+++ b/tests/test_lead_qa_core_stats_limit.py
@@ -1,0 +1,59 @@
+import logging
+from unittest.mock import MagicMock, patch
+from pyqwk.core import calculate_archive_stats, ProcessingSettings, ParsedMessage, MessageHeader, ConferenceMap
+
+def test_calculate_archive_stats_limit_break():
+    logger = logging.getLogger("test")
+
+    settings = ProcessingSettings(
+        verbose=False,
+        private=True,
+        no_header=False,
+        truncate_signatures=False,
+        cut_quoting=False,
+        individual_files=False,
+        threaded=False,
+        binaries_removal=False,
+        redact_pii=False,
+        format='text',
+        separator='none',
+        output_mode='stdout',
+        output_path=None,
+        encoding='cp437',
+        limit=1,
+        quiet=True
+    )
+
+    header = MessageHeader(
+        status=" ",
+        msgnum=1,
+        msgdate="01-01-23",
+        msgtime="12:00",
+        msgto="To",
+        msgfrom="From",
+        msgsubject="Subject",
+        msgpassword="",
+        refnum=None,
+        numblocks=1,
+        msgflag=" ",
+        confnum=1,
+        lognum=1,
+        nettag=""
+    )
+    msg = ParsedMessage(
+        text="Hello world",
+        msgnum=1,
+        refnum=None,
+        confnum=1,
+        header=header
+    )
+
+    with patch("pyqwk.core.load_data") as mock_load:
+        mock_load.return_value = ([msg], ConferenceMap())
+
+        paths = ["archive1.qwk", "archive2.qwk"]
+        stats = calculate_archive_stats(paths, settings, logger)
+
+        assert stats["matching_messages"] == 1
+        assert mock_load.call_count == 1
+        mock_load.assert_called_once_with("archive1.qwk", logger, "cp437")


### PR DESCRIPTION
*   **Type:** New Coverage
*   **What:** Added `test_calculate_archive_stats_limit_break` to verify that `calculate_archive_stats` in `pyqwk/core.py` correctly stops processing subsequent archives once the `settings.limit` is reached.
*   **Why:** This closes a 1-line coverage gap (line 3395) in `pyqwk/core.py`, bringing the core module to 100% test coverage and ensuring robust handling of limits across multiple input files.


---
*PR created automatically by Jules for task [13482003334990337394](https://jules.google.com/task/13482003334990337394) started by @RainRat*