### PR TITLE
[DOCS] Standardize and complete Markdown support documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pyqwk
 
-pyqwk is a tool to convert `.QWK`, `.REP`, `.JSON`, `.CSV`, `.XML`, SQLite, `.mbox`, and `.eml` mail archives into modern formats like Text, HTML, JSON, XML, Markdown, CSV, mbox, EML, and SQLite.
+pyqwk is a tool to convert `.QWK`, `.REP`, `.JSON`, `.CSV`, `.XML`, SQLite, `.mbox`, `.eml`, and Markdown mail archives into modern formats like Text, HTML, JSON, XML, Markdown, CSV, mbox, EML, and SQLite.
 
 ## What are QWK and REP files?
 
@@ -47,6 +47,7 @@ python qwk.py archive.csv
 python qwk.py archive.xml
 python qwk.py archive.mbox
 python qwk.py archive.eml
+python qwk.py archive.md
 python qwk.py messages.db
 ```
 
@@ -66,11 +67,6 @@ You can install `pyqwk` to use it from any folder on your computer.
 4. Launch the graphical reader:
    ```bash
    qwk-gui
-   ```
-
-**5. Import from Markdown:**
-   ```bash
-   qwk archive.md -o messages.html
    ```
 
 *Note: You can also run the reader directly without installing:*
@@ -221,6 +217,11 @@ qwk messages.csv -o updated.html
 **Import from an XML file:**
 ```bash
 qwk archive.xml -o messages.html
+```
+
+**Import from Markdown:**
+```bash
+qwk archive.md -o messages.html
 ```
 
 *Note for Windows users: If you use symbols like `*` (wildcards) to select multiple files, use PowerShell instead of the standard Command Prompt.*

--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -90,7 +90,7 @@ examples:
     )
     parser.add_argument(
         'input_paths',
-        help='Path to one or more message archives, ZIP files, or folders. Supports QWK, REP, JSON, CSV, XML, MBOX, EML, and SQLite.',
+        help='Path to one or more message archives, ZIP files, or folders. Supports QWK, REP, JSON, CSV, XML, MBOX, EML, Markdown, and SQLite.',
         nargs='+',
     )
 

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -1237,7 +1237,7 @@ def load_data(
     """Load message data and conference mappings from an archive file.
 
     This function handles both raw legacy formats (QWK, REP) and modern
-    structured formats (JSON, SQLite, XML, CSV, mbox, EML).
+    structured formats (JSON, SQLite, XML, CSV, mbox, EML, Markdown).
 
     Args:
         input_path: Path to the archive file or a raw 'MESSAGES.DAT' file.

--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -239,7 +239,7 @@ class QwkGuiApp:
         self.detail_text.insert(tk.END, "Use Ctrl+O or the 'Open' button in the toolbar to load a message archive.\n\n", "body")
 
         self.detail_text.insert(tk.END, "Supported Formats:\n", "header_label")
-        formats = "QWK, REP, JSON, CSV, SQLite (.db), XML, mbox, EML, and MESSAGES.DAT"
+        formats = "QWK, REP, JSON, CSV, SQLite (.db), XML, mbox, EML, Markdown, and MESSAGES.DAT"
         self.detail_text.insert(tk.END, f"{formats}\n\n", "body")
 
         self.detail_text.insert(tk.END, "Keyboard Shortcuts:\n", "header_label")


### PR DESCRIPTION
This PR standardizes and completes the documentation for Markdown support across the project. While Markdown import was already supported, it was inconsistently listed in user-facing documentation and internal help strings.

Key changes:
1. **README.md**: Added Markdown to the primary features and Quick Start sections. Moved the "Import from Markdown" example from Installation to Usage Examples for better logical flow.
2. **CLI Help**: Updated the `input_paths` help text in `pyqwk/cli.py` to inform users that Markdown files are supported as input.
3. **GUI Welcome Screen**: Included Markdown in the list of supported formats displayed when the Graphical Reader starts.
4. **API Documentation**: Updated the `load_data` docstring in `pyqwk/core.py` to ensure developers are aware of Markdown support when using the library.

These changes improve discoverability and usability of the Markdown import feature without affecting application logic.

---
*PR created automatically by Jules for task [6600262125882455403](https://jules.google.com/task/6600262125882455403) started by @RainRat*