### PR TITLE
[UI/UX] Enable interactive filtering from the Statistics window

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -1,5 +1,6 @@
 import argparse
 import datetime
+import hashlib
 import logging
 import os
 import webbrowser
@@ -1557,10 +1558,14 @@ class QwkGuiApp:
             txt.tag_configure("dim", foreground="#888888")
             txt.tag_configure("cyan_bar", background="#00aaaa", foreground="#ffffff")
             txt.tag_configure("info_label", font=("TkFixedFont", 10, "bold"), foreground="#666666")
+            txt.tag_configure("link", foreground="blue", underline=True)
+            txt.tag_bind("link", "<Enter>", lambda e: txt.config(cursor="hand2"))
+            txt.tag_bind("link", "<Leave>", lambda e: txt.config(cursor=""))
 
             # Rendering logic
             display_name = os.path.basename(stats['file']) if len(self.current_paths) == 1 else "Multiple Archives"
             txt.insert(tk.END, f"Statistics for: {display_name}\n\n", "h1")
+            txt.insert(tk.END, "Tip: Click on Authors, Conferences, or BBSes to filter the main view.\n", "dim")
 
             def insert_info(label, value):
                 txt.insert(tk.END, f"  {label:<15}: ", "info_label")
@@ -1579,18 +1584,45 @@ class QwkGuiApp:
             insert_info("Reply Rate", f"{stats['reply_rate']}% ({stats['reply_count']} replies)")
             insert_info("Avg Length", f"{int(stats['avg_message_length'])} characters")
 
-            def render_gui_bar_chart(title, data):
+            def render_gui_bar_chart(title, data, filter_type=None):
                 if not data:
                     return
                 txt.insert(tk.END, f"\n{title}\n", "h2")
-                max_count = max(count for _, count in data) if data else 0
-                for label, count in data:
+                max_count = max(item[1] for item in data) if data else 0
+                for i, item in enumerate(data):
+                    label = item[0]
+                    count = item[1]
+                    filter_val = item[2] if len(item) > 2 else label
+
                     truncated_label = f"{str(label)[:25]:<25}"
                     count_str = f"{count:4}"
                     bar_len = int(count * 40 / max_count) if max_count > 0 else 0
 
                     txt.insert(tk.END, "    ", "")
-                    txt.insert(tk.END, truncated_label, "dim")
+
+                    label_tags = ["dim"]
+                    if filter_type:
+                        label_tags.append("link")
+                        # Create a unique tag for this specific label to bind the click event
+                        # Include title hash to ensure uniqueness across different charts
+                        title_hash = hashlib.md5(title.encode()).hexdigest()[:8]
+                        item_tag = f"filter_{filter_type}_{title_hash}_{i}"
+                        label_tags.append(item_tag)
+
+                        def make_callback(ft, fv):
+                            def callback(e):
+                                stats_win.destroy()
+                                if ft == 'author':
+                                    self._pivot_filter(author=fv)
+                                elif ft == 'conf':
+                                    self._pivot_filter(conf_num=fv)
+                                elif ft == 'bbs':
+                                    self._pivot_filter(bbs_name=fv)
+                            return callback
+
+                        txt.tag_bind(item_tag, "<Button-1>", make_callback(filter_type, filter_val))
+
+                    txt.insert(tk.END, truncated_label, tuple(label_tags))
                     txt.insert(tk.END, " : ", "")
                     txt.insert(tk.END, count_str, "bold")
                     txt.insert(tk.END, " ", "")
@@ -1606,15 +1638,15 @@ class QwkGuiApp:
                 items = [(m, c) for m, c in sorted(stats['month_distribution'].items())]
                 render_gui_bar_chart('Monthly Activity', items)
 
-            render_gui_bar_chart('Top Authors', [(a["name"], a["count"]) for a in stats['authors']])
-            render_gui_bar_chart('Top Recipients', [(r["name"], r["count"]) for r in stats['recipients']])
+            render_gui_bar_chart('Top Authors', [(a["name"], a["count"], a["name"]) for a in stats['authors']], filter_type='author')
+            render_gui_bar_chart('Top Recipients', [(r["name"], r["count"], r["name"]) for r in stats['recipients']], filter_type='author')
 
             if stats.get('bbses'):
