### PR TITLE
Remove redundant field initialization in `_parse_sqlite_messages`

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -809,11 +809,6 @@ def _parse_sqlite_messages(db_path: str) -> tuple[list[ParsedMessage], Conferenc
                 'refnum': row['reference_number']
             }
 
-            # Add remaining fields with defaults
-            for f in fields(MessageHeader):
-                if f.name not in header_dict:
-                    header_dict[f.name] = ""
-
             header = MessageHeader.from_dict(header_dict)
 
             attachments = row['attachments'].split(';') if row['attachments'] else []


### PR DESCRIPTION
* **What:** Removed a redundant loop in `pyqwk/core.py` that manually populated a dictionary with empty strings for missing message header fields.
* **Why:** The `MessageHeader.from_dict` method already handles default values for missing fields. Removing this loop simplifies the code, reduces overhead, and improves maintainability by centralizing default value logic within the dataclass-based header reconstruction. This is a non-breaking change as verified by the existing test suite.

---
*PR created automatically by Jules for task [7413056192604516294](https://jules.google.com/task/7413056192604516294) started by @RainRat*