### PR TITLE
[FEAT] Date-based organization for individual file exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,12 @@ qwk archive.qwk --individual-files --organize -o output_folder/
 ```
 *Tip: This creates subfolders for each conference (e.g., `001-general_chat/`) to keep the output tidy.*
 
+**Save each message as a separate file organized by year and month:**
+```bash
+qwk archive.qwk --individual-files --organize-by-date -o output_folder/
+```
+*Tip: This creates a nested structure (e.g., `2023/10/`) to help manage large message archives over time. You can combine this with `--organize` to further sort by conference within each month.*
+
 **Organize archive files into folders by BBS name:**
 ```bash
 qwk my_archives/ --organize-by-bbs

--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -120,6 +120,12 @@ examples:
         action='store_true',
     )
     io_group.add_argument(
+        '--organize-by-date',
+        dest='organize_by_date',
+        help='Organize individual files into subfolders by year and month.',
+        action='store_true',
+    )
+    io_group.add_argument(
         '--filename-pattern',
         help="Set a pattern for naming individual files (e.g., '{date}_{author}_{subject}'). Available variables: date, time, author, to, subject, msgnum, confnum, confname, bbs_name, bbs_id, length.",
     )
@@ -544,6 +550,7 @@ examples:
         unique=args.unique,
         organize=args.organize,
         organize_by_bbs=args.organize_by_bbs,
+        organize_by_date=args.organize_by_date,
         include_toc=args.include_toc,
         extract_attachments=args.extractattachments,
         msgnum_filters=msgnum_filters,

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -367,6 +367,7 @@ class ProcessingSettings:
     unique: bool = False
     organize: bool = False
     organize_by_bbs: bool = False
+    organize_by_date: bool = False
     include_toc: bool = False
     extract_attachments: bool = False
     msgnum_filters: set[int] | None = None
