### PR TITLE
Fix Markdown blockquote parsing for empty lines

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -1116,13 +1116,15 @@ def _parse_markdown_messages(path: str) -> list[ParsedMessage]:
         # Detect blockquote depth for threaded Markdown
         depth = 0
         working_section = section.lstrip('\n')
-        while working_section.startswith('> '):
+        while working_section.startswith('>'):
             depth += 1
             lines = working_section.splitlines()
             new_lines = []
             for line in lines:
                 if line.startswith('> '):
                     new_lines.append(line[2:])
+                elif line.startswith('>'):
+                    new_lines.append(line[1:])
                 elif not line.strip():
                     new_lines.append("")
                 else:


### PR DESCRIPTION
### What
Updated the `_parse_markdown_messages` function in `pyqwk/core.py` to correctly identify and strip blockquote markers (`>`) even when they are not followed by a space.

### Why
In Markdown, blockquote lines can start with either `> ` or just `>`. The previous implementation only recognized the former, which led to incorrect parsing of threaded messages where empty lines were represented as a single `>`. This caused the `>` character to remain in the processed message body. This fix aligns the parser with standard Markdown behavior and ensures clean message text for threaded exports.

### Verification Results
*   Ran `python3 -m pytest tests/test_markdown_import.py`: All 6 tests passed, including `test_markdown_import_threaded` which was previously failing.
*   Ran full test suite: 602 tests passed successfully.
*   Code review confirmed the logic is sound and non-breaking.

---
*PR created automatically by Jules for task [5174953043166511849](https://jules.google.com/task/5174953043166511849) started by @RainRat*