### PR TITLE
[FEAT] Rich Quote Highlighting for HTML and Markdown Exports

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -2464,6 +2464,7 @@ def _get_html_header(title: str) -> list[str]:
         '.message { margin-bottom: 1em; border: 1px solid #eee; padding: 1em; }',
         '.header { background-color: #f9f9f9; padding: 0.5em; margin-bottom: 0.5em; }',
         '.body { white-space: pre-wrap; font-family: monospace; }',
+        '.quote { color: #4e9a06; }',
         '</style>',
         '</head>',
         '<body>',
@@ -2484,6 +2485,7 @@ def _render_single_message_html(
     search_term: str | None = None,
     is_regex: bool = False,
 ) -> list[str]:
+    """Render a single message into HTML components with quote highlighting."""
     parts = []
     id_attr = f' id="{msg_id}"' if msg_id else ""
     parts.append(f'<div class="message"{id_attr}>')
@@ -2524,9 +2526,21 @@ def _render_single_message_html(
     parts.append('</div>')
 
     # Body
-    escaped_text = h_esc(message.text.replace('\r\n', '\n'))
     parts.append('<pre class="body">')
-    parts.append(escaped_text)
+
+    body_text = message.text.replace('\r\n', '\n')
+    body_lines = body_text.split('\n')
+    processed_lines = []
+
+    for line in body_lines:
+        is_quote = bool(RE_QUOTE_PATTERN.match(line))
+        highlighted_line = h_esc(line)
+        if is_quote:
+            processed_lines.append(f'<span class="quote">{highlighted_line}</span>')
+        else:
+            processed_lines.append(highlighted_line)
+
+    parts.append('\n'.join(processed_lines))
     parts.append('</pre>')
     parts.append('</div>')
 
@@ -2560,6 +2574,7 @@ def _render_single_message_markdown(
     search_term: str | None = None,
     is_regex: bool = False,
 ) -> list[str]:
+    """Render a single message into Markdown with blockquote standardization."""
     header = message.header
     parts = []
 
@@ -2595,7 +2610,24 @@ def _render_single_message_markdown(
         parts.append(f"- **Attachments:** {', '.join(links)}")
 
     parts.append("")
-    parts.append(md_high(message.text.replace('\r\n', '\n')))
+
+    body_text = message.text.replace('\r\n', '\n')
+    body_lines = body_text.split('\n')
+    processed_lines = []
+
+    for line in body_lines:
+        is_quote = bool(RE_QUOTE_PATTERN.match(line))
+        highlighted_line = md_high(line)
+        if is_quote:
+            # Standardize to use '> ' for blockquotes if it's not already starting with it
+            if not highlighted_line.startswith('>'):
+                processed_lines.append(f"> {highlighted_line}")
+            else:
+                processed_lines.append(highlighted_line)
+        else:
+            processed_lines.append(highlighted_line)
+
+    parts.append('\n'.join(processed_lines))
     parts.append("")
     parts.append("---")
     return parts

--- a/tests/test_quote_exports.py
+++ b/tests/test_quote_exports.py
@@ -1,0 +1,130 @@
+import pytest
+from pyqwk.core import (
+    ParsedMessage,
+    MessageHeader,
+    _serialize_message_html,
+    _serialize_message_markdown,
+    _write_html,
+    _write_markdown,
+    ProcessingSettings
+)
+
+@pytest.fixture
+def sample_message():
+    header = MessageHeader(
+        status=" ",
+        msgnum=100,
+        msgdate="01-20-24",
+        msgtime="12:00",
+        msgto="Alice",
+        msgfrom="Bob",
+        msgsubject="Test Quote Highlighting",
+        msgpassword="",
+        refnum=None,
+        numblocks=None,
+        msgflag=" ",
+        confnum=1,
+        lognum=0,
+        nettag="",
+    )
+    text = (
+        "Hello Alice,\n"
+        "> This is a standard quote.\n"
+        "| This is an alternative quote style.\n"
+        "│ And another one.\n"
+        "Normal line here.\n"
+        "> Quote with search term: highlight me!"
+    )
+    return ParsedMessage(
+        text=text,
+        msgnum=100,
+        refnum=None,
+        confnum=1,
+        header=header,
+        confname="General",
+        bbs_name="TestBBS",
+    )
+
+def test_html_quote_highlighting(sample_message):
+    html_output = _serialize_message_html(sample_message, search_term="highlight")
+
+    # Check for CSS class
+    assert ".quote { color: #4e9a06; }" in html_output
+
+    # Check for quote spans
+    assert '<span class="quote">&gt; This is a standard quote.</span>' in html_output
+    assert '<span class="quote">| This is an alternative quote style.</span>' in html_output
+    assert '<span class="quote">│ And another one.</span>' in html_output
+
+    # Check for highlighting within quote
+    assert '<span class="quote">&gt; Quote with search term: <mark>highlight</mark> me!</span>' in html_output
+
+    # Normal line should not be wrapped
+    assert "Normal line here." in html_output
+    assert '<span class="quote">Normal line here.</span>' not in html_output
+
+def test_markdown_quote_standardization(sample_message):
+    md_output = _serialize_message_markdown(sample_message, search_term="highlight")
+
+    # Check for blockquote standardization
+    # Standard quote already has >
+    assert "> This is a standard quote." in md_output
+    # Alternatives should have > prepended
+    assert "> | This is an alternative quote style." in md_output
+    assert "> │ And another one." in md_output
+
+    # Check for highlighting within quote
+    assert "> Quote with search term: **highlight** me!" in md_output
+
+    # Normal line should not have >
+    assert "\nNormal line here.\n" in md_output
+    assert "\n> Normal line here.\n" not in md_output
+
+def test_write_html_with_quotes(sample_message, tmp_path):
+    output_file = tmp_path / "test.html"
+    settings = ProcessingSettings(
+        verbose=False,
+        private=True,
+        no_header=False,
+        truncate_signatures=False,
+        cut_quoting=False,
+        individual_files=False,
+        threaded=False,
+        binaries_removal=False,
+        redact_pii=False,
+        format="html",
+        separator="none",
+        output_mode="file",
+        output_path=str(output_file),
+        encoding="utf-8",
+    )
+
+    _write_html([sample_message], str(output_file), settings=settings)
+
+    content = output_file.read_text(encoding="utf-8")
+    assert ".quote { color: #4e9a06; }" in content
+    assert '<span class="quote">&gt; This is a standard quote.</span>' in content
+
+def test_write_markdown_with_quotes(sample_message, tmp_path):
+    output_file = tmp_path / "test.md"
+    settings = ProcessingSettings(
+        verbose=False,
+        private=True,
+        no_header=False,
+        truncate_signatures=False,
+        cut_quoting=False,
+        individual_files=False,
+        threaded=False,
+        binaries_removal=False,
+        redact_pii=False,
+        format="markdown",
+        separator="none",
+        output_mode="file",
+        output_path=str(output_file),
+        encoding="utf-8",
+    )
+
+    _write_markdown([sample_message], str(output_file), settings=settings)
+
+    content = output_file.read_text(encoding="utf-8")
+    assert "> | This is an alternative quote style." in content


### PR DESCRIPTION
### [FEAT] Rich Quote Highlighting for HTML and Markdown Exports

#### What:
Enhanced the HTML and Markdown export functionality to include visual quote highlighting. 
- **HTML exports** now include a `.quote` CSS class (matching the green styling of the GUI) and wrap detected quoted lines in `<span>` tags.
- **Markdown exports** now standardize various legacy BBS quote markers (e.g., `|`, `│`, `>`, `>>`) into standard Markdown blockquote syntax (`> `), ensuring they render correctly in any modern Markdown viewer.

#### Why:
I identified a lack of visual parity between the project's internal readers (GUI/Terminal) and its export outputs. While the Graphical Reader and terminal view both highlight quoted text to improve readability, this styling was lost during export to modern formats. Adding this feature ensures that exported archives maintain the same level of visual hierarchy and clarity as the original readers, making threaded conversations significantly easier to follow in web browsers and Markdown viewers without requiring any additional user configuration.

#### Changes:
- **`pyqwk/core.py`**:
    - Updated `_get_html_header` to include the `.quote` CSS class.
    - Updated `_render_single_message_html` to process message bodies line-by-line, applying quote styling while preserving existing search highlighting.
    - Updated `_render_single_message_markdown` to process message bodies line-by-line, prepending `> ` to legacy quote markers for standard blockquote rendering.
- **`tests/test_quote_exports.py`**:
    - Added comprehensive unit tests covering HTML CSS injection, Markdown syntax standardization, and interaction with search highlighting.
- **Core Library**: Added docstrings to internal rendering functions to document the new behavior.

---
*PR created automatically by Jules for task [6105710764120585849](https://jules.google.com/task/6105710764120585849) started by @RainRat*