### PR TITLE
[DOCS] Plain English pass for internal documentation and terminology

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -396,10 +396,10 @@ class ProcessingSettings:
 
 @dataclass
 class BBSInfo:
-    """Metadata about the Bulletin Board System (BBS) that created the archive.
+    """Information about the Bulletin Board System (BBS) that created the archive.
 
-    This information is typically extracted from the 'CONTROL.DAT' file in
-    QWK packets or preserved in the header of structured formats like SQLite.
+    This is usually found in the 'CONTROL.DAT' file in QWK packets or in
+    the header of files like SQLite.
     """
     name: str = ""
     location: str = ""
@@ -425,7 +425,7 @@ class ParsedMessage:
     """A fully parsed and processed message from an archive.
 
     This class contains the message body text, conference details, and
-    threading metadata used for organizing conversations.
+    threading information used for organizing conversations.
     """
     text: str
     msgnum: int | None
@@ -449,10 +449,10 @@ ProcessedMessage = ParsedMessage
 
 @dataclass
 class MessageHeader:
-    """The metadata header for a single message in the QWK format.
+    """The information header for a single message in the QWK format.
 
-    These fields correspond to the fixed-length record structure used in
-    traditional BBS message packets.
+    These fields match the fixed-length structure used in older BBS
+    message packets.
     """
     status: str
     msgnum: int | None
@@ -773,7 +773,7 @@ class LogFormatter(logging.Formatter):
 
 
 def _parse_sqlite_messages(db_path: str) -> tuple[list[ParsedMessage], ConferenceMap]:
-    """Import messages and metadata from a pyqwk SQLite database."""
+    """Import messages and information from a pyqwk SQLite database."""
     # Ensure the file exists before connecting to avoid creating an empty database
     if db_path and db_path != ':memory:' and not os.path.exists(db_path):
         raise sqlite3.OperationalError(f"unable to open database file: {db_path}")
