### PR TITLE
Simplify redundant date handling in email import

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -1009,6 +1009,8 @@ def _message_from_email(msg_obj: Any) -> ParsedMessage:
     msg_subject = get_hdr('Subject')
 
     # Date/Time
+    msg_date = "01-01-70"
+    msg_time = "00:00"
     date_hdr = get_hdr('Date')
     if date_hdr:
         try:
@@ -1016,11 +1018,7 @@ def _message_from_email(msg_obj: Any) -> ParsedMessage:
             msg_date = dt.strftime('%m-%d-%y')
             msg_time = dt.strftime('%H:%M')
         except (ValueError, TypeError):
-            msg_date = "01-01-70"
-            msg_time = "00:00"
-    else:
-        msg_date = "01-01-70"
-        msg_time = "00:00"
+            pass
 
     # Message body
     body = ""


### PR DESCRIPTION
* **What:** Refactored the `_message_from_email` function in `pyqwk/core.py` to initialize `msg_date` and `msg_time` with default values ("01-01-70", "00:00") at the start. Removed the redundant `else` block and repeated assignments within the `except` block.
* **Why:** This improves code readability and maintainability by eliminating redundant logic branches. The external behavior remains identical, ensuring a safe and non-breaking change.

---
*PR created automatically by Jules for task [6449875826422317165](https://jules.google.com/task/6449875826422317165) started by @RainRat*