-                render_gui_bar_chart('Top BBSes', [(b["name"], b["count"]) for b in stats['bbses']])
+                render_gui_bar_chart('Top BBSes', [(b["name"], b["count"], b["name"]) for b in stats['bbses']], filter_type='bbs')
 
             if stats['conferences']:
-                items = [(f"{c['number']:3} {c['name']}", c["count"]) for c in stats['conferences']]
-                render_gui_bar_chart('Top Conferences', items)
+                items = [(f"{c['number']:3} {c['name']}", c["count"], c["number"]) for c in stats['conferences']]
+                render_gui_bar_chart('Top Conferences', items, filter_type='conf')
 
             render_gui_bar_chart('Top Subjects', [(s["subject"], s["count"]) for s in stats['subjects']])
             render_gui_bar_chart('Top Keywords', [(k["word"], k["count"]) for k in stats['keywords']])

--- a/tests/test_gui_coverage_gaps_lead_qa_v2.py
+++ b/tests/test_gui_coverage_gaps_lead_qa_v2.py
@@ -140,4 +140,12 @@ def test_show_stats_window_with_bbses(app):
 
         # Verify Top BBSes header and data were inserted
         mock_txt.insert.assert_any_call(ANY, "\nTop BBSes\n", "h2")
-        mock_txt.insert.assert_any_call(ANY, f"{'MyBBS'[:25]:<25}", "dim")
+        # Check that 'dim' and 'link' tags are present (or just check the label text)
+        found_call = False
+        for call in mock_txt.insert.call_args_list:
+            if len(call.args) >= 2 and call.args[1] == f"{'MyBBS'[:25]:<25}":
+                tags = call.args[2]
+                if isinstance(tags, tuple) and "dim" in tags and "link" in tags:
+                    found_call = True
+                    break
+        assert found_call, "Could not find insert call for MyBBS with expected tags"

