### PR TITLE
[TEST] Fix blockquote parsing in Markdown imports and add coverage for markers without spaces

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -1116,13 +1116,15 @@ def _parse_markdown_messages(path: str) -> list[ParsedMessage]:
         # Detect blockquote depth for threaded Markdown
         depth = 0
         working_section = section.lstrip('\n')
-        while working_section.startswith('> '):
+        while working_section.startswith('>'):
             depth += 1
             lines = working_section.splitlines()
             new_lines = []
             for line in lines:
                 if line.startswith('> '):
                     new_lines.append(line[2:])
+                elif line.startswith('>'):
+                    new_lines.append(line[1:])
                 elif not line.strip():
                     new_lines.append("")
                 else:

--- a/tests/test_markdown_import.py
+++ b/tests/test_markdown_import.py
@@ -192,6 +192,39 @@ Root content.
         self.assertEqual(messages[1].header.msgfrom, "Bob")
         self.assertEqual(messages[1].text, "Reply content.")
 
+    def test_markdown_import_threaded_no_space(self):
+        markdown_content = """
+# Archive
+
+## Root Message
+- **Date:** 01-01-24 12:00
+- **From:** Alice
+- **To:** Bob
+- **Conference:** General (1)
+
+Root content.
+
+---
+
+>## Reply Message
+>- **Date:** 01-01-24 12:10
+>- **From:** Bob
+>- **To:** Alice
+>- **Conference:** General (1)
+>
+>Reply content.
+"""
+        markdown_path = os.path.join(self.test_dir, "test_threaded_no_space.md")
+        with open(markdown_path, 'w', encoding='utf-8') as f:
+            f.write(markdown_content)
+
+        messages, _ = load_data(markdown_path, self.logger)
+        self.assertEqual(len(messages), 2)
+        self.assertEqual(messages[0].depth, 0)
+        self.assertEqual(messages[1].depth, 1)
+        self.assertEqual(messages[1].header.msgfrom, "Bob")
+        self.assertEqual(messages[1].text, "Reply content.")
+
     def test_markdown_import_with_internal_separators(self):
         markdown_content = """
 # Archive


### PR DESCRIPTION
Fixed a bug in `pyqwk/core.py` where the Markdown importer failed to correctly strip blockquote markers if they didn't have a trailing space (e.g., `>`). This often happened on empty lines within a quoted block, leading to `>` characters appearing in the parsed message text.

The fix involves updating the `while` loop and the inner line-processing logic in `_parse_markdown_messages` to handle both `> ` and `>` correctly.

A corresponding test case was added to `tests/test_markdown_import.py` to ensure robust coverage for this edge case.

---
*PR created automatically by Jules for task [5872831204525508968](https://jules.google.com/task/5872831204525508968) started by @RainRat*