### PR TITLE
[UI/UX] Add search navigation (Find Next/Previous) to Graphical Reader

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -58,6 +58,8 @@ class QwkGuiApp:
         self._cache = {}
         self.conf_mapping = {}
         self.bbs_mapping = {}
+        self._search_matches = []
+        self._current_match_idx = -1
 
         self.column_labels = {
             "#0": "Subject",
@@ -268,6 +270,8 @@ class QwkGuiApp:
             ("Ctrl + S", "Export Current View"),
             ("Ctrl + I", "Archive Statistics"),
             ("Ctrl + F", "Search / Find"),
+            ("F3", "Find Next"),
+            ("Shift + F3", "Find Previous"),
             ("Ctrl + G", "Go to Message Number"),
             ("Ctrl + Q", "Quit Application"),
             ("Esc", "Clear Search / Filters"),
@@ -313,6 +317,16 @@ class QwkGuiApp:
             accelerator="Ctrl+F",
         )
         edit_menu.add_command(
+            label="Find Next",
+            command=lambda: self._navigate_search_matches(1),
+            accelerator="F3",
+        )
+        edit_menu.add_command(
+            label="Find Previous",
+            command=lambda: self._navigate_search_matches(-1),
+            accelerator="Shift+F3",
+        )
+        edit_menu.add_command(
             label="Go to Message...",
             command=self.prompt_jump_to_message,
             accelerator="Ctrl+G",
@@ -331,6 +345,8 @@ class QwkGuiApp:
         self.root.bind("<Control-g>", self.prompt_jump_to_message)
         self.root.bind("<Control-q>", self.quit_app)
         self.root.bind("<Escape>", self.clear_search)
+        self.root.bind("<F3>", lambda e: self._navigate_search_matches(1))
+        self.root.bind("<Shift-F3>", lambda e: self._navigate_search_matches(-1))
         self.root.bind("j", lambda e: self._select_relative_message(1))
         self.root.bind("n", lambda e: self._select_relative_message(1))
         self.root.bind("k", lambda e: self._select_relative_message(-1))
@@ -666,6 +682,9 @@ class QwkGuiApp:
         self.detail_text.tag_configure(
             "search_highlight", background="#ffff00", foreground="#000000"
         )
+        self.detail_text.tag_configure(
+            "current_search_highlight", background="#ff9900", foreground="#ffffff"
+        )
         self.detail_text.tag_configure("link", foreground="blue", underline=True)
         self.detail_text.tag_bind(
             "link", "<Enter>", lambda e: self.detail_text.config(cursor="hand2")
@@ -889,11 +908,12 @@ class QwkGuiApp:
 
         # Highlight search terms if present
         search_term = self.search_var.get().strip()
+        self._search_matches = []
+        self._current_match_idx = -1
         if search_term:
             start_pos = "1.0"
             is_regex = self.regex_var.get()
             count_var = tk.IntVar()
-            first_match_pos = None
 
             while True:
                 try:
@@ -907,20 +927,50 @@ class QwkGuiApp:
                 if not start_pos:
                     break
 
-                if first_match_pos is None:
-                    first_match_pos = start_pos
-
                 match_count = count_var.get()
                 if match_count == 0:  # Avoid infinite loop on zero-width match
                     start_pos = f"{start_pos}+1c"
                     continue
                 end_pos = f"{start_pos}+{match_count}c"
                 self.detail_text.tag_add("search_highlight", start_pos, end_pos)
+                self._search_matches.append((start_pos, end_pos))
                 start_pos = end_pos
 
             self.detail_text.tag_raise("search_highlight")
-            if first_match_pos:
-                self.detail_text.see(first_match_pos)
+            if self._search_matches:
+                self._current_match_idx = 0
+                self.detail_text.see(self._search_matches[0][0])
+                self.detail_text.tag_add("current_search_highlight", self._search_matches[0][0], self._search_matches[0][1])
+                self.detail_text.tag_raise("current_search_highlight")
+
+                # Update status feedback
+                source_display = self.root.title().split(" - ")[0]
+                self.status_label.config(
+                    text=f"Match 1 of {len(self._search_matches)}  •  Showing {len(self.messages)} messages from {source_display}"
+                )
+
+    def _navigate_search_matches(self, delta: int, _event: object | None = None) -> None:
+        """Cycle through search matches in the detail view."""
+        if not self._search_matches:
+            return
+
+        # Remove existing current highlight
+        self.detail_text.tag_remove("current_search_highlight", "1.0", tk.END)
+
+        # Update index
+        self._current_match_idx = (self._current_match_idx + delta) % len(self._search_matches)
+
+        # Apply new highlight and scroll
+        start_pos, end_pos = self._search_matches[self._current_match_idx]
+        self.detail_text.tag_add("current_search_highlight", start_pos, end_pos)
+        self.detail_text.tag_raise("current_search_highlight")
+        self.detail_text.see(start_pos)
+
+        # Update status feedback
+        source_display = self.root.title().split(" - ")[0]
+        self.status_label.config(
+            text=f"Match {self._current_match_idx + 1} of {len(self._search_matches)}  •  Showing {len(self.messages)} messages from {source_display}"
+        )
 
     def open_file(self, _event: object | None = None) -> None:
         filetypes = [

--- a/tests/test_search_navigation.py
+++ b/tests/test_search_navigation.py
@@ -1,0 +1,138 @@
+import sys
+from unittest.mock import MagicMock, patch, ANY
+import pytest
+import tkinter as tk
+
+# Mock tkinter before any pyqwk.gui imports
+mock_tk = MagicMock()
+mock_ttk = MagicMock()
+sys.modules["tkinter"] = mock_tk
+sys.modules["tkinter.filedialog"] = MagicMock()
+sys.modules["tkinter.messagebox"] = MagicMock()
+sys.modules["tkinter.ttk"] = mock_ttk
+
+from pyqwk.core import ParsedMessage, MessageHeader
+
+@pytest.fixture
+def mock_gui_deps():
+    with patch("pyqwk.gui.tk") as mock_tk, \
+         patch("pyqwk.gui.ttk") as mock_ttk, \
+         patch("pyqwk.gui.filedialog") as mock_fd, \
+         patch("pyqwk.gui.messagebox") as mock_mb:
+
+        # Configure Variable mocks
+        def make_var(value=None):
+            m = MagicMock()
+            m.get.return_value = value
+            return m
+
+        mock_tk.BooleanVar.side_effect = lambda value=False, **kwargs: make_var(value)
+        mock_tk.StringVar.side_effect = lambda value="", **kwargs: make_var(value)
+        mock_tk.IntVar.side_effect = lambda value=0, **kwargs: make_var(value)
+
+        # Tkinter constants
+        mock_tk.END = "end"
+        mock_tk.HORIZONTAL = "horizontal"
+        mock_tk.VERTICAL = "vertical"
+        mock_tk.BOTH = "both"
+        mock_tk.X = "x"
+        mock_tk.Y = "y"
+        mock_tk.LEFT = "left"
+        mock_tk.RIGHT = "right"
+        mock_tk.TOP = "top"
+        mock_tk.BOTTOM = "bottom"
+        mock_tk.SUNKEN = "sunken"
+        mock_tk.W = "w"
+        mock_tk.E = "e"
+        mock_tk.WORD = "word"
+        mock_tk.DISABLED = "disabled"
+        mock_tk.NORMAL = "normal"
+        mock_tk.INSERT = "insert"
+
+        yield {
+            "tk": mock_tk,
+            "ttk": mock_ttk,
+            "filedialog": mock_fd,
+            "messagebox": mock_mb,
+        }
+
+def get_app():
+    from pyqwk.gui import QwkGuiApp
+    root = MagicMock()
+    return QwkGuiApp(root)
+
+class TestSearchNavigation:
+    def test_search_match_population(self, mock_gui_deps):
+        app = get_app()
+        app.search_var.get.return_value = "match"
+
+        # Mock search to find 2 occurrences
+        app.detail_text.search.side_effect = ["1.5", "2.10", None]
+
+        mock_iv = MagicMock()
+        mock_iv.get.return_value = 5
+        # side_effect takes precedence, so we need to override it
+        mock_gui_deps["tk"].IntVar.side_effect = lambda *args, **kwargs: mock_iv
+
+        header = MessageHeader(' ', 1, "01-01-90", "12:00", "To", "From", "Sub", "", None, 1, " ", 1, 1, "")
+        msg = ParsedMessage("Body with match and another match", 1, None, 1, header)
+        app.messages = [msg]
+        app.board_dict = {1: "General"}
+
+        app._render_message(0)
+
+        assert len(app._search_matches) == 2
+        assert app._search_matches == [("1.5", "1.5+5c"), ("2.10", "2.10+5c")]
+        assert app._current_match_idx == 0
+
+        # Verify initial highlight
+        app.detail_text.tag_add.assert_any_call("current_search_highlight", "1.5", "1.5+5c")
+        app.detail_text.see.assert_called_with("1.5")
+
+    def test_navigate_search_matches(self, mock_gui_deps):
+        app = get_app()
+        app._search_matches = [("1.5", "1.5+5c"), ("2.10", "2.10+5c"), ("3.0", "3.0+5c")]
+        app._current_match_idx = 0
+        app.root.title.return_value = "Test BBS (test.qwk) - PyQWK Reader"
+
+        # Navigate forward
+        app._navigate_search_matches(1)
+        assert app._current_match_idx == 1
+        app.detail_text.tag_remove.assert_called_with("current_search_highlight", "1.0", "end")
+        app.detail_text.tag_add.assert_called_with("current_search_highlight", "2.10", "2.10+5c")
+        app.detail_text.see.assert_called_with("2.10")
+
+        # Navigate backward (wrap around)
+        app._navigate_search_matches(-1)
+        assert app._current_match_idx == 0
+
+        # Navigate backward again (wrap around to end)
+        app._navigate_search_matches(-1)
+        assert app._current_match_idx == 2
+        app.detail_text.see.assert_called_with("3.0")
+
+    def test_menu_and_bindings(self, mock_gui_deps):
+        app = get_app()
+        # Verify F3 bindings
+        app.root.bind.assert_any_call("<F3>", ANY)
+        app.root.bind.assert_any_call("<Shift-F3>", ANY)
+
+        # Verify menu items (Search through calls to add_command)
+        # This is a bit complex with MagicMock, but we can check if lambda was used
+        # or if specific labels were added to a menu.
+        # Actually we can check the calls to edit_menu.add_command
+        # But edit_menu is local to _build_menu.
+        # However, we can check mock_tk.Menu().add_command calls
+
+        found_next = False
+        found_prev = False
+        for call in mock_gui_deps["tk"].Menu().add_command.call_args_list:
+            if call.kwargs.get('label') == "Find Next":
+                found_next = True
+                assert call.kwargs.get('accelerator') == "F3"
+            if call.kwargs.get('label') == "Find Previous":
+                found_prev = True
+                assert call.kwargs.get('accelerator') == "Shift+F3"
+
+        # Note: multiple menus are created, so we need to be careful.
+        # If the above fails, it might be because the mock returned different Menu objects.


### PR DESCRIPTION
Improved the search experience in the Graphical Reader by adding match navigation.

### Friction Reduction
Previously, search results were highlighted, but users had to scroll manually to find them in long messages. Now, users can instantly jump between matches using standard keyboard shortcuts (F3/Shift+F3).

### Feedback & Clarity
Introduced a "Match X of Y" indicator in the status bar and a distinct orange highlight for the currently active match, making it clear which result is being viewed.

### Consistency
Used standard F3/Shift+F3 bindings and added corresponding items to the Edit menu, ensuring the feature feels native and intuitive.

---
*PR created automatically by Jules for task [3156537856005559977](https://jules.google.com/task/3156537856005559977) started by @RainRat*