### PR TITLE
[FEAT] Add chronological organization for individual file exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,12 @@ qwk archive.qwk --individual-files --organize -o output_folder/
 ```
 *Tip: This creates subfolders for each conference (e.g., `001-general_chat/`) to keep the output tidy.*
 
+**Save each message as a separate file organized by date:**
+```bash
+qwk archive.qwk --individual-files --organize-by-date -o output_folder/
+```
+*Tip: This creates a `YYYY/MM/` subfolder structure (e.g., `2023/05/`) to organize messages chronologically.*
+
 **Organize archive files into folders by BBS name:**
 ```bash
 qwk my_archives/ --organize-by-bbs
@@ -407,6 +413,7 @@ for msg in messages:
 | `-i`, `--individual-files` | Save each message as a separate file. This also creates a browsable index for HTML and Markdown. |
 | `--filename-pattern [pat]` | Set a pattern for naming individual files (e.g., `{date}_{author}_{subject}`). |
 | `--organize` | Organize files into subfolders by conference. |
+| `--organize-by-date` | Organize files into subfolders by year and month. |
 | `--organize-by-bbs` | Organize archives into folders named after the BBS. |
 | `-F, --format [type]` | Set output format: `text`, `html`, `json`, `jsonl`, `xml`, `markdown`, `csv`, `mbox`, `eml`, `sqlite`. |
 | `-j`, `--json` | Use JSON output format (shortcut for `--format json`). |

--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -114,6 +114,11 @@ examples:
         action='store_true',
     )
     io_group.add_argument(
+        '--organize-by-date',
+        help='Organize individual files into subfolders by date (YYYY/MM).',
+        action='store_true',
+    )
+    io_group.add_argument(
         '--organize-by-bbs',
         dest='organize_by_bbs',
         help='Organize archives into folders named after the BBS.',
@@ -543,6 +548,7 @@ examples:
         headers_only=args.headers_only,
         unique=args.unique,
         organize=args.organize,
+        organize_by_date=getattr(args, 'organize_by_date', False),
         organize_by_bbs=args.organize_by_bbs,
         include_toc=args.include_toc,
         extract_attachments=args.extractattachments,

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -366,6 +366,7 @@ class ProcessingSettings:
     merge: bool = False
     unique: bool = False
     organize: bool = False
+    organize_by_date: bool = False
     organize_by_bbs: bool = False
     include_toc: bool = False
     extract_attachments: bool = False
@@ -2164,18 +2165,32 @@ def process_merged_files(
             assert output_dir is not None
 
             target_dir = output_dir
-            conf_dir = ""
-            if settings.organize:
-                conf_name = parsed_message.confname or "unknown"
-                conf_slug = _slugify(conf_name, "conference")
-                conf_dir = f"{parsed_message.confnum:03d}-{conf_slug}"
-                target_dir = os.path.join(output_dir, conf_dir)
+            relative_sub_path = ""
+            if settings.organize or settings.organize_by_date:
+                sub_parts = []
+                if settings.organize:
+                    conf_name = parsed_message.confname or "unknown"
+                    conf_slug = _slugify(conf_name, "conference")
+                    sub_parts.append(f"{parsed_message.confnum:03d}-{conf_slug}")
+
+                if settings.organize_by_date:
+                    msg_dt = _parse_qwk_date(parsed_message.header.msgdate, parsed_message.header.msgtime)
+                    sub_parts.append(msg_dt.strftime('%Y'))
+                    sub_parts.append(msg_dt.strftime('%m'))
+
+                relative_sub_path = os.path.join(*sub_parts)
+                target_dir = os.path.join(output_dir, relative_sub_path)
                 if not settings.dry_run:
                     os.makedirs(target_dir, exist_ok=True)
 
             attachment_prefix = None
             if settings.extract_attachments:
-                attachment_prefix = "../attachments/" if settings.organize else "attachments/"
+                if relative_sub_path:
+                    # Each level of directory nesting requires an extra '../'
+                    depth = len(relative_sub_path.replace(os.sep, '/').split('/'))
+                    attachment_prefix = ("../" * depth) + "attachments/"
+                else:
+                    attachment_prefix = "attachments/"
 
             if settings.format == 'text':
                 encoded_buffer = processed_buffer.encode(target_encoding)
@@ -2227,7 +2242,7 @@ def process_merged_files(
             potential_files += 1
 
             if settings.format in ('html', 'markdown'):
-                rel_path = os.path.join(conf_dir if settings.organize else "", filename)
+                rel_path = os.path.join(relative_sub_path, filename)
                 collected_for_index.append({
                     'path': rel_path,
                     'subject': parsed_message.header.msgsubject.strip(),


### PR DESCRIPTION
This Pull Request implements the "missing piece" of chronological organization for individual file exports. While the tool already supported organization by BBS and conference, it lacked a way to group messages by time when exporting thousands of individual files.

### Changes:
- **Core Logic:** `pyqwk/core.py` now supports a `YYYY/MM` sub-directory structure. It handles the complexity of relative paths for attachments and index files by dynamically calculating directory depth.
- **CLI Interface:** Added the `--organize-by-date` flag to the CLI.
- **Documentation:** Updated `README.md` with usage examples for date-based organization.
- **Stability:** Used `getattr(args, 'organize_by_date', False)` to ensure that existing tests using mocked `argparse.Namespace` objects don't fail due to the new attribute.

### Verification:
- Verified the folder structure with a dedicated test script.
- Verified that attachment links in HTML exports correctly use `../../attachments/` when nested.
- Verified that combined organization (`--organize --organize-by-date`) works as expected (e.g., `001-general/2023/05/`).
- Confirmed that `--dry-run` prevents directory creation.

---
*PR created automatically by Jules for task [9465698281321274130](https://jules.google.com/task/9465698281321274130) started by @RainRat*