### PR TITLE
[FEAT] Customizable filename patterns for individual message exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ qwk my_archives/ --organize-by-bbs
 ```
 *Tip: This automatically sorts your archives into folders named after the BBS they came from.*
 
+**Save messages with custom filenames:**
+```bash
+qwk archive.qwk --individual-files --filename-pattern "{date}_{author}_{subject}" -o output/
+```
+*Tip: Use variables like `{date}`, `{author}`, and `{subject}` to create descriptive filenames instead of just numbers.*
+
 **Merge multiple archives into one file (removing any duplicate messages):**
 ```bash
 qwk archive1.qwk archive2.qwk --merge --unique -o combined.mbox
@@ -365,6 +371,7 @@ for msg in messages:
 | :--- | :--- |
 | `-o`, `--output [path]` | Save output to a file or folder. Prints to the screen by default. |
 | `-i`, `--individual-files` | Save each message as a separate file. |
+| `--filename-pattern [pat]` | Set a pattern for naming individual files (e.g., `{date}_{author}_{subject}`). |
 | `--organize` | Organize files into subfolders by conference. |
 | `--organize-by-bbs` | Organize archives into folders named after the BBS. |
 | `-F, --format [type]` | Set output format: `text`, `html`, `json`, `xml`, `markdown`, `csv`, `mbox`, `eml`, `sqlite`. |

--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -120,6 +120,10 @@ examples:
         action='store_true',
     )
     io_group.add_argument(
+        '--filename-pattern',
+        help="A pattern for naming individual files (e.g., '{date}_{author}_{subject}'). Available variables: date, time, author, to, subject, msgnum, confnum, confname, bbs_name, bbs_id.",
+    )
+    io_group.add_argument(
         '-E',
         '--encoding',
         help="The character set of the input files. Default is 'cp437' (standard for DOS-based BBSs). Use this if messages show strange characters.",
@@ -526,6 +530,7 @@ examples:
         mine=args.mine,
         on_this_day=args.on_this_day,
         merge_stats=args.merge_stats,
+        filename_pattern=getattr(args, 'filename_pattern', None),
     )
 
     if args.organize_by_bbs:

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -349,6 +349,7 @@ class ProcessingSettings:
     output_mode: str
     output_path: str | None
     encoding: str
+    filename_pattern: str | None = None
     regex: bool = False
     dry_run: bool = False
     strip_ansi: bool = False
@@ -1851,9 +1852,41 @@ def _slugify(text: str, default: str) -> str:
     return slug if slug else default
 
 
-def _generate_safe_filename(message: ParsedMessage, output_format: str, count: int) -> str:
+def _generate_safe_filename(message: ParsedMessage, settings_or_format: ProcessingSettings | str, count: int) -> str:
     """Generate a human-readable filename for an individual message."""
+    if isinstance(settings_or_format, ProcessingSettings):
+        settings = settings_or_format
+        output_format = settings.format
+    else:
+        settings = None
+        output_format = settings_or_format
+
     ext = FORMAT_EXTENSIONS.get(output_format, '.txt')
+
+    if settings and settings.filename_pattern:
+        try:
+            mapping = {
+                'date': _slugify(message.header.msgdate, "date"),
+                'time': _slugify(message.header.msgtime, "time"),
+                'author': _slugify(message.header.msgfrom, "author"),
+                'to': _slugify(message.header.msgto, "to"),
+                'subject': _slugify(message.header.msgsubject, "subject"),
+                'msgnum': message.msgnum if message.msgnum is not None else count,
+                'confnum': message.confnum,
+                'confname': _slugify(message.confname or f"conf_{message.confnum}", "conf"),
+                'bbs_name': _slugify(message.bbs_name or "bbs", "bbs"),
+                'bbs_id': _slugify(message.bbs_id or "id", "id"),
+            }
+            # Use formatting while preserving the pattern's intent
+            filename = settings.filename_pattern.format(**mapping)
+            # Basic sanitization of the resulting filename (replace any remaining odd chars)
+            filename = re.sub(r'[^\w\-.]', '_', filename)
+            if not filename.endswith(ext):
+                filename += ext
+            return filename
+        except (KeyError, ValueError, AttributeError):
+            # Fallback to default if pattern is invalid
+            pass
 
     msg_num = message.msgnum if message.msgnum is not None else count
     slug = _slugify(message.header.msgsubject, "message")
