### PR TITLE
[UI/UX] Improve Graphical Reader toolbar hierarchy and reset workflow

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -355,8 +355,13 @@ class QwkGuiApp:
         self.message_list.focus(new_item)
 
     def clear_search(self, _event: object | None = None) -> None:
-        self.search_var.set("")
-        self.message_list.focus_set()
+        """Clear the search bar first, and if already empty, reset all filters."""
+        if self.search_var.get():
+            self.search_var.set("")
+            self.reload_messages()
+            self.message_list.focus_set()
+        else:
+            self.clear_filters()
 
     def _focus_search(self, _event: object | None = None) -> None:
         """Focus the search bar and select all text for quick replacement."""
@@ -364,7 +369,8 @@ class QwkGuiApp:
         self.search_entry.selection_range(0, tk.END)
 
     def clear_filters(self, _event: object | None = None) -> None:
-        """Reset all filters to their default state."""
+        """Reset all filters and search to their default state."""
+        self.search_var.set("")
         try:
             self.bbs_combo.current(0)
         except Exception:
@@ -395,7 +401,7 @@ class QwkGuiApp:
         toolbar = ttk.Frame(self.root, padding=(10, 5))
         toolbar.pack(side=tk.TOP, fill=tk.X)
 
-        # Row 1: Actions and Search
+        # Row 1: Actions and View Options
         row1 = ttk.Frame(toolbar)
         row1.pack(side=tk.TOP, fill=tk.X, pady=(0, 5))
 
@@ -409,7 +415,24 @@ class QwkGuiApp:
 
         ttk.Separator(row1, orient=tk.VERTICAL).pack(side=tk.LEFT, fill=tk.Y, padx=10)
 
-        search_frame = ttk.Frame(row1)
+        options_frame = ttk.Frame(row1)
+        options_frame.pack(side=tk.LEFT, padx=5)
+        ttk.Label(options_frame, text="View:").pack(side=tk.LEFT, padx=(0, 5))
+
+        for text, var in [
+            ("Threaded", self.threaded_var),
+            ("Clean", self.clean_var),
+            ("Remove Colors", self.ansi_var),
+        ]:
+            ttk.Checkbutton(
+                options_frame, text=text, variable=var, command=self.reload_messages
+            ).pack(side=tk.LEFT, padx=5)
+
+        # Row 2: Search and Filters
+        row2 = ttk.Frame(toolbar)
+        row2.pack(side=tk.TOP, fill=tk.X)
+
+        search_frame = ttk.Frame(row2)
         search_frame.pack(side=tk.LEFT, padx=5)
         ttk.Label(search_frame, text="Search:").pack(side=tk.LEFT)
         self.search_entry = ttk.Entry(
@@ -419,13 +442,8 @@ class QwkGuiApp:
         ttk.Checkbutton(
             search_frame, text="Regex", variable=self.regex_var, command=self.reload_messages
         ).pack(side=tk.LEFT, padx=5)
-        ttk.Button(search_frame, text="×", width=2, command=self.clear_search).pack(
-            side=tk.LEFT
-        )
 
-        # Row 2: Filters and View Options
-        row2 = ttk.Frame(toolbar)
-        row2.pack(side=tk.TOP, fill=tk.X)
+        ttk.Separator(row2, orient=tk.VERTICAL).pack(side=tk.LEFT, fill=tk.Y, padx=10)
 
         filters_frame = ttk.Frame(row2)
         filters_frame.pack(side=tk.LEFT, padx=5)
@@ -444,24 +462,9 @@ class QwkGuiApp:
                 filters_frame, text=text, variable=var, command=self.reload_messages
             ).pack(side=tk.LEFT, padx=5)
 