@@ -2164,18 +2165,30 @@ def process_merged_files(
             assert output_dir is not None
 
             target_dir = output_dir
-            conf_dir = ""
+            sub_dir = ""
+            if settings.organize_by_date:
+                dt = _parse_qwk_date(parsed_message.header.msgdate, parsed_message.header.msgtime)
+                sub_dir = os.path.join(str(dt.year), f"{dt.month:02d}")
+
             if settings.organize:
                 conf_name = parsed_message.confname or "unknown"
                 conf_slug = _slugify(conf_name, "conference")
                 conf_dir = f"{parsed_message.confnum:03d}-{conf_slug}"
-                target_dir = os.path.join(output_dir, conf_dir)
+                sub_dir = os.path.join(sub_dir, conf_dir)
+
+            if sub_dir:
+                target_dir = os.path.join(output_dir, sub_dir)
                 if not settings.dry_run:
                     os.makedirs(target_dir, exist_ok=True)
 
             attachment_prefix = None
             if settings.extract_attachments:
-                attachment_prefix = "../attachments/" if settings.organize else "attachments/"
+                if sub_dir:
+                    # Count path separators to determine depth for relative link
+                    depth = len(sub_dir.replace('\\', '/').split('/'))
+                    attachment_prefix = ("../" * depth) + "attachments/"
+                else:
+                    attachment_prefix = "attachments/"
 
             if settings.format == 'text':
                 encoded_buffer = processed_buffer.encode(target_encoding)
@@ -2227,7 +2240,7 @@ def process_merged_files(
             potential_files += 1
 
             if settings.format in ('html', 'markdown'):
-                rel_path = os.path.join(conf_dir if settings.organize else "", filename)
+                rel_path = os.path.join(sub_dir, filename)
                 collected_for_index.append({
                     'path': rel_path,
                     'subject': parsed_message.header.msgsubject.strip(),

--- a/tests/test_organize_by_date.py
+++ b/tests/test_organize_by_date.py
@@ -1,0 +1,141 @@
+import os
+import logging
+from pathlib import Path
+from pyqwk.core import ProcessingSettings, process_file
+
+def _make_settings(**overrides) -> ProcessingSettings:
+    defaults = dict(
+        verbose=False,
+        private=False,
+        no_header=False,
+        truncate_signatures=False,
+        cut_quoting=False,
+        individual_files=True,
+        threaded=False,
+        binaries_removal=False,
+        redact_pii=False,
+        format="text",
+        separator="auto",
+        output_mode="file",
+        output_path=None,
+        encoding="latin1",
+        organize_by_date=True,
+    )
+    defaults.update(overrides)
+    return ProcessingSettings(**defaults)
+
+def test_organize_by_date(tmp_path: Path):
+    logger = logging.getLogger("pyqwk.tests")
+    test_data_dir = Path(__file__).resolve().parents[1] / "testdata"
+    input_file = test_data_dir / "messages.dat"
+    output_dir = tmp_path / "date_org"
+
+    settings = _make_settings(output_path=str(output_dir))
+
+    # messages.dat message has date "07-21-94" -> 1994/07
+    process_file(str(input_file), settings, logger)
+
+    expected_dir = output_dir / "1994" / "07"
+    assert expected_dir.exists()
+    assert expected_dir.is_dir()
+
+    files = list(expected_dir.iterdir())
+    assert len(files) == 1
+    assert files[0].name.startswith("003-00028")
+
+def test_organize_by_date_and_conf(tmp_path: Path):
+    logger = logging.getLogger("pyqwk.tests")
+    test_data_dir = Path(__file__).resolve().parents[1] / "testdata"
+    input_file = test_data_dir / "messages.dat"
+    output_dir = tmp_path / "date_conf_org"
+
+    settings = _make_settings(
+        output_path=str(output_dir),
+        organize=True
+    )
+
+    # messages.dat message has date "07-21-94" and conf 3 ("New User")
+    process_file(str(input_file), settings, logger)
+
+    # Expected: 1994 / 07 / 003-unknown
+    expected_dir = output_dir / "1994" / "07" / "003-unknown"
+    assert expected_dir.exists()
+    assert expected_dir.is_dir()
+
+def test_organize_by_date_index_html(tmp_path: Path):
+    logger = logging.getLogger("pyqwk.tests")
+    test_data_dir = Path(__file__).resolve().parents[1] / "testdata"
+    input_file = test_data_dir / "messages.dat"
+    output_dir = tmp_path / "date_index"
+
+    settings = _make_settings(
+        output_path=str(output_dir),
+        format="html"
+    )
+
+    process_file(str(input_file), settings, logger)
+
+    index_file = output_dir / "index.html"
+    assert index_file.exists()
+    content = index_file.read_text()
+
+    # Check that relative path in index is correct
+    # It should be 1994/07/filename
+    import re
+    match = re.search(r'href="([^"]+)"', content)
+    assert match
+    rel_path = match.group(1)
+    assert rel_path.replace("\\", "/").startswith("1994/07/")
+
+def test_organize_by_date_attachments(tmp_path: Path):
+    logger = logging.getLogger("pyqwk.tests")
+    test_data_dir = Path(__file__).resolve().parents[1] / "testdata"
+    # We need a file with attachments.
+    # test_binary_detection.py uses some text, but we need it in a file processable by process_file.
+    # For simplicity, we can mock the attachment extraction or just check the prefix calculation logic if we trust it.
+    # Let's create a dummy file with UUE.
+
+    dummy_qwk = tmp_path / "dummy.qwk"
+    # A minimal QWK header + one message with UUE
+    # Actually, process_file calls load_data, which handles raw QWK or others.
+    # Easiest is to use a .json file as input since pyqwk supports it.
+
+    import json
+    msg_data = [{
+        "header": {
+            "confnum": 1,
+            "msgnum": 100,
+            "msgdate": "10-25-23",
+            "msgtime": "12:00",
+            "msgfrom": "Alice",
+            "msgto": "Bob",
+            "msgsubject": "Test Attach",
+            "status": " "
+        },
+        "text": "Hello\nbegin 644 test.txt\n#0V%T\n`\nend\n",
+        "conference": "General"
+    }]
+
+    input_json = tmp_path / "test.json"
+    input_json.write_text(json.dumps(msg_data))
+
+    output_dir = tmp_path / "attach_org"
+    settings = _make_settings(
+        output_path=str(output_dir),
+        format="html",
+        extract_attachments=True
+    )
+
+    process_file(str(input_json), settings, logger)
+
+    # Subdir: 2023/10/001-00100-test_attach.html
+    # Attachments: attachments/test.txt (relative to output_dir)
+    # Relative link in HTML: ../../attachments/test.txt
+
+    msg_file = output_dir / "2023" / "10" / "001-00100-test_attach.html"
+    assert msg_file.exists()
+    content = msg_file.read_text()
+    assert "../../attachments/test.txt" in content.replace("\\", "/")
+
+    attach_file = output_dir / "attachments" / "test.txt"
+    assert attach_file.exists()


### PR DESCRIPTION
I have implemented a new feature that adds date-based organization for individual file exports. By using the `--organize-by-date` flag, users can now group exported messages into subfolders by year and month (e.g., `output/2023/10/message.html`). This logic can be combined with the existing `--organize` (conference-based) flag to create even more structured archives (e.g., `output/2023/10/001-general/message.html`).

The implementation handles:
1.  **Nesting:** Automatically creates the `YYYY/MM` (and optionally `conf-slug`) directory structure.
2.  **Relative Path Stability:** The system now calculates the depth of the output directory and adjusts the relative links for attachments and the main index file accordingly. This ensures that features like clickable attachment links in HTML/Markdown exports continue to work perfectly regardless of how deep the folder structure is.
3.  **Index Generation:** The HTML and Markdown index generation logic was updated to use the full relative paths to messages, maintaining a working "Table of Contents" for the entire export.

This feature provides immediate value for users managing large, multi-year message archives by providing a logical and convenient way to browse their history.

---
*PR created automatically by Jules for task [11238055751263994072](https://jules.google.com/task/11238055751263994072) started by @RainRat*