### PR TITLE
Fix Markdown blockquote parsing and prevent infinite loop

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -1116,13 +1116,15 @@ def _parse_markdown_messages(path: str) -> list[ParsedMessage]:
         # Detect blockquote depth for threaded Markdown
         depth = 0
         working_section = section.lstrip('\n')
-        while working_section.startswith('> '):
+        while working_section.startswith('>'):
             depth += 1
             lines = working_section.splitlines()
             new_lines = []
             for line in lines:
                 if line.startswith('> '):
                     new_lines.append(line[2:])
+                elif line.startswith('>'):
+                    new_lines.append(line[1:])
                 elif not line.strip():
                     new_lines.append("")
                 else:


### PR DESCRIPTION
* **What:** Updated the `_parse_markdown_messages` function in `pyqwk/core.py` to correctly identify and strip Markdown blockquote markers (`>`). The logic now handles markers even when they are not followed by a space (e.g., `>content` or a line containing only `>`).
* **Why:** Previously, the parser only recognized `> ` (with a space), causing it to fail on valid Markdown and, in a previous iteration of the fix, potentially enter an infinite loop if a line started with `>` but didn't match the stripping criteria. This change ensures robust parsing of threaded Markdown archives and fixes the `test_markdown_import_threaded` test failure. No breaking changes were introduced, and the full test suite passes.

---
*PR created automatically by Jules for task [15645870466042921417](https://jules.google.com/task/15645870466042921417) started by @RainRat*