### PR TITLE
[UI/UX] Implement metadata-aware context menu in detail viewer

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -133,6 +133,33 @@ class QwkGuiApp:
         menu = tk.Menu(self.root, tearoff=0)
         menu.add_command(label="Copy", command=lambda: self.detail_text.event_generate("<<Copy>>"))
         menu.add_command(label="Select All", command=lambda: self.detail_text.tag_add("sel", "1.0", tk.END))
+        menu.add_command(label="Copy Full Message", command=lambda: self._copy_to_clipboard(self.detail_text.get("1.0", tk.END).strip()))
+
+        # Get current message for metadata filtering
+        current_selection = self.message_list.selection()
+        if current_selection:
+            try:
+                idx = int(current_selection[0])
+                msg = self.messages[idx]
+
+                menu.add_separator()
+                author_text = msg.header.msgfrom.strip()
+                author_label = (author_text[:20] + "...") if len(author_text) > 20 else author_text
+                menu.add_command(label=f"Filter by Author: {author_label}",
+                                 command=lambda a=author_text: self._pivot_filter(author=a))
+
+                conf_name = self.board_dict.get(msg.confnum, str(msg.confnum))
+                conf_label = (conf_name[:20] + "...") if len(conf_name) > 20 else conf_name
+                menu.add_command(label=f"Filter by Conference: {conf_label}",
+                                 command=lambda c=msg.confnum: self._pivot_filter(conf_num=c))
+
+                bbs_display = msg.bbs_name or msg.bbs_id
+                if bbs_display:
+                    bbs_label = (bbs_display[:20] + "...") if len(bbs_display) > 20 else bbs_display
+                    menu.add_command(label=f"Filter by BBS: {bbs_label}",
+                                     command=lambda b=bbs_display: self._pivot_filter(bbs_name=b))
+            except (ValueError, IndexError):
+                pass
 
         try:
             sel_range = self.detail_text.tag_ranges("sel")

--- a/tests/test_gui_ux_enhancements.py
+++ b/tests/test_gui_ux_enhancements.py
@@ -92,10 +92,31 @@ def test_show_list_context_menu(app):
         mock_menu_instance.post.assert_called_once_with(100, 100)
 
 def test_show_text_context_menu(app):
-    """Verify that right-clicking the text triggers menu posting."""
+    """Verify that right-clicking the text triggers menu posting with metadata filters."""
     event = MagicMock(x_root=200, y_root=200)
+
+    # Mock selection
+    app.message_list.selection.return_value = ("0",)
+    header = MessageHeader(
+        status=' ', msgnum=1, msgdate='01-01-23', msgtime='12:00',
+        msgto='Alice', msgfrom='Bob', msgsubject='Test',
+        msgpassword='', refnum=None, numblocks=1, msgflag=' ',
+        confnum=1, lognum=1, nettag=''
+    )
+    app.messages = [ParsedMessage(text="Hello", msgnum=1, refnum=None, confnum=1, header=header, bbs_name="TestBBS")]
+    app.board_dict = {1: "General"}
 
     with patch("pyqwk.gui.tk.Menu") as mock_menu_class:
         mock_menu_instance = mock_menu_class.return_value
         app._show_text_context_menu(event)
+
+        # Check for expected commands: Copy, Select All, Copy Full Message, Filter by Author, Conf, BBS
+        calls = [c[1]["label"] for c in mock_menu_instance.add_command.call_args_list]
+        assert "Copy" in calls
+        assert "Select All" in calls
+        assert "Copy Full Message" in calls
+        assert any("Filter by Author: Bob" == c for c in calls)
+        assert any("Filter by Conference: General" == c for c in calls)
+        assert any("Filter by BBS: TestBBS" == c for c in calls)
+
         mock_menu_instance.post.assert_called_once_with(200, 200)


### PR DESCRIPTION
### Context: GUI (Graphical Reader)

### Problem: 
When reading a message in the Graphical Reader, users often want to explore more messages from the same author, conference, or BBS. Previously, this required moving the focus back to the message list, finding the current message again, and right-clicking it. This created unnecessary cognitive load and "mouse travel."

### Solution:
I enhanced the right-click context menu of the message detail viewer to be metadata-aware. It now includes:
1.  **Metadata Filters:** Instant "Filter by Author", "Filter by Conference", and "Filter by BBS" options based on the message being read.
2.  **Copy Full Message:** A quick way to copy the entire message content to the clipboard.
3.  **Visual Polish:** Filter labels are intelligently truncated to 20 characters only when needed, ensuring the menu remains compact and legible.
4.  **Power User Efficiency:** Commands use lambda default arguments for reliable execution, matching the behavior and aesthetics of the existing message list context menu.

### Changes:
- Modified `_show_text_context_menu` in `pyqwk/gui.py` to add these dynamic options.
- Updated `tests/test_gui_ux_enhancements.py` to ensure high-quality programmatic verification.

---
*PR created automatically by Jules for task [878638596901301234](https://jules.google.com/task/878638596901301234) started by @RainRat*