### PR TITLE
Fix logic bug in UUE block terminator detection

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -196,7 +196,7 @@ def _is_binary_line(
         return True, True, in_uue_block, in_base64_block
 
     if in_uue_block:
-        if stripped_line == 'end':
+        if stripped_line in ('end', '`'):
             return True, in_yenc_block, False, in_base64_block
         return True, in_yenc_block, True, in_base64_block
 

--- a/tests/test_binary_detection.py
+++ b/tests/test_binary_detection.py
@@ -54,13 +54,13 @@ class TestBinaryDetection:
         assert in_b64_4 is False
 
     def test_uue_backtick_inside_block(self):
-        # Backtick is a valid UUE line (zero length) but often doesn't match data patterns
+        # Backtick is a valid UUE terminator and should exit the block
         line = "`"
         skip, in_yenc, in_uue, in_b64 = _is_binary_line(
             line, previous_line=None, in_yenc_block=False, in_uue_block=True, in_base64_block=False
         )
         assert skip is True
-        assert in_uue is True
+        assert in_uue is False
 
     def test_uue_skips_until_end(self):
         # Any garbage inside a UUE block should be skipped until 'end'


### PR DESCRIPTION
* **What:** Updated the `_is_binary_line` function in `pyqwk/core.py` to include the backtick (`` ` ``) character as a valid terminator for UUEncoded (UUE) blocks.
* **Why:** Previously, the parser only recognized the "end" tag. In many UUE implementations, a backtick signifies a zero-length line and serves as the data terminator. Missing this character caused the parser to "swallow" the remaining text of a message as if it were part of the binary attachment. This fix ensures that normal message text following a UUE block is correctly displayed even if the explicit "end" tag is missing or malformed.
* **Verification:** Verified the fix with a reproduction script and updated the existing unit tests in `tests/test_binary_detection.py`. Ran the full test suite (674 tests) and all passed.

---
*PR created automatically by Jules for task [8776064576216945653](https://jules.google.com/task/8776064576216945653) started by @RainRat*