### PR TITLE
[FEAT] Expand full-text search scope to metadata and attachments

### DIFF
--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -326,7 +326,7 @@ examples:
         '-S',
         '--search',
         dest='search_term',
-        help='Search for a keyword in author, recipient, subject, and message body.',
+        help='Search for a keyword in author, recipient, subject, body, conference, BBS, and attachments.',
     )
     filter_group.add_argument(
         '--regex',

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -1846,11 +1846,20 @@ def matches_filters(
 
     # 7. Full-Text Search
     if settings.search_term:
+        if message.text and message.attachments is None:
+            found_attachments = extract_binaries(message.text)
+            message.attachments = [name for name, data in found_attachments]
+
         found = (
             check_str_match(settings.search_term, message.header.msgfrom)
             or check_str_match(settings.search_term, message.header.msgto)
             or check_str_match(settings.search_term, message.header.msgsubject)
             or check_str_match(settings.search_term, message.text)
+            or (message.confname and check_str_match(settings.search_term, message.confname))
+            or (message.bbs_name and check_str_match(settings.search_term, message.bbs_name))
+            or (message.bbs_id and check_str_match(settings.search_term, message.bbs_id))
+            or (message.source_file and check_str_match(settings.search_term, message.source_file))
+            or (message.attachments and any(check_str_match(settings.search_term, a) for a in message.attachments))
         )
         if not found:
             return False

--- a/tests/test_search_expansion.py
+++ b/tests/test_search_expansion.py
@@ -1,0 +1,118 @@
+import pytest
+from pyqwk.core import ParsedMessage, MessageHeader, ProcessingSettings, matches_filters
+
+@pytest.fixture
+def base_header():
+    return MessageHeader(
+        status=" ",
+        msgnum=1,
+        msgdate="01-01-23",
+        msgtime="12:00",
+        msgto="Recipient",
+        msgfrom="Author",
+        msgsubject="Subject",
+        msgpassword="",
+        refnum=None,
+        numblocks=1,
+        msgflag=" ",
+        confnum=1,
+        lognum=0,
+        nettag=""
+    )
+
+@pytest.fixture
+def base_settings():
+    return ProcessingSettings(
+        verbose=False,
+        private=False,
+        no_header=False,
+        truncate_signatures=False,
+        cut_quoting=False,
+        individual_files=False,
+        threaded=False,
+        binaries_removal=False,
+        redact_pii=False,
+        format='text',
+        separator='auto',
+        output_mode='stdout',
+        output_path=None,
+        encoding='cp437',
+        search_term=None
+    )
+
+def test_search_confname(base_header, base_settings):
+    msg = ParsedMessage(
+        text="Hello world",
+        msgnum=1,
+        refnum=None,
+        confnum=1,
+        header=base_header,
+        confname="Vintage Computing"
+    )
+    base_settings.search_term = "vintage"
+    assert matches_filters(msg, base_settings, set()) is True
+
+    base_settings.search_term = "modern"
+    assert matches_filters(msg, base_settings, set()) is False
+
+def test_search_bbs_info(base_header, base_settings):
+    msg = ParsedMessage(
+        text="Hello world",
+        msgnum=1,
+        refnum=None,
+        confnum=1,
+        header=base_header,
+        bbs_name="The Digital Orbit",
+        bbs_id="DIGITAL"
+    )
+    base_settings.search_term = "orbit"
+    assert matches_filters(msg, base_settings, set()) is True
+
+    base_settings.search_term = "digital"
+    assert matches_filters(msg, base_settings, set()) is True
+
+def test_search_source_file(base_header, base_settings):
+    msg = ParsedMessage(
+        text="Hello world",
+        msgnum=1,
+        refnum=None,
+        confnum=1,
+        header=base_header,
+        source_file="archive_2023.qwk"
+    )
+    base_settings.search_term = "2023"
+    assert matches_filters(msg, base_settings, set()) is True
+
+def test_search_attachments(base_header, base_settings):
+    # Test searching in explicitly provided attachments
+    msg = ParsedMessage(
+        text="Hello world",
+        msgnum=1,
+        refnum=None,
+        confnum=1,
+        header=base_header,
+        attachments=["image.gif", "data.zip"]
+    )
+    base_settings.search_term = "gif"
+    assert matches_filters(msg, base_settings, set()) is True
+
+def test_search_extracted_attachments(base_header, base_settings):
+    # Test that attachments are extracted and searched if not present
+    uue_text = (
+        "Hello\r\n"
+        "begin 644 secret.txt\r\n"
+        "M\"@H*      \r\n"
+        "`\r\n"
+        "end\r\n"
+    )
+    msg = ParsedMessage(
+        text=uue_text,
+        msgnum=1,
+        refnum=None,
+        confnum=1,
+        header=base_header,
+        attachments=None
+    )
+    base_settings.search_term = "secret"
+    assert matches_filters(msg, base_settings, set()) is True
+    assert msg.attachments == ["secret.txt"]


### PR DESCRIPTION
This pull request expands the capabilities of the `--search` flag to include message information and context beyond just the author, recipient, subject, and body.

### What
- **Expanded Search Scope:** Users can now find messages by searching for conference names, BBS names, BBS IDs, and the names of the source archives.
- **Attachment Name Searching:** The search now includes filenames of attachments (UUE, yEnc, Base64) embedded within the message text.
- **Lazy Attachment Extraction:** To support searching without excessive overhead, attachment filenames are extracted only when a search is active and they haven't been previously identified.
- **Updated Documentation:** The CLI help text now explicitly lists these new searchable fields.

### Why
Previously, the search was limited to core message fields. If a user wanted to find all messages from a specific BBS across multiple merged archives or find a message that they knew contained a specific file (e.g., "IMAGE.GIF"), they had to use separate filters or external tools. This change brings symmetry to the search functionality—if a piece of information is visible in the output or header, it should be searchable.

### Verification Results
- All new search targets (Conference, BBS, Source File, Attachments) were verified with the new `tests/test_search_expansion.py` suite.
- Existing search and filtering tests pass, ensuring no regressions.
- Code review confirmed the safety and efficiency of the lazy extraction mechanism.

---
*PR created automatically by Jules for task [14661373156110313243](https://jules.google.com/task/14661373156110313243) started by @RainRat*