### PR TITLE
[FEAT] Add Markdown Import Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Today, these files are valuable pieces of digital history. `pyqwk` helps you ope
 
 ## Features
 
-- **Multiple Formats:** Export to Text, HTML, JSON, XML, Markdown, CSV, mbox, EML, or SQLite. Import from QWK, REP, JSON, CSV, XML, SQLite, mbox, or EML.
+- **Multiple Formats:** Export to Text, HTML, JSON, XML, Markdown, CSV, mbox, EML, or SQLite. Import from QWK, REP, JSON, CSV, XML, SQLite, mbox, EML, or Markdown.
 - **Conversation Threading:** Group replies together to follow discussions easily.
 - **Content Cleaning:** Automatically remove signatures, old quotes, and attachments like images.
 - **Privacy:** Hide personal information and handle private messages.
@@ -68,6 +68,11 @@ You can install `pyqwk` to use it from any folder on your computer.
    qwk-gui
    ```
 
+**5. Import from Markdown:**
+   ```bash
+   qwk archive.md -o messages.html
+   ```
+
 *Note: You can also run the reader directly without installing:*
 ```bash
 python -m pyqwk.gui
@@ -75,7 +80,7 @@ python -m pyqwk.gui
 
 ## Graphical Reader
 
-If you prefer a visual interface, you can use the built-in reader. It allows you to browse conferences, search for messages, and follow threaded conversations. It supports all input formats (QWK, REP, JSON, CSV, XML, SQLite, mbox, and EML).
+If you prefer a visual interface, you can use the built-in reader. It allows you to browse conferences, search for messages, and follow threaded conversations. It supports all input formats (QWK, REP, JSON, CSV, XML, SQLite, mbox, EML, and Markdown).
 
 **To start the reader:**
 ```bash

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -41,7 +41,7 @@ def expand_paths(paths: list[str]) -> list[str]:
             for root, _, files in os.walk(path):
                 for file in files:
                     lower_file = file.lower()
-                    if lower_file.endswith(('.qwk', '.zip', '.rep', '.json', '.csv', '.db', '.sqlite', '.xml', '.mbox', '.eml')) or lower_file == 'messages.dat':
+                    if lower_file.endswith(('.qwk', '.zip', '.rep', '.json', '.csv', '.db', '.sqlite', '.xml', '.mbox', '.eml', '.md', '.markdown')) or lower_file == 'messages.dat':
                         expanded_paths.append(os.path.join(root, file))
         else:
             expanded_paths.append(path)
@@ -1080,6 +1080,161 @@ def _parse_eml_messages(path: str) -> list[ParsedMessage]:
     return [_message_from_email(msg_obj)]
 
 
+def _parse_markdown_messages(path: str) -> list[ParsedMessage]:
+    """Import messages from a Markdown file."""
+    with open(path, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    # Split into sections by horizontal rules '---'
+    raw_sections = re.split(r'\n---\n', content)
+    sections = []
+    current_chunk = ""
+    for s in raw_sections:
+        # A new message section contains '## ' or '> ## '
+        if '## ' in s:
+            if current_chunk:
+                sections.append(current_chunk)
+            current_chunk = s
+        else:
+            if current_chunk:
+                current_chunk += "\n---\n" + s
+            else:
+                # Header of the file before any message
+                continue
+    if current_chunk:
+        sections.append(current_chunk)
+
+    messages = []
+
+    # Regex patterns for fields
+    re_subject = re.compile(r'^## (.*)', re.MULTILINE)
+    re_date = re.compile(r'^- \*\*Date:\*\* (.*)', re.MULTILINE)
+    re_from = re.compile(r'^- \*\*From:\*\* (.*)', re.MULTILINE)
+    re_to = re.compile(r'^- \*\*To:\*\* (.*)', re.MULTILINE)
+    re_conf = re.compile(r'^- \*\*Conference:\*\* (.*) \((\d+)\)', re.MULTILINE)
+    re_bbs = re.compile(r'^- \*\*BBS:\*\* (.*)', re.MULTILINE)
+    re_source = re.compile(r'^- \*\*Source:\*\* (.*)', re.MULTILINE)
+    re_number = re.compile(r'^- \*\*Number:\*\* (.*)', re.MULTILINE)
+    re_attachments = re.compile(r'^- \*\*Attachments:\*\* (.*)', re.MULTILINE)
+
+    for section in sections:
+        # Detect blockquote depth for threaded Markdown
+        depth = 0
+        working_section = section.lstrip('\n')
+        while working_section.startswith('> '):
+            depth += 1
+            lines = working_section.splitlines()
+            new_lines = []
+            for line in lines:
+                if line.startswith('> '):
+                    new_lines.append(line[2:])
+                elif not line.strip():
+                    new_lines.append("")
+                else:
+                    new_lines.append(line)
+            working_section = "\n".join(new_lines).strip()
+
+        # If it's the first section, it might start with the archive title (# )
+        msg_start = working_section.find('## ')
+        if msg_start == -1:
+            continue
+
+        working_section = working_section[msg_start:]
+
+        # Extract metadata
+        subject_match = re_subject.search(working_section)
+        if not subject_match:
+            continue
+
+        subject = subject_match.group(1).strip().replace('**', '')
+        date_match = re_date.search(working_section)
+        from_match = re_from.search(working_section)
+        to_match = re_to.search(working_section)
+        conf_match = re_conf.search(working_section)
+        bbs_match = re_bbs.search(working_section)
+        source_match = re_source.search(working_section)
+        num_match = re_number.search(working_section)
+        attach_match = re_attachments.search(working_section)
+
+        # Date and Time
+        msg_date = "01-01-70"
+        msg_time = "00:00"
+        if date_match:
+            dt_parts = date_match.group(1).split()
+            if len(dt_parts) >= 1:
+                msg_date = dt_parts[0]
+            if len(dt_parts) >= 2:
+                msg_time = dt_parts[1]
+
+        # Conference
+        conf_num = 0
+        conf_name = None
+        if conf_match:
+            conf_name = conf_match.group(1).strip().replace('**', '')
+            conf_num = int(conf_match.group(2))
+
+        # BBS info
+        bbs_name = bbs_match.group(1).strip().replace('**', '') if bbs_match else None
+        source_file = source_match.group(1).strip().replace('**', '') if source_match else None
+        msg_num = _safe_to_int(num_match.group(1).strip()) if num_match else None
+
+        attachments = None
+        if attach_match:
+            attach_str = attach_match.group(1).strip()
+            if '[' in attach_str:
+                attachments = re.findall(r'\[(.*?)\]', attach_str)
+            else:
+                attachments = [a.strip() for a in attach_str.split(',') if a.strip()]
+
+        # Message body: everything after the metadata lines
+        lines = working_section.splitlines()
+        body_start_idx = 0
+        for i, line in enumerate(lines):
+            line_strip = line.strip()
+            if not line_strip:
+                continue
+            if line_strip.startswith('## ') or line_strip.startswith('- **'):
+                body_start_idx = i + 1
+            else:
+                body_start_idx = i
+                break
+
+        body = "\n".join(lines[body_start_idx:]).strip()
+
+        # Construct MessageHeader
+        header = MessageHeader(
+            status=" ",
+            msgnum=msg_num,
+            msgdate=msg_date,
+            msgtime=msg_time,
+            msgto=to_match.group(1).strip().replace('**', '') if to_match else "",
+            msgfrom=from_match.group(1).strip().replace('**', '') if from_match else "",
+            msgsubject=subject,
+            msgpassword="",
+            refnum=None,
+            numblocks=None,
+            msgflag=" ",
+            confnum=conf_num,
+            lognum=0,
+            nettag="",
+        )
+
+        msg = ParsedMessage(
+            text=body,
+            msgnum=msg_num,
+            refnum=None,
+            confnum=conf_num,
+            header=header,
+            depth=depth,
+            confname=conf_name,
+            bbs_name=bbs_name,
+            source_file=source_file,
+            attachments=attachments,
+        )
+        messages.append(msg)
+
+    return messages
+
 
 def load_data(
     input_path: str, logger: logging.Logger, encoding: str = 'cp437'
@@ -1129,6 +1284,15 @@ def load_data(
             messages = _parse_mbox_messages(input_path)
         except Exception as e:
             raise ValueError(f"Failed to load mbox archive: {e}")
+
+        board_dict = _reconstruct_metadata(messages)
+        return messages, board_dict
+
+    if input_path.lower().endswith(('.md', '.markdown')):
+        try:
+            messages = _parse_markdown_messages(input_path)
+        except Exception as e:
+            raise ValueError(f"Failed to load Markdown archive: {e}")
 
         board_dict = _reconstruct_metadata(messages)
         return messages, board_dict

--- a/tests/test_markdown_import.py
+++ b/tests/test_markdown_import.py
@@ -1,0 +1,222 @@
+import unittest
+import os
+import tempfile
+import shutil
+import logging
+from pyqwk.core import (
+    load_data,
+    ProcessingSettings,
+    process_merged_files,
+)
+
+class TestMarkdownImport(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.mkdtemp()
+        self.logger = logging.getLogger("pyqwk_test")
+        self.logger.setLevel(logging.CRITICAL)
+
+    def tearDown(self):
+        shutil.rmtree(self.test_dir)
+
+    def test_markdown_round_trip(self):
+        # 1. Create a sample archive or use existing test data
+        # We'll use testdata/test1_qwk.zip
+        input_path = "testdata/test1_qwk.zip"
+        if not os.path.exists(input_path):
+            self.skipTest("testdata/test1_qwk.zip not found")
+
+        markdown_path = os.path.join(self.test_dir, "test_output.md")
+
+        # 2. Export to Markdown
+        settings_export = ProcessingSettings(
+            verbose=True,
+            private=True,
+            no_header=False,
+            truncate_signatures=False,
+            cut_quoting=False,
+            individual_files=False,
+            threaded=False,
+            binaries_removal=False,
+            redact_pii=False,
+            format='markdown',
+            separator='auto',
+            output_mode='file',
+            output_path=markdown_path,
+            encoding='cp437',
+            quiet=True
+        )
+        process_merged_files([input_path], settings_export, self.logger)
+
+        # Verify export exists
+        self.assertTrue(os.path.exists(markdown_path))
+
+        # 3. Import from Markdown
+        messages, board_dict = load_data(markdown_path, self.logger)
+
+        # 4. Assertions
+        self.assertEqual(len(messages), 1)
+        msg = messages[0]
+
+        # Check metadata
+        self.assertEqual(msg.header.msgsubject.strip(), "Re: Fujitsu hard drive")
+        self.assertEqual(msg.header.msgfrom.strip(), "Warren Zatwarniski")
+        self.assertEqual(msg.header.msgto.strip(), "Wes Kitchen")
+        self.assertEqual(msg.confnum, 4)
+        self.assertEqual(msg.confname, "Pnw.Tech")
+        self.assertEqual(msg.bbs_name, "Benden Weyr, Pern, Sagittarius Sector")
+        self.assertEqual(msg.header.msgnum, 158)
+        self.assertEqual(msg.header.msgdate, "09-03-94")
+        self.assertEqual(msg.header.msgtime, "23:45")
+
+        # Check body content (basic check)
+        self.assertIn("Hi Wes. Seen your message", msg.text)
+        self.assertIn("M2261SA", msg.text)
+
+    def test_markdown_multi_message_round_trip(self):
+        input_path = "testdata/test2_qwk.zip"
+        if not os.path.exists(input_path):
+            self.skipTest("testdata/test2_qwk.zip not found")
+
+        markdown_path = os.path.join(self.test_dir, "test_multi.md")
+
+        # Export
+        settings_export = ProcessingSettings(
+            verbose=True,
+            private=True,
+            no_header=False,
+            truncate_signatures=False,
+            cut_quoting=False,
+            individual_files=False,
+            threaded=False,
+            binaries_removal=False,
+            redact_pii=False,
+            format='markdown',
+            separator='auto',
+            output_mode='file',
+            output_path=markdown_path,
+            encoding='cp437',
+            quiet=True
+        )
+        process_merged_files([input_path], settings_export, self.logger)
+
+        # Import
+        messages, board_dict = load_data(markdown_path, self.logger)
+
+        # Assertions
+        self.assertEqual(len(messages), 2)
+
+        # First message
+        msg1 = messages[0]
+        self.assertEqual(msg1.header.msgsubject.strip(), "I NEED A DOOM FIX......")
+        self.assertEqual(msg1.header.msgnum, 199)
+        self.assertIn("Try the Alternative BBS", msg1.text)
+
+        # Second message
+        msg2 = messages[1]
+        self.assertEqual(msg2.header.msgsubject.strip(), "GUS Problem")
+        self.assertEqual(msg2.header.msgnum, 200)
+        self.assertIn("Are you sure that you have stereo wires", msg2.text)
+
+    def test_markdown_import_with_attachments(self):
+        markdown_content = """
+# Archive
+
+## Message with Attachments
+- **Date:** 01-01-24 12:00
+- **From:** Alice
+- **To:** Bob
+- **Conference:** General (1)
+- **Attachments:** [image.jpg](attachments/image.jpg), [data.zip](attachments/data.zip)
+
+Hello with files.
+"""
+        markdown_path = os.path.join(self.test_dir, "test_attach.md")
+        with open(markdown_path, 'w', encoding='utf-8') as f:
+            f.write(markdown_content)
+
+        messages, _ = load_data(markdown_path, self.logger)
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(messages[0].attachments, ["image.jpg", "data.zip"])
+
+    def test_markdown_import_plain_attachments(self):
+        markdown_content = """
+# Archive
+
+## Message with Attachments
+- **Date:** 01-01-24 12:00
+- **From:** Alice
+- **To:** Bob
+- **Conference:** General (1)
+- **Attachments:** file1.txt, file2.txt
+
+Hello with plain attachments.
+"""
+        markdown_path = os.path.join(self.test_dir, "test_attach_plain.md")
+        with open(markdown_path, 'w', encoding='utf-8') as f:
+            f.write(markdown_content)
+
+        messages, _ = load_data(markdown_path, self.logger)
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(messages[0].attachments, ["file1.txt", "file2.txt"])
+
+    def test_markdown_import_threaded(self):
+        markdown_content = """
+# Archive
+
+## Root Message
+- **Date:** 01-01-24 12:00
+- **From:** Alice
+- **To:** Bob
+- **Conference:** General (1)
+
+Root content.
+
+---
+
+> ## Reply Message
+> - **Date:** 01-01-24 12:10
+> - **From:** Bob
+> - **To:** Alice
+> - **Conference:** General (1)
+>
+> Reply content.
+"""
+        markdown_path = os.path.join(self.test_dir, "test_threaded.md")
+        with open(markdown_path, 'w', encoding='utf-8') as f:
+            f.write(markdown_content)
+
+        messages, _ = load_data(markdown_path, self.logger)
+        self.assertEqual(len(messages), 2)
+        self.assertEqual(messages[0].depth, 0)
+        self.assertEqual(messages[1].depth, 1)
+        self.assertEqual(messages[1].header.msgfrom, "Bob")
+        self.assertEqual(messages[1].text, "Reply content.")
+
+    def test_markdown_import_with_internal_separators(self):
+        markdown_content = """
+# Archive
+
+## Message with HR
+- **Date:** 01-01-24 12:00
+- **From:** Alice
+- **To:** Bob
+- **Conference:** General (1)
+
+This is the first part.
+
+---
+
+This is the second part (after a horizontal rule).
+"""
+        markdown_path = os.path.join(self.test_dir, "test_hr.md")
+        with open(markdown_path, 'w', encoding='utf-8') as f:
+            f.write(markdown_content)
+
+        messages, _ = load_data(markdown_path, self.logger)
+        self.assertEqual(len(messages), 1)
+        self.assertIn("first part", messages[0].text)
+        self.assertIn("---", messages[0].text)
+        self.assertIn("second part", messages[0].text)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR introduces the ability to import mail archives from Markdown files, creating symmetry with the existing Markdown export functionality.

The parser is designed to handle the specific format generated by pyqwk's Markdown exporter, including:
- Metadata extraction (Subject, Date, From, To, Conference, BBS, Number, Attachments).
- Body text extraction, with support for internal horizontal rules (`---`).
- Threading reconstruction based on blockquote depth (`> `).

The feature was tested with round-trip exports and imports, ensuring that both metadata and content are preserved correctly. All existing tests passed, and new tests were added to cover specific Markdown edge cases.

---
*PR created automatically by Jules for task [17791032177665884722](https://jules.google.com/task/17791032177665884722) started by @RainRat*