### PR TITLE
[FEAT] BBS Filtering in Graphical Reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ qwk-gui archive.eml
 
 **Key Features:**
 - **Search:** Quickly find messages by keyword. Use the **Regex** checkbox to search with advanced patterns (regular expressions). Results are highlighted in the text. You can also highlight any text in a message, right-click, and select **Search for [Selection]** to instantly find related messages.
-- **Filtering:** View messages from specific conferences, include private messages, filter by the presence of attachments, or only show messages from/to yourself.
-- **Context Menus:** Right-click on any message in the list to copy its metadata (Subject, From, To) or instantly filter the entire archive by that author or conference. You can also right-click in the message text to copy selected sections.
+- **Filtering:** View messages from specific BBSes or conferences, include private messages, filter by the presence of attachments, or only show messages from/to yourself.
+- **Context Menus:** Right-click on any message in the list to copy its metadata (Subject, From, To) or instantly filter the entire view by that author, conference, or BBS. You can also right-click in the message text to copy selected sections.
 - **Exporting:** Save your current filtered and sorted view to any supported format (HTML, Markdown, JSON, etc.).
 - **Viewing Options:** Toggle between **Clean** view (removes formatting), **Hide Personal Info** (hides emails and phone numbers), and **Remove Colors**.
 - **Threading:** Group replies together to follow the flow of a conversation.

--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -52,6 +52,7 @@ class QwkGuiApp:
         self.current_paths: list[str] = []
         self._cache = {}
         self.conf_mapping = {}
