### PR TITLE
[FEAT] Search for Selection in Graphical Reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ qwk-gui archive.eml
 ```
 
 **Key Features:**
-- **Search:** Quickly find messages by keyword. Use the **Regex** checkbox to search with advanced patterns (regular expressions). Results are highlighted in the text.
+- **Search:** Quickly find messages by keyword. Use the **Regex** checkbox to search with advanced patterns (regular expressions). Results are highlighted in the text. You can also highlight any text in a message, right-click, and select **Search for [Selection]** to instantly find related messages.
 - **Filtering:** View messages from specific conferences, include private messages, filter by the presence of attachments, or only show messages from/to yourself.
 - **Context Menus:** Right-click on any message in the list to copy its metadata (Subject, From, To) or instantly filter the entire archive by that author or conference. You can also right-click in the message text to copy selected sections.
 - **Exporting:** Save your current filtered and sorted view to any supported format (HTML, Markdown, JSON, etc.).

--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -127,7 +127,35 @@ class QwkGuiApp:
         menu = tk.Menu(self.root, tearoff=0)
         menu.add_command(label="Copy", command=lambda: self.detail_text.event_generate("<<Copy>>"))
         menu.add_command(label="Select All", command=lambda: self.detail_text.tag_add("sel", "1.0", tk.END))
+
+        try:
+            sel_range = self.detail_text.tag_ranges("sel")
+            if sel_range:
+                selected_text = self.detail_text.get(*sel_range).strip()
+                if selected_text:
+                    display_text = (selected_text[:20] + "...") if len(selected_text) > 20 else selected_text
+                    menu.add_separator()
+                    menu.add_command(
+                        label=f"Search for '{display_text}'",
+                        command=self._search_from_selection
+                    )
+        except tk.TclError:
+            pass
+
         menu.post(event.x_root, event.y_root)
+
+    def _search_from_selection(self) -> None:
+        """Search for the currently selected text in the detail viewer."""
+        try:
+            sel_range = self.detail_text.tag_ranges("sel")
+            if sel_range:
+                selected_text = self.detail_text.get(*sel_range).strip()
+                if selected_text:
+                    self.search_var.set(selected_text)
+                    self.reload_messages()
+                    self.message_list.focus_set()
+        except tk.TclError:
+            pass
 
     def _copy_to_clipboard(self, text: str) -> None:
         """Copy the given text to the system clipboard."""

--- a/tests/test_gui_search_selection.py
+++ b/tests/test_gui_search_selection.py
@@ -1,0 +1,97 @@
+
+import sys
+from unittest.mock import MagicMock, patch
+
+# Mock tkinter before any pyqwk.gui imports
+mock_tk = MagicMock()
+mock_ttk = MagicMock()
+sys.modules["tkinter"] = mock_tk
+sys.modules["tkinter.filedialog"] = MagicMock()
+sys.modules["tkinter.messagebox"] = MagicMock()
+sys.modules["tkinter.simpledialog"] = MagicMock()
+sys.modules["tkinter.ttk"] = mock_ttk
+
+import pytest
+from pyqwk.gui import QwkGuiApp
+
+@pytest.fixture
+def app():
+    root = MagicMock()
+    root.after = MagicMock()
+    # Mock search_var as it's initialized with tk.StringVar()
+    with patch('tkinter.StringVar'), patch('tkinter.BooleanVar'):
+        app = QwkGuiApp(root)
+        app.search_var = MagicMock()
+        return app
+
+def test_search_from_selection_logic(app):
+    """Verify that _search_from_selection correctly updates search_var and reloads."""
+    app.detail_text = MagicMock()
+    app.detail_text.tag_ranges.return_value = ("1.0", "1.5")
+    app.detail_text.get.return_value = " BBS "
+    app.reload_messages = MagicMock()
+    app.message_list = MagicMock()
+
+    app._search_from_selection()
+
+    app.search_var.set.assert_called_once_with("BBS")
+    app.reload_messages.assert_called_once()
+    app.message_list.focus_set.assert_called_once()
+
+def test_search_from_selection_empty(app):
+    """Verify that _search_from_selection does nothing if no text is selected."""
+    app.detail_text = MagicMock()
+    app.detail_text.tag_ranges.return_value = ()
+    app.reload_messages = MagicMock()
+
+    app._search_from_selection()
+
+    app.search_var.set.assert_not_called()
+    app.reload_messages.assert_not_called()
+
+def test_show_text_context_menu_with_selection(app):
+    """Verify that the context menu includes the Search option when text is selected."""
+    event = MagicMock(x_root=100, y_root=100)
+    app.detail_text = MagicMock()
+    app.detail_text.tag_ranges.return_value = ("1.0", "1.10")
+    app.detail_text.get.return_value = "Selected Text"
+
+    with patch("pyqwk.gui.tk.Menu") as mock_menu_class:
+        mock_menu_instance = mock_menu_class.return_value
+        app._show_text_context_menu(event)
+
+        # Check that add_command was called with the search label
+        calls = mock_menu_instance.add_command.call_args_list
+        labels = [c[1].get('label', '') for c in calls]
+        assert "Search for 'Selected Text'" in labels
+
+def test_show_text_context_menu_with_long_selection(app):
+    """Verify that the context menu truncates long selected text."""
+    event = MagicMock(x_root=100, y_root=100)
+    app.detail_text = MagicMock()
+    app.detail_text.tag_ranges.return_value = ("1.0", "1.50")
+    app.detail_text.get.return_value = "This is a very long selection that should be truncated"
+
+    with patch("pyqwk.gui.tk.Menu") as mock_menu_class:
+        mock_menu_instance = mock_menu_class.return_value
+        app._show_text_context_menu(event)
+
+        calls = mock_menu_instance.add_command.call_args_list
+        labels = [c[1].get('label', '') for c in calls]
+        expected_label = "Search for 'This is a very long ...'"
+        assert expected_label in labels
+
+def test_show_text_context_menu_no_selection(app):
+    """Verify that the context menu excludes the Search option when no text is selected."""
+    event = MagicMock(x_root=100, y_root=100)
+    app.detail_text = MagicMock()
+    app.detail_text.tag_ranges.return_value = ()
+
+    with patch("pyqwk.gui.tk.Menu") as mock_menu_class:
+        mock_menu_instance = mock_menu_class.return_value
+        app._show_text_context_menu(event)
+
+        calls = mock_menu_instance.add_command.call_args_list
+        labels = [c[1].get('label', '') for c in calls]
+        for label in labels:
+            assert "Search for" not in label


### PR DESCRIPTION
Added a "Search for Selection" feature to the Graphical Reader's message viewer. When text is highlighted in a message, a right-click context menu option "Search for '[Selection]'" appears. Clicking it updates the global search and refreshes the message list.

This improves the exploration workflow for large archives by allowing users to instantly find related messages without manual typing.

---
*PR created automatically by Jules for task [2848800745627654274](https://jules.google.com/task/2848800745627654274) started by @RainRat*