@@ -2104,7 +2137,7 @@ def process_merged_files(
             else:
                 encoded_buffer = processed_buffer.encode(target_encoding)
 
-            filename = _generate_safe_filename(parsed_message, settings.format, processed_count)
+            filename = _generate_safe_filename(parsed_message, settings, processed_count)
             full_path = os.path.join(target_dir, filename)
 
             # Collision avoidance

--- a/tests/test_filename_patterns.py
+++ b/tests/test_filename_patterns.py
@@ -1,0 +1,95 @@
+import pytest
+from pyqwk.core import ParsedMessage, MessageHeader, ProcessingSettings, _generate_safe_filename
+
+@pytest.fixture
+def base_message():
+    header = MessageHeader(
+        status=" ",
+        msgnum=123,
+        msgdate="01-20-24",
+        msgtime="14:30",
+        msgto="Recipient Name",
+        msgfrom="Author Name",
+        msgsubject="Test Subject!",
+        msgpassword="",
+        refnum=None,
+        numblocks=None,
+        msgflag=" ",
+        confnum=1,
+        lognum=0,
+        nettag="",
+    )
+    return ParsedMessage(
+        text="Hello world",
+        msgnum=123,
+        refnum=None,
+        confnum=1,
+        header=header,
+        confname="General Chat",
+        bbs_name="The BBS",
+        bbs_id="THEBBS"
+    )
+
+@pytest.fixture
+def settings():
+    return ProcessingSettings(
+        verbose=False,
+        private=False,
+        no_header=False,
+        truncate_signatures=False,
+        cut_quoting=False,
+        individual_files=True,
+        threaded=False,
+        binaries_removal=False,
+        redact_pii=False,
+        format='text',
+        separator='auto',
+        output_mode='file',
+        output_path='output/',
+        encoding='cp437'
+    )
+
+def test_generate_safe_filename_default(base_message, settings):
+    filename = _generate_safe_filename(base_message, settings, 1)
+    assert filename == "001-00123-test_subject.txt"
+
+def test_generate_safe_filename_custom_pattern(base_message, settings):
+    settings.filename_pattern = "{date}_{author}_{subject}"
+    filename = _generate_safe_filename(base_message, settings, 1)
+    # _slugify(01-20-24) -> 01_20_24
+    # _slugify(Author Name) -> author_name
+    # _slugify(Test Subject!) -> test_subject
+    assert filename == "01_20_24_author_name_test_subject.txt"
+
+def test_generate_safe_filename_pattern_with_msgnum(base_message, settings):
+    settings.filename_pattern = "msg_{msgnum}_{confname}"
+    filename = _generate_safe_filename(base_message, settings, 1)
+    assert filename == "msg_123_general_chat.txt"
+
+def test_generate_safe_filename_invalid_pattern_fallback(base_message, settings):
+    settings.filename_pattern = "{invalid_var}_{subject}"
+    filename = _generate_safe_filename(base_message, settings, 1)
+    # Should fall back to default
+    assert filename == "001-00123-test_subject.txt"
+
+def test_generate_safe_filename_sanitization(base_message, settings):
+    settings.filename_pattern = "{author}/../../{subject}"
+    filename = _generate_safe_filename(base_message, settings, 1)
+    # mapping will slugify author and subject
+    # author_name_.._.._test_subject.txt
+    # re.sub(r'[^\w\-.]', '_', filename) will replace / with _
+    assert ".." in filename
+    assert "/" not in filename
+
+def test_generate_safe_filename_different_format(base_message, settings):
+    settings.format = 'json'
+    settings.filename_pattern = "{msgnum}_{subject}"
+    filename = _generate_safe_filename(base_message, settings, 1)
+    assert filename == "123_test_subject.json"
+
+def test_generate_safe_filename_missing_metadata(base_message, settings):
+    base_message.confname = None
+    base_message.bbs_name = None
+    settings.filename_pattern = "{confname}_{bbs_name}"
+    filename = _generate_safe_filename(base_message, settings, 1)
+    assert filename == "conf_1_bbs.txt"


### PR DESCRIPTION
This PR introduces the ability to customize the filenames of messages exported as individual files. Previously, messages were saved using a fixed format (e.g., `001-00001-subject.txt`). Users can now specify a pattern using placeholders:

Example: `--filename-pattern "{date}_{author}_{subject}"`

Available variables:
- `{date}`, `{time}`
- `{author}`, `{to}`
- `{subject}`
- `{msgnum}`, `{confnum}`
- `{confname}`, `{bbs_name}`, `{bbs_id}`

Non-numeric variables are automatically slugified to ensure they are safe for use as filenames across different operating systems. The implementation also handles potential collisions and malformed patterns gracefully.

---
*PR created automatically by Jules for task [12597343342756381521](https://jules.google.com/task/12597343342756381521) started by @RainRat*