### PR TITLE
[DOCS] Update Graphical Reader format support documentation and filters

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -256,7 +256,7 @@ class QwkGuiApp:
         self.detail_text.insert(tk.END, "Use Ctrl+O or the 'Open' button in the toolbar to load a message archive.\n\n", "body")
 
         self.detail_text.insert(tk.END, "Supported Formats:\n", "header_label")
-        formats = "QWK, REP, JSON, CSV, SQLite (.db), XML, mbox, EML, and MESSAGES.DAT"
+        formats = "QWK, REP, JSON, JSONL, CSV, SQLite (.db), XML, mbox, EML, Markdown, and MESSAGES.DAT"
         self.detail_text.insert(tk.END, f"{formats}\n\n", "body")
 
         self.detail_text.insert(tk.END, "Keyboard Shortcuts:\n", "header_label")
@@ -758,7 +758,7 @@ class QwkGuiApp:
         )
         self.detail_text.insert(tk.END, "\n\n")
 
-        # Metadata line (Date, Conference, BBS, Msg #)
+        # Information line (Date, Conference, BBS, Msg #)
         self.detail_text.insert(tk.END, f"{header.msgdate} {header.msgtime}", "header_meta")
 
         # Badges
@@ -902,7 +902,10 @@ class QwkGuiApp:
 
     def open_file(self, _event: object | None = None) -> None:
         filetypes = [
-            ("All supported formats", "*.qwk *.rep *.json *.jsonl *.csv *.db *.sqlite *.xml *.mbox *.eml"),
+            (
+                "All supported formats",
+                "*.qwk *.rep *.json *.jsonl *.csv *.db *.sqlite *.xml *.mbox *.eml *.md *.markdown",
+            ),
             ("QWK archives", "*.qwk"),
             ("REP archives", "*.rep"),
             ("JSON archives", "*.json"),
@@ -912,6 +915,7 @@ class QwkGuiApp:
             ("XML archives", "*.xml"),
             ("mbox files", "*.mbox"),
             ("EML files", "*.eml"),
+            ("Markdown files", "*.md *.markdown"),
             ("messages.dat", "messages.dat"),
             ("All files", "*.*"),
         ]


### PR DESCRIPTION
The Graphical Reader's welcome screen and file dialogs in `pyqwk/gui.py` were updated to explicitly include Markdown and JSONL, ensuring the user-facing documentation matches the tool's actual capabilities. The technical term "Metadata" was also replaced with "Information" in code comments to follow Plain English standards.

Key changes:
- Added JSONL and Markdown to the "Supported Formats" list on the GUI welcome screen.
- Updated the "Open Archive" file dialog to include Markdown (`*.md`, `*.markdown`) in both the collective and individual filters.
- Refined code comments to use simpler language.

---
*PR created automatically by Jules for task [17892534748929886877](https://jules.google.com/task/17892534748929886877) started by @RainRat*