@@ -854,7 +854,7 @@ def _parse_sqlite_messages(db_path: str) -> tuple[list[ParsedMessage], Conferenc
         # Preserve existing bbs_info if it was loaded from a table.
         # We only restore it if it's not a default empty BBSInfo object.
         loaded_bbs_info = board_dict.bbs_info
-        board_dict = _reconstruct_metadata(messages)
+        board_dict = _reconstruct_archive_information(messages)
         if loaded_bbs_info and loaded_bbs_info != BBSInfo():
             # Merge: prefer data loaded from SQLite tables, but fill gaps from reconstruction
             for field in fields(BBSInfo):
@@ -984,8 +984,8 @@ def _parse_csv_messages(data: Iterator[dict[str, Any]]) -> list[ParsedMessage]:
     return messages
 
 
-def _reconstruct_metadata(messages: list[ParsedMessage]) -> ConferenceMap:
-    """Reconstruct board_dict and bbs_info from a list of messages."""
+def _reconstruct_archive_information(messages: list[ParsedMessage]) -> ConferenceMap:
+    """Reconstruct conference and BBS information from a list of messages."""
     board_dict = ConferenceMap()
     bbs_info = BBSInfo()
     for msg in messages:
@@ -1169,7 +1169,7 @@ def _parse_markdown_messages(path: str) -> list[ParsedMessage]:
 
         working_section = working_section[msg_start:]
 
-        # Extract metadata
+        # Extract message information
         subject_match = re_subject.search(working_section)
         if not subject_match:
             continue
@@ -1214,7 +1214,7 @@ def _parse_markdown_messages(path: str) -> list[ParsedMessage]:
             else:
                 attachments = [a.strip() for a in attach_str.split(',') if a.strip()]
 
-        # Message body: everything after the metadata lines
+        # Message body: everything after the information lines
         lines = working_section.splitlines()
         body_start_idx = 0
         for i, line in enumerate(lines):
@@ -1282,7 +1282,7 @@ def load_data(
         - file_data: A 'bytearray' of raw records for QWK/REP files, or
           a list of 'ParsedMessage' objects for modern structured formats.
         - board_dict: A 'ConferenceMap' linking conference numbers to names,
-          which may also include BBS metadata.
+          which may also include BBS information.
 
         Note: When loading a raw 'MESSAGES.DAT' file, it automatically searches
         for a corresponding 'CONTROL.DAT' in the same folder to load conference names.
@@ -1302,7 +1302,7 @@ def load_data(
             data = json.load(f)
             messages = _parse_json_messages(data)
 
-            board_dict = _reconstruct_metadata(messages)
+            board_dict = _reconstruct_archive_information(messages)
             return messages, board_dict
 
     if input_path.lower().endswith('.jsonl'):
@@ -1313,7 +1313,7 @@ def load_data(
                     data = json.loads(line)
                     messages.extend(_parse_json_messages(data))
 
-        board_dict = _reconstruct_metadata(messages)
+        board_dict = _reconstruct_archive_information(messages)
         return messages, board_dict
 
     if input_path.lower().endswith('.mbox'):
@@ -1322,7 +1322,7 @@ def load_data(
         except Exception as e:
             raise ValueError(f"Failed to load mbox archive: {e}")
 
-        board_dict = _reconstruct_metadata(messages)
+        board_dict = _reconstruct_archive_information(messages)
         return messages, board_dict
 
     if input_path.lower().endswith(('.md', '.markdown')):
@@ -1331,7 +1331,7 @@ def load_data(
         except Exception as e:
             raise ValueError(f"Failed to load Markdown archive: {e}")
 
-        board_dict = _reconstruct_metadata(messages)
+        board_dict = _reconstruct_archive_information(messages)
         return messages, board_dict
 
     if input_path.lower().endswith('.eml'):
@@ -1340,7 +1340,7 @@ def load_data(
         except Exception as e:
             raise ValueError(f"Failed to load EML file: {e}")
 
-        board_dict = _reconstruct_metadata(messages)
+        board_dict = _reconstruct_archive_information(messages)
         return messages, board_dict
 
     if input_path.lower().endswith('.xml'):
@@ -1351,7 +1351,7 @@ def load_data(
         except Exception as e:
             raise ValueError(f"Failed to load XML archive: {e}")
 
-        board_dict = _reconstruct_metadata(messages)
+        board_dict = _reconstruct_archive_information(messages)
         return messages, board_dict
 
     if input_path.lower().endswith('.csv'):
@@ -1359,7 +1359,7 @@ def load_data(
             reader = csv.DictReader(f)
             messages = _parse_csv_messages(reader)
 
-            board_dict = _reconstruct_metadata(messages)
+            board_dict = _reconstruct_archive_information(messages)
             return messages, board_dict
 
     if zipfile.is_zipfile(input_path):
@@ -1781,13 +1781,13 @@ def matches_filters(
     allowed_conferences: set[int],
     user_name: str | None = None,
 ) -> bool:
-    """Check if a message satisfies all configured processing filters.
+    """Check if a message matches all your filters.
 
     Args:
-        message: The message to evaluate.
-        settings: Processing settings containing filter criteria.
-        allowed_conferences: Pre-computed set of allowed conference numbers.
-        user_name: The user's name to use for the "mine" filter.
+        message: The message to check.
+        settings: Settings containing your filter choices.
+        allowed_conferences: A set of allowed conference numbers.
+        user_name: Your name to use for the "mine" filter.
 
     Returns:
         True if the message matches all filters, False otherwise.

--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -142,7 +142,7 @@ class QwkGuiApp:
         menu.add_command(label="Select All", command=lambda: self.detail_text.tag_add("sel", "1.0", tk.END))
         menu.add_command(label="Copy Full Message", command=lambda: self._copy_to_clipboard(self.detail_text.get("1.0", tk.END).strip()))
 
-        # Get current message for metadata filtering
+        # Get current message for information filtering
         current_selection = self.message_list.selection()
         if current_selection:
             try:
@@ -212,7 +212,7 @@ class QwkGuiApp:
         self.root.clipboard_append(text)
 
     def _pivot_filter(self, author: str | None = None, conf_num: int | None = None, bbs_name: str | None = None) -> None:
-        """Update filters to pivot the view around a specific attribute."""
+        """Update filters based on the selected author, conference, or BBS."""
         if author:
             self.search_var.set(author)
 
@@ -1054,7 +1054,7 @@ class QwkGuiApp:
                 for parsed_message in messages_to_process:
                     total_count += 1
 
-                    # Add BBS and source file metadata
+                    # Add BBS and source file information
                     parsed_message = replace(
                         parsed_message,
                         bbs_name=parsed_message.bbs_name or (bbs_info.name if bbs_info else None),

--- a/tests/test_lead_qa_coverage_expansion.py
+++ b/tests/test_lead_qa_coverage_expansion.py
@@ -1,9 +1,9 @@
 from pyqwk.core import (
-    _reconstruct_metadata, ParsedMessage, MessageHeader, _serialize_rfc822,
+    _reconstruct_archive_information, ParsedMessage, MessageHeader, _serialize_rfc822,
     _order_messages_by_thread
 )
 
-def test_reconstruct_metadata_with_bbs_id():
+def test_reconstruct_archive_information_with_bbs_id():
     # Covers line 912: if msg.bbs_id: bbs_info.bbs_id = msg.bbs_id
     header = MessageHeader(
         status=' ', msgnum=1, msgdate='01-01-23', msgtime='12:00',
@@ -14,7 +14,7 @@ def test_reconstruct_metadata_with_bbs_id():
         text="body", msgnum=1, refnum=None, confnum=1, header=header,
         bbs_name="TestBBS", bbs_id="BBS123"
     )
-    board_dict = _reconstruct_metadata([msg])
+    board_dict = _reconstruct_archive_information([msg])
     assert board_dict.bbs_info.bbs_id == "BBS123"
     assert board_dict.bbs_info.name == "TestBBS"
 

--- a/tests/test_lead_qa_gap_closure_v4.py
+++ b/tests/test_lead_qa_gap_closure_v4.py
@@ -9,7 +9,7 @@ from pyqwk.core import (
     LogFormatter,
     _parse_sqlite_messages,
     _parse_xml_messages,
-    _reconstruct_metadata,
+    _reconstruct_archive_information,
     _message_from_email,
     load_data,
     _serialize_rfc822,
@@ -108,11 +108,11 @@ def test_parse_xml_missing_header_and_unknown_tags():
     assert messages[0].header.msgfrom == "Sender"
     assert messages[1].header.msgfrom == ""
 
-def test_reconstruct_metadata_none_confnum():
+def test_reconstruct_archive_information_none_confnum():
     header = MessageHeader(" ", None, "", "", "", "", "", "", None, None, "", 1, 0, "")
     msg = ParsedMessage("Text", None, None, None, header)
     msg.confnum = None
-    board_dict = _reconstruct_metadata([msg])
+    board_dict = _reconstruct_archive_information([msg])
     assert board_dict == {}
 
 def test_message_from_email_empty_payload(mocker):


### PR DESCRIPTION
This PR improves the internal documentation of the project by applying Plain English principles. 

Technical terms like "metadata" have been replaced with "information" in docstrings and comments to make the codebase more accessible to a global audience. Complex sentences in function descriptions have been simplified and converted to active voice. Additionally, the internal function `_reconstruct_metadata` was renamed to `_reconstruct_archive_information` to maintain consistency with the updated terminology. All tests have been updated and verified to pass.

---
*PR created automatically by Jules for task [16525647423174019898](https://jules.google.com/task/16525647423174019898) started by @RainRat*