### PR TITLE
[DOCS] Clarify Graphical Reader viewing options and shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ qwk-gui archive.eml
 - **Filtering:** View messages from specific BBSes or conferences, include private messages, filter by the presence of attachments, or only show messages from/to yourself.
 - **Context Menus:** Right-click on any message in the list to copy its metadata (Subject, From, To) or instantly filter the entire view by that author, conference, or BBS. You can also right-click in the message text to copy selected sections.
 - **Exporting:** Save your current filtered and sorted view to any supported format (HTML, Markdown, JSON, etc.).
-- **Viewing Options:** Toggle between **Clean** view (removes formatting) and **Remove Colors**.
+- **Viewing Options:** Toggle the **Clean** view to hide signatures, quoted replies, and attachments. Use **Remove Colors** to strip ANSI color codes from the text.
 - **Threading:** Group replies together to follow the flow of a conversation.
 - **Sorting:** Click on column headers (like "Num" or "Date") to sort the message list.
 - **Statistics:** View detailed activity reports, top authors, and temporal distributions for the current archive and filters.
@@ -107,7 +107,8 @@ qwk-gui archive.eml
 - **Ctrl + F**: Jump to the search bar.
 - **Ctrl + G**: Jump to a specific message number.
 - **Ctrl + Q**: Exit the application.
-- **j / k** or **n / p**: Move to the next or previous message in the list.
+- **j** or **n**: Move to the next message in the list.
+- **k** or **p**: Move to the previous message in the list.
 - **Esc**: Clear the search filter and return focus to the message list. This works from anywhere in the application.
 - **Enter**: Execute the search immediately and move focus to the message list.
 


### PR DESCRIPTION
Improved the "Graphical Reader" section in `README.md` to clarify the behavior of viewing options and keyboard shortcuts. 

Key changes:
- Specified that the **Clean** view hides signatures, quoted replies, and attachments.
- Clarified that **Remove Colors** strips ANSI color codes.
- Separated navigation shortcuts (`j/n` for next, `k/p` for previous) into distinct lines for better readability.

These changes ensure the documentation accurately reflects the application's behavior and is more accessible to a global audience.

---
*PR created automatically by Jules for task [13180135106221426464](https://jules.google.com/task/13180135106221426464) started by @RainRat*