### PR TITLE
[DOCS] Simplify statistics report heading by removing jargon

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -3892,7 +3892,7 @@ def render_stats_as_text(stats: dict[str, Any], use_colors: bool = False) -> str
 
     parts.append(f"  {c('Private:', BOLD)}    {stats['private_count']} messages")
 
-    parts.append(f"\n  {c('Vitality & Content:', BOLD)}")
+    parts.append(f"\n  {c('Activity & Content:', BOLD)}")
     parts.append(f"    Reply Rate:    {stats['reply_rate']}% ({stats['reply_count']} replies)")
     parts.append(f"    Avg Length:    {int(stats['avg_message_length'])} characters")
 

--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -1575,7 +1575,7 @@ class QwkGuiApp:
                 insert_info("Date Range", f"{earliest} to {latest}")
             insert_info("Private", f"{stats['private_count']} messages")
 
-            txt.insert(tk.END, "\nVitality & Content\n", "h2")
+            txt.insert(tk.END, "\nActivity & Content\n", "h2")
             insert_info("Reply Rate", f"{stats['reply_rate']}% ({stats['reply_count']} replies)")
             insert_info("Avg Length", f"{int(stats['avg_message_length'])} characters")
 

--- a/tests/test_stats_advanced.py
+++ b/tests/test_stats_advanced.py
@@ -114,7 +114,7 @@ def test_stats_advanced_ui(monkeypatch, capsys):
     show_stats(["dummy.qwk"], settings, logging.getLogger("test"))
 
     captured = capsys.readouterr()
-    assert "Vitality & Content:" in captured.out
+    assert "Activity & Content:" in captured.out
     assert "Reply Rate:" in captured.out
     assert "Avg Length:" in captured.out
     assert "Yearly Activity:" in captured.out


### PR DESCRIPTION
This change improves the clarity and accessibility of the statistics reports by replacing the jargon-heavy term "Vitality" with the simpler and more descriptive "Activity". This follows the Plain English guidelines for user-facing text.

Key changes:
- In `pyqwk/core.py`, the CLI/text statistics heading was updated.
- In `pyqwk/gui.py`, the Graphical Reader's statistics window heading was updated.
- In `tests/test_stats_advanced.py`, the test assertion for the heading was updated.

---
*PR created automatically by Jules for task [13079662237520306612](https://jules.google.com/task/13079662237520306612) started by @RainRat*