--- a/tests/test_gui_stats_interactivity.py
+++ b/tests/test_gui_stats_interactivity.py
@@ -1,0 +1,131 @@
+import sys
+from unittest.mock import MagicMock, patch
+import pytest
+
+# Mock tkinter before any pyqwk.gui imports
+class MockTclError(Exception):
+    pass
+
+if "tkinter" in sys.modules:
+    existing_tk = sys.modules["tkinter"]
+    existing_tk.TclError = MockTclError
+else:
+    mock_tk = MagicMock()
+    mock_tk.TclError = MockTclError
+    sys.modules["tkinter"] = mock_tk
+
+if "tkinter.ttk" not in sys.modules:
+    sys.modules["tkinter.ttk"] = MagicMock()
+if "tkinter.filedialog" not in sys.modules:
+    sys.modules["tkinter.filedialog"] = MagicMock()
+if "tkinter.messagebox" not in sys.modules:
+    sys.modules["tkinter.messagebox"] = MagicMock()
+if "tkinter.simpledialog" not in sys.modules:
+    sys.modules["tkinter.simpledialog"] = MagicMock()
+
+from pyqwk.gui import QwkGuiApp
+
+@pytest.fixture
+def app():
+    root = MagicMock()
+    root.after = MagicMock()
+
+    with patch("tkinter.BooleanVar", return_value=MagicMock()), \
+         patch("tkinter.StringVar", return_value=MagicMock()), \
+         patch("tkinter.ttk.Treeview", return_value=MagicMock()) as mock_tree, \
+         patch("tkinter.Text", return_value=MagicMock()) as mock_text, \
+         patch("tkinter.ttk.Combobox") as mock_combo:
+
+        a = QwkGuiApp(root)
+        a.message_list = mock_tree.return_value
+        a.detail_text = mock_text.return_value
+        a.bbs_combo = mock_combo.return_value
+        a.conf_combo = mock_combo.return_value
+
+        return a
+
+def test_stats_window_interactivity(app):
+    app.current_paths = ["test.qwk"]
+    full_stats = {
+        'file': 'test.qwk',
+        'matching_messages': 1,
+        'total_messages': 1,
+        'attachments_count': 0,
+        'dates': {'earliest': None, 'latest': None},
+        'private_count': 0,
+        'reply_rate': 0.0,
+        'reply_count': 0,
+        'avg_message_length': 0.0,
+        'year_distribution': {},
+        'month_distribution': {},
+        'authors': [{'name': 'Target Author', 'count': 1}],
+        'recipients': [{'name': 'Target Recipient', 'count': 1}],
+        'bbses': [{'name': 'Target BBS', 'count': 1}],
+        'conferences': [{'number': 101, 'name': 'Target Conf', 'count': 1}],
+        'subjects': [],
+        'keywords': [],
+        'links': [],
+        'emails': [],
+        'phones': [],
+        'day_of_week': {},
+        'hour_of_day': {}
+    }
+
+    with patch("pyqwk.gui.calculate_archive_stats", return_value=full_stats), \
+         patch("pyqwk.gui.tk.Toplevel") as mock_toplevel_cls, \
+         patch("pyqwk.gui.tk.Text") as mock_text_cls:
+
+        mock_win = MagicMock()
+        mock_toplevel_cls.return_value = mock_win
+        mock_txt = MagicMock()
+        mock_text_cls.return_value = mock_txt
+
+        # Dictionary to store tag callbacks for <Button-1>
+        tag_callbacks = {}
+        def mock_tag_bind(tag, event, callback):
+            if event == "<Button-1>":
+                tag_callbacks[tag] = callback
+        mock_txt.tag_bind.side_effect = mock_tag_bind
+
+        app.show_stats_window()
+
+        # Verify instructional tip was inserted
+        inserted_texts = [call.args[1] for call in mock_txt.insert.call_args_list if len(call.args) > 1]
+        assert any("Tip: Click on Authors" in text for text in inserted_texts)
+
+        # Find tags
+        author_tags = [tag for tag in tag_callbacks if tag.startswith("filter_author")]
+        bbs_tags = [tag for tag in tag_callbacks if tag.startswith("filter_bbs")]
+        conf_tags = [tag for tag in tag_callbacks if tag.startswith("filter_conf")]
+
+        # Top Authors and Top Recipients both use filter_type='author'
+        assert len(author_tags) == 2
+        assert len(bbs_tags) == 1
+        assert len(conf_tags) == 1
+
+        # Simulate click on Author
+        with patch.object(app, "_pivot_filter") as mock_pivot:
+            tag_callbacks[author_tags[0]](None)
+            mock_pivot.assert_called_with(author='Target Author')
+            mock_win.destroy.assert_called()
+
+        # Simulate click on Recipient (also uses author filter)
+        mock_win.destroy.reset_mock()
+        with patch.object(app, "_pivot_filter") as mock_pivot:
+            tag_callbacks[author_tags[1]](None)
+            mock_pivot.assert_called_with(author='Target Recipient')
+            mock_win.destroy.assert_called()
+
+        # Simulate click on BBS
+        mock_win.destroy.reset_mock()
+        with patch.object(app, "_pivot_filter") as mock_pivot:
+            tag_callbacks[bbs_tags[0]](None)
+            mock_pivot.assert_called_with(bbs_name='Target BBS')
+            mock_win.destroy.assert_called()
+
+        # Simulate click on Conference
+        mock_win.destroy.reset_mock()
+        with patch.object(app, "_pivot_filter") as mock_pivot:
+            tag_callbacks[conf_tags[0]](None)
+            mock_pivot.assert_called_with(conf_num=101)
+            mock_win.destroy.assert_called()


### PR DESCRIPTION
* **Context:** GUI
* **Problem:** Users viewing the Archive Statistics report (Ctrl+I) had to manually note interesting authors, conferences, or BBSes and then manually apply filters in the main toolbar to find those messages. This created friction when moving from high-level analytics to specific message discovery.
* **Solution:** Added interactivity to the Statistics window's bar charts. Labels for Authors, Recipients, BBSes, and Conferences are now clickable links. Clicking a label automatically closes the statistics window and applies the corresponding filter to the main view. This significantly reduces the steps required to pivot from data analysis to message reading.
* **Verification:** Added `tests/test_gui_stats_interactivity.py` and updated existing GUI tests. All 719 tests pass.

---
*PR created automatically by Jules for task [16755140717055497429](https://jules.google.com/task/16755140717055497429) started by @RainRat*