### PR TITLE
[UI/UX] Add text wrapping toggle and horizontal scrolling to message viewer

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -69,6 +69,7 @@ class QwkGuiApp:
         }
 
         self.clean_var = tk.BooleanVar(value=False)
+        self.wrap_var = tk.BooleanVar(value=True)
         self.private_var = tk.BooleanVar(value=True)
         self.ansi_var = tk.BooleanVar(value=False)
         self.threaded_var = tk.BooleanVar(value=False)
@@ -406,11 +407,22 @@ class QwkGuiApp:
         self.has_emails_var.set(False)
         self.has_phones_var.set(False)
         self.has_ansi_var.set(False)
+        self.wrap_var.set(True)
+        self._update_wrap()
         self.reload_messages()
         self.message_list.focus_set()
 
     def quit_app(self, _event: object | None = None) -> None:
         self.root.quit()
+
+    def _update_wrap(self) -> None:
+        """Toggle text wrapping in the detail view."""
+        if self.wrap_var.get():
+            self.detail_text.config(wrap=tk.WORD)
+            self.detail_h_scrollbar.grid_forget()
+        else:
+            self.detail_text.config(wrap=tk.NONE)
+            self.detail_h_scrollbar.grid(row=1, column=0, sticky="ew")
 
     def _build_status_bar(self) -> None:
         status_bar = ttk.Frame(self.root, relief=tk.SUNKEN, borderwidth=1)
@@ -500,13 +512,14 @@ class QwkGuiApp:
         options_frame.pack(side=tk.LEFT, padx=5)
         ttk.Label(options_frame, text="View:").pack(side=tk.LEFT, padx=(0, 5))
 