-        ttk.Button(filters_frame, text="×", width=2, command=self.clear_filters).pack(
-            side=tk.LEFT
+        ttk.Button(row2, text="Reset All", command=self.clear_filters).pack(
+            side=tk.LEFT, padx=10
         )
-
-        ttk.Separator(row2, orient=tk.VERTICAL).pack(side=tk.LEFT, fill=tk.Y, padx=10)
-
-        options_frame = ttk.Frame(row2)
-        options_frame.pack(side=tk.LEFT, padx=5)
-        ttk.Label(options_frame, text="View:").pack(side=tk.LEFT, padx=(0, 5))
-
-        for text, var in [
-            ("Threaded", self.threaded_var),
-            ("Clean", self.clean_var),
-            ("Remove Colors", self.ansi_var),
-        ]:
-            ttk.Checkbutton(
-                options_frame, text=text, variable=var, command=self.reload_messages
-            ).pack(side=tk.LEFT, padx=5)
 
         # Binds
         self.search_entry.bind("<Return>", self._on_search_enter)

--- a/tests/test_gui_ux_enhancements_v2.py
+++ b/tests/test_gui_ux_enhancements_v2.py
@@ -1,0 +1,96 @@
+import sys
+from unittest.mock import MagicMock, patch
+import pytest
+from pyqwk.gui import QwkGuiApp
+
+@pytest.fixture
+def mock_gui_deps():
+    with patch("pyqwk.gui.tk") as mock_tk, \
+         patch("pyqwk.gui.ttk") as mock_ttk, \
+         patch("pyqwk.gui.filedialog") as mock_fd, \
+         patch("pyqwk.gui.messagebox") as mock_mb:
+
+        # Configure Variable mocks
+        def make_var(value=None):
+            m = MagicMock()
+            m.get.return_value = value
+            return m
+
+        mock_tk.BooleanVar.side_effect = lambda value=False, **kwargs: make_var(value)
+        mock_tk.StringVar.side_effect = lambda value="", **kwargs: make_var(value)
+        mock_tk.IntVar.side_effect = lambda value=0, **kwargs: make_var(value)
+
+        # Tkinter constants
+        mock_tk.END = "end"
+        mock_tk.HORIZONTAL = "horizontal"
+        mock_tk.VERTICAL = "vertical"
+        mock_tk.BOTH = "both"
+        mock_tk.X = "x"
+        mock_tk.Y = "y"
+        mock_tk.LEFT = "left"
+        mock_tk.RIGHT = "right"
+        mock_tk.TOP = "top"
+        mock_tk.BOTTOM = "bottom"
+        mock_tk.SUNKEN = "sunken"
+        mock_tk.W = "w"
+        mock_tk.E = "e"
+        mock_tk.WORD = "word"
+        mock_tk.DISABLED = "disabled"
+        mock_tk.NORMAL = "normal"
+        mock_tk.INSERT = "insert"
+
+        # Mock classes/types
+        class TclError(Exception):
+            pass
+        mock_tk.TclError = TclError
+
+        # Mock Combobox
+        mock_combo = MagicMock()
+        mock_ttk.Combobox.return_value = mock_combo
+
+        yield {
+            "tk": mock_tk,
+            "ttk": mock_ttk,
+            "filedialog": mock_fd,
+            "messagebox": mock_mb,
+            "combo": mock_combo,
+            "bbs_combo": MagicMock(),
+            "conf_combo": MagicMock(),
+        }
+
+def test_clear_search_progressive(mock_gui_deps):
+    root = MagicMock()
+    app = QwkGuiApp(root)
+
+    # Manually assign mocks to comboboxes to avoid using the same return_value from mock_ttk.Combobox
+    app.bbs_combo = mock_gui_deps["bbs_combo"]
+    app.conf_combo = mock_gui_deps["conf_combo"]
+
+    # Case 1: Search bar has text
+    app.search_var.get.return_value = "some search"
+    with patch.object(app, 'reload_messages') as mock_reload, \
+         patch.object(app, 'clear_filters') as mock_clear_filters:
+        app.clear_search()
+        app.search_var.set.assert_called_with("")
+        mock_reload.assert_called_once()
+        mock_clear_filters.assert_not_called()
+
+    # Case 2: Search bar is already empty
+    app.search_var.set.reset_mock()
+    app.search_var.get.return_value = ""
+    with patch.object(app, 'reload_messages') as mock_reload, \
+         patch.object(app, 'clear_filters') as mock_clear_filters:
+        app.clear_search()
+        mock_clear_filters.assert_called_once()
+
+def test_clear_filters_resets_search(mock_gui_deps):
+    root = MagicMock()
+    app = QwkGuiApp(root)
+
+    app.bbs_combo = mock_gui_deps["bbs_combo"]
+    app.conf_combo = mock_gui_deps["conf_combo"]
+
+    with patch.object(app, 'reload_messages') as mock_reload:
+        app.clear_filters()
+        app.search_var.set.assert_called_with("")
+        mock_reload.assert_called_once()


### PR DESCRIPTION
This PR improves the usability and visual hierarchy of the Graphical Reader's toolbar. 

Key changes:
1. **Toolbar Reorganization:** Controls are now grouped logically into two rows. Row 1 contains global file actions and view toggles, while Row 2 focuses on search and data-driven filters.
2. **Friction Reduction:** Individual '×' buttons have been removed in favor of a single 'Reset All' button, reducing visual clutter and simplifying the reset workflow.
3. **Progressive Clearing (Escape Key):** The `clear_search` method (bound to the Escape key) now implements a state-aware workflow. If the search bar contains text, the first press clears it. If the search bar is already empty, the second press resets all filters and conferences to their default state.

These changes adhere to the "Invisible Design" principle by making common workflows more intuitive without adding decorative elements.

---
*PR created automatically by Jules for task [2747185296000064564](https://jules.google.com/task/2747185296000064564) started by @RainRat*