### PR TITLE
Increase test coverage for pyqwk/core.py to 100%

### DIFF
--- a/tests/test_lead_qa_core_gap_closure.py
+++ b/tests/test_lead_qa_core_gap_closure.py
@@ -1,0 +1,29 @@
+import logging
+import xml.etree.ElementTree as ET
+import pytest
+from pyqwk.core import load_data
+
+def test_sqlite_import_non_existent_file(tmp_path):
+    logger = logging.getLogger("pyqwk.tests")
+    db_path = tmp_path / "non_existent.db"
+
+    with pytest.raises(ValueError, match="Failed to load SQLite archive: unable to open database file"):
+        load_data(str(db_path), logger)
+
+def test_xml_import_single_message_root(tmp_path):
+    logger = logging.getLogger("pyqwk.tests")
+
+    root = ET.Element("message")
+    header_el = ET.SubElement(root, "header")
+    ET.SubElement(header_el, "msgfrom").text = "Root Author"
+    ET.SubElement(header_el, "confnum").text = "1"
+    ET.SubElement(root, "text").text = "Root text"
+
+    xml_path = tmp_path / "single_root.xml"
+    ET.ElementTree(root).write(xml_path, encoding="utf-8", xml_declaration=True)
+
+    messages, _ = load_data(str(xml_path), logger)
+
+    assert len(messages) == 1
+    assert messages[0].header.msgfrom == "Root Author"
+    assert messages[0].text == "Root text"


### PR DESCRIPTION
Identified and closed the final two branch coverage gaps in `pyqwk/core.py`. 

The missing coverage was in:
1. `_parse_sqlite_messages`: The check for non-existent database files before calling `sqlite3.connect`.
2. `_parse_xml_messages`: The symmetry branch that handles a single `<message>` element as the XML root.

A new test file `tests/test_lead_qa_core_gap_closure.py` was created to target these scenarios. Following a code review, temporary coverage reports were removed, and the test file was refactored for better hygiene (removed unused imports and redundant docstrings).

Running the full suite now confirms 100% statement and branch coverage for the library core.

---
*PR created automatically by Jules for task [1272485165486176719](https://jules.google.com/task/1272485165486176719) started by @RainRat*