-        for text, var in [
-            ("Threaded", self.threaded_var),
-            ("Clean", self.clean_var),
-            ("Remove Colors", self.ansi_var),
+        for text, var, cmd in [
+            ("Threaded", self.threaded_var, self.reload_messages),
+            ("Clean", self.clean_var, self.reload_messages),
+            ("Wrap", self.wrap_var, self._update_wrap),
+            ("Remove Colors", self.ansi_var, self.reload_messages),
         ]:
             ttk.Checkbutton(
-                options_frame, text=text, variable=var, command=self.reload_messages
+                options_frame, text=text, variable=var, command=cmd
             ).pack(side=tk.LEFT, padx=5)
 
         ttk.Separator(row2, orient=tk.VERTICAL).pack(side=tk.LEFT, fill=tk.Y, padx=10)
@@ -603,10 +616,19 @@ class QwkGuiApp:
         detail_scrollbar = ttk.Scrollbar(
             detail_frame, orient=tk.VERTICAL, command=self.detail_text.yview
         )
-        self.detail_text.configure(yscrollcommand=detail_scrollbar.set)
+        self.detail_h_scrollbar = ttk.Scrollbar(
+            detail_frame, orient=tk.HORIZONTAL, command=self.detail_text.xview
+        )
+        self.detail_text.configure(
+            yscrollcommand=detail_scrollbar.set,
+            xscrollcommand=self.detail_h_scrollbar.set
+        )
 
-        detail_scrollbar.pack(side=tk.RIGHT, fill=tk.Y)
-        self.detail_text.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        detail_scrollbar.grid(row=0, column=1, sticky="ns")
+        self.detail_text.grid(row=0, column=0, sticky="nsew")
+
+        detail_frame.grid_rowconfigure(0, weight=1)
+        detail_frame.grid_columnconfigure(0, weight=1)
         self.detail_text.config(state=tk.NORMAL)
 
         # Intercept key events to allow selection/copy but block editing

--- a/tests/test_gui_wrap_toggle.py
+++ b/tests/test_gui_wrap_toggle.py
@@ -1,0 +1,90 @@
+import sys
+from unittest.mock import MagicMock, patch
+import pytest
+
+# Mock tkinter before any pyqwk.gui imports
+mock_tk = MagicMock()
+mock_ttk = MagicMock()
+sys.modules["tkinter"] = mock_tk
+sys.modules["tkinter.filedialog"] = MagicMock()
+sys.modules["tkinter.messagebox"] = MagicMock()
+sys.modules["tkinter.ttk"] = mock_ttk
+
+from pyqwk.gui import QwkGuiApp
+
+@pytest.fixture
+def mock_gui_deps():
+    with patch("pyqwk.gui.tk") as mock_tk, \
+         patch("pyqwk.gui.ttk") as mock_ttk, \
+         patch("pyqwk.gui.filedialog") as mock_fd, \
+         patch("pyqwk.gui.messagebox") as mock_mb:
+
+        # Configure Variable mocks
+        def make_var(value=None):
+            m = MagicMock()
+            m.get.return_value = value
+            return m
+
+        mock_tk.BooleanVar.side_effect = lambda value=False, **kwargs: make_var(value)
+        mock_tk.StringVar.side_effect = lambda value="", **kwargs: make_var(value)
+        mock_tk.IntVar.side_effect = lambda value=0, **kwargs: make_var(value)
+
+        # Tkinter constants
+        mock_tk.END = "end"
+        mock_tk.HORIZONTAL = "horizontal"
+        mock_tk.VERTICAL = "vertical"
+        mock_tk.BOTH = "both"
+        mock_tk.X = "x"
+        mock_tk.Y = "y"
+        mock_tk.LEFT = "left"
+        mock_tk.RIGHT = "right"
+        mock_tk.TOP = "top"
+        mock_tk.BOTTOM = "bottom"
+        mock_tk.SUNKEN = "sunken"
+        mock_tk.W = "w"
+        mock_tk.E = "e"
+        mock_tk.WORD = "word"
+        mock_tk.NONE = "none"
+        mock_tk.DISABLED = "disabled"
+        mock_tk.NORMAL = "normal"
+        mock_tk.INSERT = "insert"
+
+        yield {
+            "tk": mock_tk,
+            "ttk": mock_ttk,
+            "filedialog": mock_fd,
+            "messagebox": mock_mb,
+        }
+
+def test_wrap_toggle(mock_gui_deps):
+    root = MagicMock()
+    app = QwkGuiApp(root)
+
+    # Initially wrapping should be ON (tk.WORD)
+    app.wrap_var.get.return_value = True
+    app._update_wrap()
+    app.detail_text.config.assert_any_call(wrap=mock_gui_deps["tk"].WORD)
+    app.detail_h_scrollbar.grid_forget.assert_called()
+
+    # Toggle wrapping OFF
+    app.wrap_var.get.return_value = False
+    app._update_wrap()
+    app.detail_text.config.assert_any_call(wrap=mock_gui_deps["tk"].NONE)
+    app.detail_h_scrollbar.grid.assert_called_with(row=1, column=0, sticky="ew")
+
+def test_reset_all_resets_wrap(mock_gui_deps):
+    root = MagicMock()
+    app = QwkGuiApp(root)
+
+    # Mock wrap_var.get to return True after it's set to True
+    def mock_set(val):
+        app.wrap_var.get.return_value = val
+    app.wrap_var.set.side_effect = mock_set
+
+    # Initially False
+    app.wrap_var.get.return_value = False
+
+    app.clear_filters()
+
+    app.wrap_var.set.assert_called_with(True)
+    app.detail_text.config.assert_any_call(wrap=mock_gui_deps["tk"].WORD)


### PR DESCRIPTION
### Improving Message Readability with Dynamic Text Wrapping

This PR introduces a functional improvement to the PyQWK Graphical Reader by allowing users to toggle text wrapping in the message detail viewer.

#### Problem
Legacy BBS messages often contain structured data, ASCII art, or long lines that are best viewed in their original formatting. The previous implementation forced word-wrapping (`tk.WORD`), which could distort such content. However, simply disabling wrapping would make long lines inaccessible without a horizontal scrollbar.

#### Solution
- **Wrap Toggle:** A new "Wrap" checkbox in the "View" section of the toolbar allows users to instantly toggle between word-wrap and no-wrap modes.
- **Horizontal Scrolling:** Added a horizontal scrollbar to the detail view that automatically appears when wrapping is disabled, ensuring full accessibility to long lines.
- **Layout Refinement:** Refactored the `detail_frame` from `pack` to `grid` to reliably position the text widget alongside both vertical and horizontal scrollbars.
- **State Persistence:** Included wrapping in the "Reset All" action (and the `Esc` shortcut) to ensure a consistent return to sensible defaults.

#### Verification
- Added `tests/test_gui_wrap_toggle.py` to verify the toggle logic and UI state transitions.
- Verified that existing GUI tests pass, ensuring no regressions in message selection or rendering.
- Manual verification of the layout behavior under different window sizes.

---
*PR created automatically by Jules for task [6751563504063198274](https://jules.google.com/task/6751563504063198274) started by @RainRat*