### PR TITLE
[FEAT] GUI Attachment Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ qwk-gui archive.eml
 
 **Key Features:**
 - **Search:** Quickly find messages by keyword. Use the **Regex** checkbox to search with advanced patterns (regular expressions). Results are highlighted in the text. You can also highlight any text in a message, right-click, and select **Search for '[Selected Text]'** to instantly find related messages.
+- **Attachments:** Messages containing attachments (UUE, Base64, yEnc) display clickable links in the header. Click any attachment name to save it to your computer. You can also use **File > Extract All Attachments...** to batch-save all attachments from the current filtered view to a folder.
 - **Filtering:** View messages from specific BBSes or conferences, include private messages, filter by the presence of attachments, or only show messages from/to yourself.
 - **Context Menus:** Right-click on any message in the list to copy its metadata (Subject, From, To) or instantly filter the entire view by that author, conference, or BBS. You can also right-click in the message text to copy selected sections.
 - **Exporting:** Save your current filtered and sorted view to any supported format (HTML, Markdown, JSON, etc.).

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -1116,13 +1116,20 @@ def _parse_markdown_messages(path: str) -> list[ParsedMessage]:
         # Detect blockquote depth for threaded Markdown
         depth = 0
         working_section = section.lstrip('\n')
-        while working_section.startswith('> '):
+        while working_section.startswith('>'):
+            # Only count as blockquote if the first line starts with "> " or is exactly ">"
+            first_line = working_section.splitlines()[0] if working_section else ""
+            if not (first_line.startswith('> ') or first_line == '>'):
+                break
+
             depth += 1
             lines = working_section.splitlines()
             new_lines = []
             for line in lines:
                 if line.startswith('> '):
                     new_lines.append(line[2:])
+                elif line == '>':
+                    new_lines.append("")
                 elif not line.strip():
                     new_lines.append("")
                 else:

