### PR TITLE
[DOCS] Update Graphical Reader UI strings for Markdown and JSONL support

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -256,7 +256,7 @@ class QwkGuiApp:
         self.detail_text.insert(tk.END, "Use Ctrl+O or the 'Open' button in the toolbar to load a message archive.\n\n", "body")
 
         self.detail_text.insert(tk.END, "Supported Formats:\n", "header_label")
-        formats = "QWK, REP, JSON, CSV, SQLite (.db), XML, mbox, EML, and MESSAGES.DAT"
+        formats = "QWK, REP, JSON, JSONL, CSV, SQLite (.db), XML, mbox, EML, Markdown, and MESSAGES.DAT"
         self.detail_text.insert(tk.END, f"{formats}\n\n", "body")
 
         self.detail_text.insert(tk.END, "Keyboard Shortcuts:\n", "header_label")
@@ -902,7 +902,7 @@ class QwkGuiApp:
 
     def open_file(self, _event: object | None = None) -> None:
         filetypes = [
-            ("All supported formats", "*.qwk *.rep *.json *.jsonl *.csv *.db *.sqlite *.xml *.mbox *.eml"),
+            ("All supported formats", "*.qwk *.rep *.json *.jsonl *.csv *.db *.sqlite *.xml *.mbox *.eml *.md *.markdown"),
             ("QWK archives", "*.qwk"),
             ("REP archives", "*.rep"),
             ("JSON archives", "*.json"),
@@ -910,6 +910,7 @@ class QwkGuiApp:
             ("CSV archives", "*.csv"),
             ("SQLite databases", "*.db *.sqlite"),
             ("XML archives", "*.xml"),
+            ("Markdown files", "*.md *.markdown"),
             ("mbox files", "*.mbox"),
             ("EML files", "*.eml"),
             ("messages.dat", "messages.dat"),
@@ -1375,7 +1376,7 @@ class QwkGuiApp:
         filetypes = [
             ("Text files", "*.txt"),
             ("HTML files", "*.html"),
-            ("Markdown files", "*.md"),
+            ("Markdown files", "*.md *.markdown"),
             ("JSON files", "*.json"),
             ("JSONL files", "*.jsonl"),
             ("mbox files", "*.mbox"),


### PR DESCRIPTION
### Description
* **Type:** Internal Help
* **What:** Updated the welcome screen and file selection dialogs in `pyqwk/gui.py`.
* **Why:** The Graphical Reader's interface did not explicitly mention support for Markdown or JSONL formats. Updating these strings ensures the interface accurately reflects the application's capabilities, following the 'Truth First' documentation principle and making it easier for users to work with these file types.

### Changes
- **Welcome Screen:** Added 'JSONL' and 'Markdown' to the list of supported formats.
- **Open Dialog:** Added `*.md` and `*.markdown` to the "All supported formats" filter and inserted a dedicated "Markdown files" entry.
- **Export Dialog:** Updated the "Markdown files" entry to support both `.md` and `.markdown` extensions.

Verified with existing GUI tests (`tests/test_gui.py` and `tests/test_gui_welcome.py`).

---
*PR created automatically by Jules for task [13108795068477410235](https://jules.google.com/task/13108795068477410235) started by @RainRat*