### PR TITLE
Prevent accidental SQLite file creation in load_data

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -772,6 +772,10 @@ class LogFormatter(logging.Formatter):
 
 def _parse_sqlite_messages(db_path: str) -> tuple[list[ParsedMessage], ConferenceMap]:
     """Import messages and metadata from a pyqwk SQLite database."""
+    # Ensure the file exists before connecting to avoid creating an empty database
+    if db_path and db_path != ':memory:' and not os.path.exists(db_path):
+        raise sqlite3.OperationalError(f"unable to open database file: {db_path}")
+
     conn = sqlite3.connect(db_path)
     conn.row_factory = sqlite3.Row
     cursor = conn.cursor()
@@ -1276,10 +1280,10 @@ def load_data(
     """
     board_dict: dict[int, str] = {}
 
-    if input_path.lower().endswith(('.db', '.sqlite')):
+    if input_path.lower().endswith(('.db', '.sqlite')) or input_path == ':memory:':
         try:
             messages, board_dict = _parse_sqlite_messages(input_path)
-        except Exception as e:
+        except (ValueError, sqlite3.Error) as e:
             raise ValueError(f"Failed to load SQLite archive: {e}")
 
         return messages, board_dict


### PR DESCRIPTION
* **What:** Added a check to verify that the database file exists in `_parse_sqlite_messages` before calling `sqlite3.connect`. Included support for `:memory:` as a valid SQLite path and ensured consistent exception wrapping in `load_data`.
* **Why:** `sqlite3.connect` creates a new empty database file if the path does not exist. For a data loading function, this is unexpected side-effect behavior that can leave orphan empty files on the disk. This change ensures that a `sqlite3.OperationalError` is raised instead of creating a new file, matching standard database access patterns. No breaking changes are introduced as `:memory:` support is preserved and callers already handle the resulting errors via `load_data`'s standard `ValueError` wrapping.

---
*PR created automatically by Jules for task [16949686267178745648](https://jules.google.com/task/16949686267178745648) started by @RainRat*