--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -274,6 +274,10 @@ class QwkGuiApp:
             accelerator="Ctrl+S",
         )
         file_menu.add_command(
+            label="Extract All Attachments...",
+            command=self.extract_all_attachments,
+        )
+        file_menu.add_command(
             label="Statistics...",
             command=self.show_stats_window,
             accelerator="Ctrl+I",
@@ -672,9 +676,10 @@ class QwkGuiApp:
 
         if message.refnum:
             self.detail_text.insert(tk.END, "  •  ", "header_meta")
-            self.detail_text.insert(tk.END, f"Ref #{message.refnum}", "link")
+            ref_tag = f"ref_link_{id(message)}"
+            self.detail_text.insert(tk.END, f"Ref #{message.refnum}", ("link", ref_tag))
             self.detail_text.tag_bind(
-                "link",
+                ref_tag,
                 "<Button-1>",
                 lambda e, c=header.confnum, r=message.refnum: self.jump_to_message(c, r),
             )
@@ -686,7 +691,17 @@ class QwkGuiApp:
 
         if message.attachments:
             self.detail_text.insert(tk.END, "Attachments: ", "header_label")
-            self.detail_text.insert(tk.END, ", ".join(message.attachments) + "\n", "header_value")
+            for i, filename in enumerate(message.attachments):
+                tag = f"attach_link_{id(message)}_{i}"
+                self.detail_text.insert(tk.END, filename, ("link", tag))
+                self.detail_text.tag_bind(
+                    tag,
+                    "<Button-1>",
+                    lambda e, f=filename, idx=i: self.save_attachment(f, idx),
+                )
+                if i < len(message.attachments) - 1:
+                    self.detail_text.insert(tk.END, ", ", "header_value")
+            self.detail_text.insert(tk.END, "\n")
 
         header_end = self.detail_text.index(tk.INSERT)
         self.detail_text.tag_add("header_area", header_start, header_end)
@@ -1116,6 +1131,90 @@ class QwkGuiApp:
     def _set_detail_text(self, text: str) -> None:
         self.detail_text.delete("1.0", tk.END)
         self.detail_text.insert(tk.END, text)
+
+    def save_attachment(self, filename: str, attachment_index: int) -> None:
+        """Save a specific attachment from the currently selected message."""
+        current_selection = self.message_list.selection()
+        if not current_selection:
+            return
+
+        try:
+            idx = int(current_selection[0])
+            msg = self.messages[idx]
+
+            # Re-extract to get the raw data
+            if not msg.text:
+                return
+            found = extract_binaries(msg.text)
+            if attachment_index >= len(found):
+                return
+
+            _, data = found[attachment_index]
+
+            initial_file = os.path.basename(filename)
+            path = filedialog.asksaveasfilename(
+                title=f"Save Attachment: {initial_file}",
+                initialfile=initial_file,
+            )
+
+            if path:
+                with open(path, 'wb') as f:
+                    f.write(data)
+                self.status_label.config(text=f"Saved attachment to {os.path.basename(path)}")
+        except Exception as e:
+            messagebox.showerror("Save Attachment", f"Failed to save attachment: {e}")
+
+    def extract_all_attachments(self, _event: object | None = None) -> None:
+        """Batch-extract all attachments from the current filtered view."""
+        if not self.messages:
+            messagebox.showwarning("Extract Attachments", "No messages to process.")
+            return
+
+        folder = filedialog.askdirectory(title="Select Folder to Extract Attachments")
+        if not folder:
+            return
+
+        try:
+            count = 0
+            # Use messages in their current display order from the treeview
+            ordered_item_ids = self._get_all_tree_items()
+
+            for iid in ordered_item_ids:
+                try:
+                    idx = int(iid)
+                    msg = self.messages[idx]
+                    if not msg.text:
+                        continue
+
+                    found = extract_binaries(msg.text)
+                    for filename, data in found:
+                        # Sanitize filename
+                        filename = os.path.basename(filename)
+                        if not filename:
+                            filename = "attachment.bin"
+
+                        target_path = os.path.join(folder, filename)
+                        # Collision avoidance
+                        if os.path.exists(target_path):
+                            base, ext = os.path.splitext(filename)
+                            counter = 1
+                            while os.path.exists(target_path):
+                                target_path = os.path.join(folder, f"{base}_{counter}{ext}")
+                                counter += 1
+
+                        with open(target_path, 'wb') as f:
+                            f.write(data)
+                        count += 1
+                except (ValueError, IndexError):
+                    continue
+
+            messagebox.showinfo(
+                "Extraction Successful",
+                f"Successfully extracted {count} attachments to {folder}",
+            )
+            self.status_label.config(text=f"Extracted {count} attachments")
+        except Exception as e:
+            messagebox.showerror("Extraction Failed", f"Failed to extract attachments: {e}")
 
     def export_messages(self, _event: object | None = None) -> None:
         """Export the currently filtered and sorted messages to a file."""

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -145,7 +145,15 @@ class TestQwkGui:
 
             # Verify Ref #: was rendered
             app._render_message(0)
-            app.detail_text.insert.assert_any_call(mock_gui_deps["tk"].END, "Ref #99", "link")
+            # Find the call with "Ref #99". The tag should be ('link', 'ref_link_...')
+            found_ref = False
+            for call in app.detail_text.insert.call_args_list:
+                if len(call.args) >= 2 and call.args[1] == "Ref #99":
+                    tags = call.args[2]
+                    if isinstance(tags, tuple) and "link" in tags and any(t.startswith("ref_link_") for t in tags):
+                        found_ref = True
+                        break
+            assert found_ref, "Ref #99 link with correct tags not found"
 
     def test_load_messages_error(self, mock_gui_deps):
         app = get_app()

--- a/tests/test_gui_attachments.py
+++ b/tests/test_gui_attachments.py
@@ -67,5 +67,8 @@ def test_gui_renders_attachments(mock_gui_deps):
 
     # Check if "Attachments: " label was inserted
     app.detail_text.insert.assert_any_call(mock_gui_deps["tk"].END, "Attachments: ", "header_label")
-    # Check if attachment names were inserted
-    app.detail_text.insert.assert_any_call(mock_gui_deps["tk"].END, "file1.zip, image.jpg\n", "header_value")
+    # Check if attachment names were inserted as links
+    # Note: Using id(message) in tags
+    msg_id = id(message)
+    app.detail_text.insert.assert_any_call(mock_gui_deps["tk"].END, "file1.zip", ("link", f"attach_link_{msg_id}_0"))
+    app.detail_text.insert.assert_any_call(mock_gui_deps["tk"].END, "image.jpg", ("link", f"attach_link_{msg_id}_1"))

--- a/tests/test_gui_batch_attachments.py
+++ b/tests/test_gui_batch_attachments.py
@@ -1,0 +1,118 @@
+import sys
+import os
+from unittest.mock import MagicMock, patch
+import pytest
+from pyqwk.core import ParsedMessage, MessageHeader
+
+# Mock tkinter before any pyqwk.gui imports
+mock_tk = MagicMock()
+mock_ttk = MagicMock()
+sys.modules["tkinter"] = mock_tk
+sys.modules["tkinter.filedialog"] = MagicMock()
+sys.modules["tkinter.messagebox"] = MagicMock()
+sys.modules["tkinter.ttk"] = mock_ttk
+
+from pyqwk.gui import QwkGuiApp
+
+@pytest.fixture
+def mock_gui_deps():
+    with patch("pyqwk.gui.tk") as mock_tk, \
+         patch("pyqwk.gui.ttk") as mock_ttk, \
+         patch("pyqwk.gui.filedialog") as mock_fd, \
+         patch("pyqwk.gui.messagebox") as mock_mb:
+
+        mock_tk.END = "end"
+        mock_tk.INSERT = "insert"
+
+        # Configure Variable mocks
+        def make_var(value=None):
+            m = MagicMock()
+            m.get.return_value = value
+            return m
+
+        mock_tk.BooleanVar.side_effect = lambda value=False, **kwargs: make_var(value)
+        mock_tk.StringVar.side_effect = lambda value="", **kwargs: make_var(value)
+        mock_tk.IntVar.side_effect = lambda value=0, **kwargs: make_var(value)
+
+        yield {
+            "tk": mock_tk,
+            "ttk": mock_ttk,
+            "filedialog": mock_fd,
+            "messagebox": mock_mb,
+        }
+
+def test_extract_all_attachments(mock_gui_deps, tmp_path):
+    root = MagicMock()
+    app = QwkGuiApp(root)
+
+    # Setup messages with attachments
+    header = MessageHeader(
+        status=' ', msgnum=1, msgdate='01-01-90', msgtime='12:00',
+        msgto='All', msgfrom='User', msgsubject='Subject',
+        msgpassword='', refnum=None, numblocks=1, msgflag=' ',
+        confnum=1, lognum=1, nettag=''
+    )
+
+    # Message with UUE attachment
+    uue_text = "begin 644 test.txt\n#0V%T\n`\nend"
+    message = ParsedMessage(
+        text=uue_text,
+        msgnum=1,
+        refnum=None,
+        confnum=1,
+        header=header,
+    )
+
+    app.messages = [message]
+
+    def get_children_side_effect(parent=""):
+        if parent == "":
+            return ["0"]
+        return []
+    app.message_list.get_children.side_effect = get_children_side_effect
+
+    # Mock askdirectory to return tmp_path
+    mock_gui_deps["filedialog"].askdirectory.return_value = str(tmp_path)
+
+    # Trigger extraction
+    app.extract_all_attachments()
+
+    # Check if file was created
+    target_file = tmp_path / "test.txt"
+    assert target_file.exists()
+    assert target_file.read_text().strip() == "Cat"
+
+def test_save_individual_attachment(mock_gui_deps, tmp_path):
+    root = MagicMock()
+    app = QwkGuiApp(root)
+
+    # Setup message with attachment
+    header = MessageHeader(
+        status=' ', msgnum=1, msgdate='01-01-90', msgtime='12:00',
+        msgto='All', msgfrom='User', msgsubject='Subject',
+        msgpassword='', refnum=None, numblocks=1, msgflag=' ',
+        confnum=1, lognum=1, nettag=''
+    )
+
+    uue_text = "begin 644 test_save.txt\n#0V%T\n`\nend"
+    message = ParsedMessage(
+        text=uue_text,
+        msgnum=1,
+        refnum=None,
+        confnum=1,
+        header=header,
+    )
+
+    app.messages = [message]
+    app.message_list.selection.return_value = ["0"]
+
+    # Mock asksaveasfilename
+    save_path = tmp_path / "saved_test.txt"
+    mock_gui_deps["filedialog"].asksaveasfilename.return_value = str(save_path)
+
+    # Trigger individual save
+    app.save_attachment("test_save.txt", 0)
+
+    # Check if file was created
+    assert save_path.exists()
+    assert save_path.read_text().strip() == "Cat"


### PR DESCRIPTION
This PR introduces comprehensive attachment management to the Graphical Reader. 

Previously, the GUI only listed detected attachments as static text. This update makes them interactive:
1. **Interactive Links:** Each attachment name in the message header is now a clickable link. Clicking a link prompts the user to save that specific file.
2. **Batch Extraction:** A new "File > Extract All Attachments..." menu option allows users to batch-save every attachment from the messages currently visible in their filtered/searched view into a selected folder.
3. **Robustness:** 
    - Uses `os.path.basename` for safe filename handling.
    - Implements filename collision avoidance in batch mode (e.g., `image_1.jpg`).
    - Uses unique instance-based tags (`id(message)`) for Link bindings, fixing a subtle issue where global tags could accumulate stale callbacks.
4. **Fixes:** Includes a fix for a regression in Markdown blockquote parsing where empty lines within quotes would retain a `>` marker.
5. **Documentation:** Updated README.md to reflect these new capabilities.

All 604 tests pass.

---
*PR created automatically by Jules for task [5290123788703604951](https://jules.google.com/task/5290123788703604951) started by @RainRat*