### PR TITLE
[DOCS] Improve intent-focused comments in threading logic

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -3832,7 +3832,7 @@ def _order_messages_by_thread(messages: list[ProcessedMessage]) -> list[Processe
     children: dict[int, list[int]] = defaultdict(list)
     roots: list[int] = []
 
-    # 1. Indexing
+    # Build lookup tables to efficiently match replies by message number and subject
     for index, message in enumerate(messages):
         if message.msgnum is not None:
             index_by_key[(message.confnum, message.msgnum)] = index
@@ -3842,7 +3842,7 @@ def _order_messages_by_thread(messages: list[ProcessedMessage]) -> list[Processe
         if subj:
             index_by_subject[(message.confnum, subj)].append(index)
 
-    # 2. Identify Parents
+    # Establish parent-child relationships using explicit references or subject-based heuristics
     parent_map: dict[int, int] = {}
 
     for index, message in enumerate(messages):
@@ -3886,7 +3886,7 @@ def _order_messages_by_thread(messages: list[ProcessedMessage]) -> list[Processe
         else:
             roots.append(index)
 
-    # 3. Traversal
+    # Perform an iterative depth-first traversal to group threads while safely handling potential cycles and recursion depth
     ordered_messages: list[ProcessedMessage] = []
     visited: set[int] = set()
     cycle_reported: set[int] = set()


### PR DESCRIPTION
Improved the internal documentation of a complex message-threading function by replacing vague section headers with descriptive summaries that explain the intent behind each step. This change adheres to the project's documentation standards for clarity and accessibility for a global developer audience.

---
*PR created automatically by Jules for task [13043357668175198470](https://jules.google.com/task/13043357668175198470) started by @RainRat*