+        self.bbs_mapping = {}
 
         self.column_labels = {
             "#0": "Subject",
@@ -120,6 +121,11 @@ class QwkGuiApp:
         menu.add_command(label=f"Filter by Conference: {conf_name[:20]}...",
                          command=lambda: self._pivot_filter(conf_num=msg.confnum))
 
+        bbs_display = msg.bbs_name or msg.bbs_id
+        if bbs_display:
+            menu.add_command(label=f"Filter by BBS: {bbs_display[:20]}...",
+                             command=lambda: self._pivot_filter(bbs_name=bbs_display))
+
         menu.post(event.x_root, event.y_root)
 
     def _show_text_context_menu(self, event: tk.Event) -> None:
@@ -162,10 +168,17 @@ class QwkGuiApp:
         self.root.clipboard_clear()
         self.root.clipboard_append(text)
 
-    def _pivot_filter(self, author: str | None = None, conf_num: int | None = None) -> None:
+    def _pivot_filter(self, author: str | None = None, conf_num: int | None = None, bbs_name: str | None = None) -> None:
         """Update filters to pivot the view around a specific attribute."""
         if author:
             self.search_var.set(author)
+
+        if bbs_name:
+            # Find match in BBS combobox
+            for i, val in enumerate(self.bbs_combo['values']):
+                if val.startswith(bbs_name):
+                    self.bbs_combo.current(i)
+                    break
 
         if conf_num is not None:
             # Find exact match in combobox
@@ -324,6 +337,10 @@ class QwkGuiApp:
     def clear_filters(self, _event: object | None = None) -> None:
         """Reset all filters to their default state."""
         try:
+            self.bbs_combo.current(0)
+        except Exception:
+            self.bbs_combo.set("All BBSes")
+        try:
             self.conf_combo.current(0)
         except Exception:
             self.conf_combo.set("All Conferences")
@@ -384,8 +401,10 @@ class QwkGuiApp:
         filters_frame = ttk.Frame(row2)
         filters_frame.pack(side=tk.LEFT, padx=5)
         ttk.Label(filters_frame, text="Filters:").pack(side=tk.LEFT)
+        self.bbs_combo = ttk.Combobox(filters_frame, state="readonly", width=25)
+        self.bbs_combo.pack(side=tk.LEFT, padx=(5, 2))
         self.conf_combo = ttk.Combobox(filters_frame, state="readonly", width=25)
-        self.conf_combo.pack(side=tk.LEFT, padx=(5, 2))
+        self.conf_combo.pack(side=tk.LEFT, padx=2)
 
         for text, var in [
             ("Attachments", self.has_attach_var),
@@ -421,6 +440,8 @@ class QwkGuiApp:
         self.search_entry.bind("<Up>", lambda e: self._select_relative_message(-1, force=True))
         self.search_entry.bind("<Down>", lambda e: self._select_relative_message(1, force=True))
         self.root.bind("<Control-f>", self._focus_search)
+        self.bbs_combo.bind("<<ComboboxSelected>>", lambda e: self.reload_messages())
+        self.bbs_combo.bind("<Escape>", lambda e: self.clear_filters())
         self.conf_combo.bind("<<ComboboxSelected>>", lambda e: self.reload_messages())
         self.conf_combo.bind("<Escape>", lambda e: self.clear_filters())
 
@@ -542,6 +563,13 @@ class QwkGuiApp:
         if not search_val:
             search_val = None
 
+        selected_bbs_name = self.bbs_combo.get()
+        bbs_names = None
+        if selected_bbs_name and not selected_bbs_name.startswith("All BBSes"):
+            bbs_id = self.bbs_mapping.get(selected_bbs_name)
+            if bbs_id is not None:
+                bbs_names = [bbs_id]
+
         selected_conf_name = self.conf_combo.get()
         conferences = None
         if selected_conf_name and not selected_conf_name.startswith("All Conferences"):
@@ -569,6 +597,7 @@ class QwkGuiApp:
             quiet=True,
             search_term=search_val if search_val else None,
             conferences=conferences,
+            bbs_names=bbs_names,
             has_attachments=self.has_attach_var.get(),
             mine=self.mine_var.get(),
             on_this_day=self.on_this_day_var.get(),
@@ -795,6 +824,8 @@ class QwkGuiApp:
             merged_board_dict = ConferenceMap()
             total_count = 0
             conf_counts = Counter()
+            bbs_counts = Counter()
+            bbs_identities = {}
 
             for path in paths:
                 if len(paths) == 1 and self._cache.get('path') == path:
@@ -838,8 +869,9 @@ class QwkGuiApp:
                 else:
                     messages_to_process = parse_messages(file_data, None, settings.encoding)
 
-                # Create a settings object without conference filter for counting
+                # Create settings objects without conference/BBS filters for counting
                 count_settings = replace(settings, conferences=None)
+                bbs_count_settings = replace(settings, bbs_names=None)
 
                 for parsed_message in messages_to_process:
                     total_count += 1
@@ -847,17 +879,25 @@ class QwkGuiApp:
                     # Add BBS and source file metadata
                     parsed_message = replace(
                         parsed_message,
-                        bbs_name=bbs_info.name if bbs_info else None,
-                        bbs_id=bbs_info.bbs_id if bbs_info else None,
-                        source_file=os.path.basename(path)
+                        bbs_name=parsed_message.bbs_name or (bbs_info.name if bbs_info else None),
+                        bbs_id=parsed_message.bbs_id or (bbs_info.bbs_id if bbs_info else None),
+                        source_file=parsed_message.source_file or os.path.basename(path)
                     )
+
+                    # Check if message matches filters ignoring the BBS filter itself
+                    if matches_filters(parsed_message, bbs_count_settings, set(), user_name):
+                        bbs_display = parsed_message.bbs_name or parsed_message.bbs_id or "Unknown BBS"
+                        # Use ID for exact filtering if available, else name
+                        bbs_val = parsed_message.bbs_id or parsed_message.bbs_name or ""
+                        bbs_counts[bbs_display] += 1
+                        bbs_identities[bbs_display] = bbs_val
 
                     # Check if message matches filters ignoring the conference filter itself
                     if matches_filters(parsed_message, count_settings, set(), user_name):
                         conf_counts[parsed_message.confnum] += 1
 
-                        # Now apply the actual conference filter for the display list
-                        if not settings.conferences or parsed_message.confnum in allowed_conferences:
+                        # Now apply the actual filters for the display list
+                        if matches_filters(parsed_message, settings, allowed_conferences, user_name):
                             processed_buffer = process_message(
                                 parsed_message.text,
                                 settings.truncate_signatures,
@@ -882,6 +922,27 @@ class QwkGuiApp:
                     'file_data': file_data, # From the last iteration
                     'board_dict': board_dict
                 }
+
+            # Re-populate BBS selector with dynamic counts
+            total_bbs_filtered = sum(bbs_counts.values())
+            bbs_list = [f"All BBSes ({total_bbs_filtered})"]
+            new_bbs_mapping = {}
+
+            old_bbs_selection = self.bbs_combo.get()
+            selected_bbs_id = self.bbs_mapping.get(old_bbs_selection)
+            new_bbs_selection = bbs_list[0]
+
+            for b_name, count in sorted(bbs_counts.items()):
+                b_val = bbs_identities[b_name]
+                display_str = f"{b_name} ({count})"
+                bbs_list.append(display_str)
+                new_bbs_mapping[display_str] = b_val
+                if b_val == selected_bbs_id:
+                    new_bbs_selection = display_str
+
+            self.bbs_combo['values'] = bbs_list
+            self.bbs_mapping = new_bbs_mapping
+            self.bbs_combo.set(new_bbs_selection)
 
             # Re-populate conference selector with dynamic counts
             total_filtered = sum(conf_counts.values())

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -325,7 +325,10 @@ class TestQwkGui:
             header = MessageHeader(' ', 1, "01-01-90", "12:00", "To", "From", "Sub", "", None, 1, " ", 1, 1, "")
             mock_msgs = [ParsedMessage("Msg 1", 1, None, 1, header), ParsedMessage("Msg 2", 2, None, 1, header)]
             mock_parse_messages.return_value = mock_msgs
-            mock_matches_filters.side_effect = [True, False]
+            # matches_filters is called 3 times per message (BBS count, conf count, filter check)
+            # For 2 messages, total 6 calls.
+            # We want Msg 1 to show up (3x True) and Msg 2 conf count/filter to fail (or at least filter fail)
+            mock_matches_filters.side_effect = [True, True, True, True, False, False]
             app.load_messages("test.qwk")
             calls = app.status_label.config.call_args_list
             texts = [c.kwargs['text'] for c in calls if 'text' in c.kwargs]

--- a/tests/test_gui_bbs_filter.py
+++ b/tests/test_gui_bbs_filter.py
@@ -1,0 +1,142 @@
+import sys
+from unittest.mock import MagicMock, patch, ANY
+import pytest
+import tkinter as tk
+
+# Mock tkinter before any pyqwk.gui imports
+mock_tk = MagicMock()
+mock_ttk = MagicMock()
+sys.modules["tkinter"] = mock_tk
+sys.modules["tkinter.filedialog"] = MagicMock()
+sys.modules["tkinter.messagebox"] = MagicMock()
+sys.modules["tkinter.ttk"] = mock_ttk
+
+from pyqwk.core import ParsedMessage, MessageHeader, BBSInfo, ConferenceMap
+
+@pytest.fixture
+def mock_gui_deps():
+    with patch("pyqwk.gui.tk") as mock_tk, \
+         patch("pyqwk.gui.ttk") as mock_ttk, \
+         patch("pyqwk.gui.filedialog") as mock_fd, \
+         patch("pyqwk.gui.messagebox") as mock_mb:
+
+        # Configure Variable mocks
+        def make_var(value=None):
+            m = MagicMock()
+            m.get.return_value = value
+            return m
+
+        mock_tk.BooleanVar.side_effect = lambda value=False, **kwargs: make_var(value)
+        mock_tk.StringVar.side_effect = lambda value="", **kwargs: make_var(value)
+        mock_tk.IntVar.side_effect = lambda value=0, **kwargs: make_var(value)
+
+        # Tkinter constants
+        mock_tk.END = "end"
+        mock_tk.HORIZONTAL = "horizontal"
+        mock_tk.VERTICAL = "vertical"
+        mock_tk.BOTH = "both"
+        mock_tk.X = "x"
+        mock_tk.Y = "y"
+        mock_tk.LEFT = "left"
+        mock_tk.RIGHT = "right"
+        mock_tk.TOP = "top"
+        mock_tk.BOTTOM = "bottom"
+        mock_tk.SUNKEN = "sunken"
+        mock_tk.W = "w"
+        mock_tk.E = "e"
+        mock_tk.WORD = "word"
+        mock_tk.DISABLED = "disabled"
+        mock_tk.NORMAL = "normal"
+        mock_tk.INSERT = "insert"
+
+        # Mock classes/types
+        class TclError(Exception):
+            pass
+        mock_tk.TclError = TclError
+
+        # Mock Combobox
+        # We need distinct mock objects for bbs_combo and conf_combo
+        bbs_combo = MagicMock()
+        conf_combo = MagicMock()
+
+        # side_effect to return different mocks on successive calls
+        mock_ttk.Combobox.side_effect = [bbs_combo, conf_combo]
+
+        yield {
+            "tk": mock_tk,
+            "ttk": mock_ttk,
+            "filedialog": mock_fd,
+            "messagebox": mock_mb,
+            "bbs_combo": bbs_combo,
+            "conf_combo": conf_combo,
+        }
+
+def get_app(initial_path=None):
+    from pyqwk.gui import QwkGuiApp
+    root = MagicMock()
+    return QwkGuiApp(root, initial_path=initial_path)
+
+def test_bbs_filter_population(mock_gui_deps):
+    app = get_app()
+
+    # Mock archives from two different BBSes
+    header = MessageHeader(' ', 1, "01-01-90", "12:00", "To", "From", "Sub", "", None, 1, " ", 1, 1, "")
+
+    bbs1_info = BBSInfo(name="BBS One", bbs_id="BBS1")
+    bbs2_info = BBSInfo(name="BBS Two", bbs_id="BBS2")
+
+    msg1 = ParsedMessage("Msg 1", 1, None, 1, header)
+    msg2 = ParsedMessage("Msg 2", 2, None, 1, header)
+
+    with patch("pyqwk.gui.load_data") as mock_load_data, \
+         patch("pyqwk.gui.parse_messages") as mock_parse_messages, \
+         patch("pyqwk.gui.matches_filters", return_value=True):
+
+        board_dict1 = ConferenceMap({1: "General"})
+        board_dict1.bbs_info = bbs1_info
+
+        board_dict2 = ConferenceMap({1: "General"})
+        board_dict2.bbs_info = bbs2_info
+
+        mock_load_data.side_effect = [
+            (bytearray(), board_dict1),
+            (bytearray(), board_dict2)
+        ]
+
+        mock_parse_messages.side_effect = [
+            [msg1], # Discovery phase (though it's not strictly necessary for this test, current implementation calls it)
+            [msg1], # Loading phase
+            [msg2], # Discovery phase
+            [msg2]  # Loading phase
+        ]
+
+        app.load_messages(["file1.qwk", "file2.qwk"])
+
+        # Check if bbs_combo was populated
+        # Values should be ["All BBSes (2)", "BBS One (1)", "BBS Two (1)"]
+        # In our case it was the first Combobox created
+        expected_values = ["All BBSes (2)", "BBS One (1)", "BBS Two (1)"]
+        app.bbs_combo.__setitem__.assert_any_call('values', expected_values)
+        assert app.bbs_mapping["BBS One (1)"] == "BBS1"
+        assert app.bbs_mapping["BBS Two (1)"] == "BBS2"
+
+def test_bbs_filter_selection(mock_gui_deps):
+    app = get_app()
+
+    # Setup mock data and state
+    app.bbs_mapping = {"BBS One (1)": "BBS1"}
+    app.bbs_combo.get.return_value = "BBS One (1)"
+
+    settings = app._current_settings()
+    assert settings.bbs_names == ["BBS1"]
+
+def test_pivot_filter_bbs(mock_gui_deps):
+    app = get_app()
+    # Resetting mocks since get_app creates them via side_effect
+    app.bbs_combo = MagicMock()
+    app.bbs_combo.__getitem__.return_value = ["All BBSes (2)", "BBS One (1)", "BBS Two (1)"]
+
+    with patch.object(app, "reload_messages"):
+        app._pivot_filter(bbs_name="BBS Two")
+        app.bbs_combo.current.assert_called_with(2)
+        app.reload_messages.assert_called_once()


### PR DESCRIPTION
**What:** Added a BBS-level filter to the Graphical Reader (GUI), including a dynamic dropdown with message counts and context menu integration.

**Why:** QWK readers often handle merged archives from multiple BBSes. While the CLI already supported BBS filtering, the GUI lacked this capability, making it difficult for users to isolate messages from a specific source in a unified view. This addition provides a more powerful and symmetrical filtering experience across the interface.

**Changes:**
- Modified `pyqwk/gui.py` to include `bbs_combo` in the toolbar.
- Implemented faceted counting in `load_messages` to show accurate message counts for both BBS and Conference filters.
- Added "Filter by BBS" to the message list context menu.
- Updated `_current_settings`, `clear_filters`, and `_pivot_filter` to support BBS filtering.
- Updated `README.md` to document the new feature.
- Updated `tests/test_gui.py` and added `tests/test_gui_bbs_filter.py` to verify the functionality.

---
*PR created automatically by Jules for task [7582464719635699565](https://jules.google.com/task/7582464719635699565) started by @RainRat*