### PR TITLE
Remove redundant process_file wrapper

### DIFF
--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -10,7 +10,6 @@ from pyqwk.core import (
     ProcessingSettings,
     __version__,
     expand_paths,
-    process_file,
     process_merged_files,
     process_multiple_files,
     organize_by_bbs,
@@ -621,7 +620,7 @@ examples:
             sys.exit(1)
     else:
         try:
-            process_file(input_paths[0], settings, logger)
+            process_merged_files([input_paths[0]], settings, logger)
         except PROCESSING_EXCEPTIONS as error:
             logger.error(error)
             sys.exit(1)

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -2476,14 +2476,6 @@ def process_merged_files(
         print(f"{_colorize('No changes were made to the disk.', BOLD)}")
 
 
-def process_file(
-    input_path: str,
-    settings: ProcessingSettings,
-    logger: logging.Logger,
-) -> None:
-    process_merged_files([input_path], settings, logger)
-
-
 def _message_to_dict(message: ProcessedMessage) -> dict[str, Any]:
     return {
         'header': message.header.as_dict,
@@ -4152,7 +4144,7 @@ def process_multiple_files(
                 output_mode='file',
                 output_path=output_path,
             )
-            process_file(input_path, per_file_settings, logger)
+            process_merged_files([input_path], per_file_settings, logger)
         except PROCESSING_EXCEPTIONS as error:
             logger.error("Error processing file %s: %s", input_path, error)
             had_errors = True

--- a/tests/test_auto_detect.py
+++ b/tests/test_auto_detect.py
@@ -23,15 +23,15 @@ def test_main_auto_detects_json(monkeypatch, tmp_path, baseline_path):
     monkeypatch.setattr(sys, "argv", ["qwk", str(baseline_path), "-o", str(output_path)])
 
     # We want to verify that ProcessingSettings was created with format='json'
-    # We can mock process_file to check settings
+    # We can mock process_merged_files to check settings
 
     captured_settings = []
 
-    def mock_process_file(input_path, settings, logger):
+    def mock_process_merged_files(input_paths, settings, logger):
         captured_settings.append(settings)
 
     import pyqwk.cli as cli
-    monkeypatch.setattr(cli, "process_file", mock_process_file)
+    monkeypatch.setattr(cli, "process_merged_files", mock_process_merged_files)
 
     main()
 
@@ -46,11 +46,11 @@ def test_main_auto_detects_html(monkeypatch, tmp_path, baseline_path):
     monkeypatch.setattr(sys, "argv", ["qwk", str(baseline_path), "-o", str(output_path)])
 
     captured_settings = []
-    def mock_process_file(input_path, settings, logger):
+    def mock_process_merged_files(input_paths, settings, logger):
         captured_settings.append(settings)
 
     import pyqwk.cli as cli
-    monkeypatch.setattr(cli, "process_file", mock_process_file)
+    monkeypatch.setattr(cli, "process_merged_files", mock_process_merged_files)
 
     main()
 
@@ -65,11 +65,11 @@ def test_main_defaults_to_text_unknown_extension(monkeypatch, tmp_path, baseline
     monkeypatch.setattr(sys, "argv", ["qwk", str(baseline_path), "-o", str(output_path)])
 
     captured_settings = []
-    def mock_process_file(input_path, settings, logger):
+    def mock_process_merged_files(input_paths, settings, logger):
         captured_settings.append(settings)
 
     import pyqwk.cli as cli
-    monkeypatch.setattr(cli, "process_file", mock_process_file)
+    monkeypatch.setattr(cli, "process_merged_files", mock_process_merged_files)
 
     main()
 
@@ -85,11 +85,11 @@ def test_main_respects_explicit_format(monkeypatch, tmp_path, baseline_path):
     monkeypatch.setattr(sys, "argv", ["qwk", str(baseline_path), "-o", str(output_path), "--format", "text"])
 
     captured_settings = []
-    def mock_process_file(input_path, settings, logger):
+    def mock_process_merged_files(input_paths, settings, logger):
         captured_settings.append(settings)
 
     import pyqwk.cli as cli
-    monkeypatch.setattr(cli, "process_file", mock_process_file)
+    monkeypatch.setattr(cli, "process_merged_files", mock_process_merged_files)
 
     main()
 

--- a/tests/test_cli_coverage_extra.py
+++ b/tests/test_cli_coverage_extra.py
@@ -149,7 +149,7 @@ def test_individual_files_mode_setup(monkeypatch, testdata_dir, tmp_path):
 
     import pyqwk.cli as cli
     with monkeypatch.context() as m:
-        m.setattr(cli, "process_file", lambda *args: None)
+        m.setattr(cli, "process_merged_files", lambda *args: None)
         main()
 
 def test_merge_mode_error(monkeypatch, testdata_dir, caplog):

--- a/tests/test_coverage_gaps.py
+++ b/tests/test_coverage_gaps.py
@@ -5,7 +5,7 @@ from dataclasses import replace
 
 from pyqwk.core import (
     process_multiple_files,
-    process_file,
+    process_merged_files,
     show_info,
     show_stats,
     ProcessingSettings,
@@ -79,7 +79,7 @@ def test_process_multiple_files_error_handling(tmp_path, logger, default_setting
     input_paths = ['testdata/test1_qwk.zip']
     output_dir = tmp_path / "out_error"
 
-    with patch('pyqwk.core.process_file') as mock_process:
+    with patch('pyqwk.core.process_merged_files') as mock_process:
         mock_process.side_effect = OSError("Mocked OS Error")
 
         with patch.object(logger, 'error') as mock_log_error:
@@ -121,7 +121,7 @@ def test_individual_files_csv(tmp_path, logger, default_settings):
         output_path=str(output_dir)
     )
 
-    process_file(input_path, settings, logger)
+    process_merged_files([input_path], settings, logger)
 
     assert output_dir.exists()
     files = list(output_dir.iterdir())

--- a/tests/test_coverage_improvement.py
+++ b/tests/test_coverage_improvement.py
@@ -55,7 +55,7 @@ def test_single_file_mode_error(monkeypatch, testdata_dir, caplog):
     import pyqwk.cli as cli
     from pyqwk.core import MessagesDatFormatError
     with monkeypatch.context() as m:
-        m.setattr(cli, "process_file", MagicMock(side_effect=MessagesDatFormatError("Single file failure")))
+        m.setattr(cli, "process_merged_files", MagicMock(side_effect=MessagesDatFormatError("Single file failure")))
         with caplog.at_level(logging.ERROR):
             with pytest.raises(SystemExit) as exc:
                 main()

--- a/tests/test_date_filtering.py
+++ b/tests/test_date_filtering.py
@@ -3,7 +3,7 @@ import pytest
 import datetime
 import logging
 from dataclasses import replace
-from pyqwk.core import process_file, ProcessingSettings, ParsedMessage, MessageHeader
+from pyqwk.core import process_merged_files, ProcessingSettings, ParsedMessage, MessageHeader
 
 @pytest.fixture
 def mock_logger():
@@ -65,7 +65,7 @@ def test_filter_after(tmp_path, mock_messages_with_dates, mock_board_dict, mock_
         after=after_date
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     assert "Old Message" not in content
@@ -96,7 +96,7 @@ def test_filter_before(tmp_path, mock_messages_with_dates, mock_board_dict, mock
         before=before_date
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     assert "Old Message" in content
@@ -128,7 +128,7 @@ def test_filter_range(tmp_path, mock_messages_with_dates, mock_board_dict, mock_
         before=before_date
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     assert "Old Message" not in content
@@ -158,7 +158,7 @@ def test_filter_exact_boundary(tmp_path, mock_messages_with_dates, mock_board_di
         after=after_date
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     assert "Middle Message" in content # 2000-01-01 is >= 2000-01-01
@@ -187,7 +187,7 @@ def test_filter_before_boundary_inclusive(tmp_path, mock_messages_with_dates, mo
         before=before_date
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     assert "Middle Message" in content # 2000-01-01 12:00 is <= 2000-01-01 23:59:59
@@ -215,7 +215,7 @@ def test_filter_exclude_future(tmp_path, mock_messages_with_dates, mock_board_di
         before=before_date
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     assert content == ""

--- a/tests/test_dry_run.py
+++ b/tests/test_dry_run.py
@@ -1,7 +1,7 @@
 import pytest
 import sys
 from pathlib import Path
-from pyqwk.core import process_file, ProcessingSettings
+from pyqwk.core import process_merged_files, ProcessingSettings
 from pyqwk.cli import main
 import logging
 
@@ -18,7 +18,7 @@ def logger() -> logging.Logger:
     logger.addHandler(logging.NullHandler())
     return logger
 
-def test_process_file_dry_run_no_files_created(tmp_path, baseline_path, logger):
+def test_process_merged_files_dry_run_no_files_created(tmp_path, baseline_path, logger):
     output_dir = tmp_path / "output"
     output_dir.mkdir()
 
@@ -40,12 +40,12 @@ def test_process_file_dry_run_no_files_created(tmp_path, baseline_path, logger):
         dry_run=True
     )
 
-    process_file(str(baseline_path), settings, logger)
+    process_merged_files([str(baseline_path)], settings, logger)
 
     # Check that no files were created in the output directory
     assert len(list(output_dir.iterdir())) == 0
 
-def test_process_file_dry_run_summary_printed(capsys, baseline_path, logger):
+def test_process_merged_files_dry_run_summary_printed(capsys, baseline_path, logger):
     settings = ProcessingSettings(
         verbose=False,
         private=False,
@@ -65,7 +65,7 @@ def test_process_file_dry_run_summary_printed(capsys, baseline_path, logger):
         quiet=True
     )
 
-    process_file(str(baseline_path), settings, logger)
+    process_merged_files([str(baseline_path)], settings, logger)
 
     captured = capsys.readouterr()
     assert "--- Dry Run Summary ---" in captured.out

--- a/tests/test_email_import.py
+++ b/tests/test_email_import.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 from pyqwk.core import (
     load_data,
-    process_file,
+    process_merged_files,
     ProcessingSettings,
     ParsedMessage
 )
@@ -48,7 +48,7 @@ def test_mbox_export_reimport_symmetry(tmp_path, baseline_path, logger):
         output_mode="file",
         output_path=str(mbox_path)
     )
-    process_file(str(baseline_path), settings_export, logger)
+    process_merged_files([str(baseline_path)], settings_export, logger)
 
     assert mbox_path.exists()
 
@@ -75,7 +75,7 @@ def test_mbox_export_reimport_symmetry(tmp_path, baseline_path, logger):
         output_path=str(html_path)
     )
 
-    process_file(str(mbox_path), settings_html, logger)
+    process_merged_files([str(mbox_path)], settings_html, logger)
 
     assert html_path.exists()
     html_content = html_path.read_text(encoding="utf-8")
@@ -91,7 +91,7 @@ def test_eml_export_reimport_symmetry(tmp_path, baseline_path, logger):
         output_mode="file",
         output_path=str(eml_path)
     )
-    process_file(str(baseline_path), settings_export, logger)
+    process_merged_files([str(baseline_path)], settings_export, logger)
 
     assert eml_path.exists()
 

--- a/tests/test_eml.py
+++ b/tests/test_eml.py
@@ -6,7 +6,7 @@ import pytest
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from pyqwk.core import ProcessingSettings, process_file
+from pyqwk.core import ProcessingSettings, process_merged_files
 
 @pytest.fixture
 def testdata_dir() -> Path:
@@ -52,7 +52,7 @@ def test_eml_export_individual_files(tmp_path: Path, testdata_dir: Path) -> None
         output_path=str(output_dir)
     )
 
-    process_file(str(input_file), settings, logger)
+    process_merged_files([str(input_file)], settings, logger)
 
     files = list(output_dir.iterdir())
     assert len(files) == 1
@@ -115,7 +115,7 @@ def test_eml_aggregated_output(tmp_path: Path, testdata_dir: Path, capsys) -> No
         output_mode="stdout"
     )
 
-    process_file(str(input_file), settings, logger)
+    process_merged_files([str(input_file)], settings, logger)
 
     captured = capsys.readouterr()
     # messages.dat has one message. Aggregated EML should contain the content.

--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -2,8 +2,7 @@
 import pytest
 import logging
 from dataclasses import replace
-from pyqwk.core import (
-    process_file, ProcessingSettings, ParsedMessage, MessageHeader,
+from pyqwk.core import (process_merged_files, ProcessingSettings, ParsedMessage, MessageHeader,
     matches_filters
 )
 
@@ -79,7 +78,7 @@ def test_excludes_private_messages_by_default(tmp_path, mock_messages, mock_boar
         output_path=str(output_path), encoding="cp437", quiet=True
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     assert "Private Message" not in content
@@ -103,7 +102,7 @@ def test_includes_private_messages_when_requested(tmp_path, mock_messages, mock_
         output_path=str(output_path), encoding="cp437", quiet=True
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     assert "Private Message" in content
@@ -128,7 +127,7 @@ def test_always_excludes_password_protected_messages(tmp_path, mock_messages, mo
         output_path=str(output_path), encoding="cp437", quiet=True
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     assert "Password Protected" not in content
@@ -153,7 +152,7 @@ def test_filtering_by_id(tmp_path, mock_messages, mock_board_dict, mock_logger, 
         conferences=["2"]
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     assert "Msg 2 in Conf 2" in content
@@ -180,7 +179,7 @@ def test_filtering_by_name_exact(tmp_path, mock_messages, mock_board_dict, mock_
         conferences=["Python Dev"]
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     assert "Msg 3 in Conf 3" in content
@@ -206,7 +205,7 @@ def test_filtering_by_name_substring_case_insensitive(tmp_path, mock_messages, m
         conferences=["tech"] # Should match "Tech Talk"
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     assert "Msg 2 in Conf 2" in content
@@ -232,7 +231,7 @@ def test_filtering_multiple_criteria(tmp_path, mock_messages, mock_board_dict, m
         conferences=["1", "python"]
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     assert "Msg 1 in Conf 1" in content # Match by ID "1"
@@ -260,7 +259,7 @@ def test_filtering_numeric_fallback_when_names_missing(tmp_path, mock_messages, 
         conferences=["2"]
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     assert "Msg 2 in Conf 2" in content
@@ -286,7 +285,7 @@ def test_filtering_no_matches(tmp_path, mock_messages, mock_board_dict, mock_log
         conferences=["NonExistent"]
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     assert content == ""
@@ -311,7 +310,7 @@ def test_filtering_by_author_single(tmp_path, mock_messages, mock_board_dict, mo
         authors=["Alice"]
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     assert "Msg 1 in Conf 1" in content # From Alice
@@ -338,7 +337,7 @@ def test_filtering_by_author_multiple(tmp_path, mock_messages, mock_board_dict, 
         authors=["Alice", "Bob"]
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     assert "Msg 1 in Conf 1" in content # From Alice
@@ -365,7 +364,7 @@ def test_filtering_by_subject_substring(tmp_path, mock_messages, mock_board_dict
         subjects=["python"]
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     assert "Msg 3 in Conf 3" in content # Subject "Python Rules" matches "python"
@@ -391,7 +390,7 @@ def test_filtering_by_subject_multiple(tmp_path, mock_messages, mock_board_dict,
         subjects=["hello", "tech"]
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     assert "Msg 1 in Conf 1" in content # Subject "Hello World"
@@ -423,7 +422,7 @@ def test_filtering_combined_criteria(tmp_path, mock_messages, mock_board_dict, m
         authors=["Alice"]
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     assert "Msg 1 in Conf 1" in content

--- a/tests/test_fix_separators.py
+++ b/tests/test_fix_separators.py
@@ -2,7 +2,7 @@ import logging
 import sqlite3
 import pytest
 from pathlib import Path
-from pyqwk.core import process_file, ProcessingSettings
+from pyqwk.core import process_merged_files, ProcessingSettings
 
 @pytest.fixture
 def logger():
@@ -31,7 +31,7 @@ def test_sqlite_no_separator_by_default(tmp_path, logger):
         encoding="latin1"
     )
 
-    process_file(str(input_path), settings, logger)
+    process_merged_files([str(input_path)], settings, logger)
 
     conn = sqlite3.connect(str(db_path))
     c = conn.cursor()
@@ -65,7 +65,7 @@ def test_mbox_no_separator_by_default(tmp_path, logger):
         encoding="latin1"
     )
 
-    process_file(str(input_path), settings, logger)
+    process_merged_files([str(input_path)], settings, logger)
 
     content = mbox_path.read_text(encoding='utf-8')
     # In mbox, the separator should NOT be there.

--- a/tests/test_headers_only.py
+++ b/tests/test_headers_only.py
@@ -8,7 +8,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 import pyqwk.core as qwk
-from pyqwk.core import ProcessingSettings, ParsedMessage, parse_messages, process_file
+from pyqwk.core import ProcessingSettings, ParsedMessage, parse_messages, process_merged_files
 
 @pytest.fixture
 def baseline_path() -> Path:
@@ -60,13 +60,11 @@ def test_parse_messages_headers_only(baseline_path: Path, logger: logging.Logger
     assert message.header.msgto.strip() == "All"
 
 def test_cli_headers_only_text_output(capsys, baseline_path: Path, logger: logging.Logger) -> None:
-    # When headers_only=True, process_file should output the formatted header but NO body.
+    # When headers_only=True, process_merged_files should output the formatted header but NO body.
     # The default text output prepends formatted header to body.
     # If body is empty, we just get formatted header.
 
-    process_file(
-        str(baseline_path),
-        _make_settings(headers_only=True),
+    process_merged_files([str(baseline_path)], _make_settings(headers_only=True),
         logger=logger,
     )
 
@@ -81,9 +79,7 @@ def test_cli_headers_only_text_output(capsys, baseline_path: Path, logger: loggi
 
 def test_cli_headers_only_json_output(tmp_path: Path, baseline_path: Path, logger: logging.Logger) -> None:
     output_path = tmp_path / "metadata.json"
-    process_file(
-        str(baseline_path),
-        _make_settings(headers_only=True, format="json", output_mode="file", output_path=str(output_path)),
+    process_merged_files([str(baseline_path)], _make_settings(headers_only=True, format="json", output_mode="file", output_path=str(output_path)),
         logger=logger,
     )
 
@@ -98,9 +94,7 @@ def test_cli_headers_only_json_output(tmp_path: Path, baseline_path: Path, logge
 
 def test_cli_headers_only_csv_output(tmp_path: Path, baseline_path: Path, logger: logging.Logger) -> None:
     output_path = tmp_path / "metadata.csv"
-    process_file(
-        str(baseline_path),
-        _make_settings(headers_only=True, format="csv", output_mode="file", output_path=str(output_path)),
+    process_merged_files([str(baseline_path)], _make_settings(headers_only=True, format="csv", output_mode="file", output_path=str(output_path)),
         logger=logger,
     )
 
@@ -120,9 +114,7 @@ def test_headers_only_and_noheader_results_in_empty_output(capsys, baseline_path
     # If we ask for headers only (empty body) AND no header (don't print header),
     # we should get almost nothing (just separator)
 
-    process_file(
-        str(baseline_path),
-        _make_settings(headers_only=True, no_header=True),
+    process_merged_files([str(baseline_path)], _make_settings(headers_only=True, no_header=True),
         logger=logger,
     )
 

--- a/tests/test_individual_files_encoding.py
+++ b/tests/test_individual_files_encoding.py
@@ -6,7 +6,7 @@ import sys
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from pyqwk.core import process_file, ProcessingSettings, ParsedMessage, MessageHeader
+from pyqwk.core import process_merged_files, ProcessingSettings, ParsedMessage, MessageHeader
 
 @pytest.fixture
 def logger():
@@ -71,7 +71,7 @@ def test_individual_files_text_format_respects_encoding(tmp_path, logger, monkey
         output_path=str(output_dir)
     )
 
-    process_file("dummy.qwk", settings, logger)
+    process_merged_files(["dummy.qwk"], settings, logger)
 
     files = list(output_dir.iterdir())
     assert len(files) == 1
@@ -118,7 +118,7 @@ def test_individual_files_json_format_forces_utf8(tmp_path, logger, monkeypatch)
         output_path=str(output_dir)
     )
 
-    process_file("dummy.qwk", settings, logger)
+    process_merged_files(["dummy.qwk"], settings, logger)
 
     files = list(output_dir.iterdir())
     assert len(files) == 1

--- a/tests/test_individual_files_formats.py
+++ b/tests/test_individual_files_formats.py
@@ -8,7 +8,7 @@ import logging
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from pyqwk.core import process_file, ProcessingSettings
+from pyqwk.core import process_merged_files, ProcessingSettings
 
 @pytest.fixture
 def baseline_path() -> Path:
@@ -46,10 +46,8 @@ def _make_settings(**overrides) -> ProcessingSettings:
 def test_individual_files_json_format(tmp_path: Path, baseline_path: Path, logger: logging.Logger):
     output_dir = tmp_path / "json_out"
 
-    # Run process_file with individual_files=True and format='json'
-    process_file(
-        str(baseline_path),
-        _make_settings(
+    # Run process_merged_files with individual_files=True and format='json'
+    process_merged_files([str(baseline_path)], _make_settings(
             individual_files=True,
             format="json",
             output_mode="file",
@@ -76,9 +74,7 @@ def test_individual_files_json_format(tmp_path: Path, baseline_path: Path, logge
 def test_individual_files_xml_format(tmp_path: Path, baseline_path: Path, logger: logging.Logger):
     output_dir = tmp_path / "xml_out"
 
-    process_file(
-        str(baseline_path),
-        _make_settings(
+    process_merged_files([str(baseline_path)], _make_settings(
             individual_files=True,
             format="xml",
             output_mode="file",
@@ -104,9 +100,7 @@ def test_individual_files_xml_format(tmp_path: Path, baseline_path: Path, logger
 def test_individual_files_html_format(tmp_path: Path, baseline_path: Path, logger: logging.Logger):
     output_dir = tmp_path / "html_out"
 
-    process_file(
-        str(baseline_path),
-        _make_settings(
+    process_merged_files([str(baseline_path)], _make_settings(
             individual_files=True,
             format="html",
             output_mode="file",
@@ -127,9 +121,7 @@ def test_individual_files_html_format(tmp_path: Path, baseline_path: Path, logge
 def test_individual_files_markdown_format(tmp_path: Path, baseline_path: Path, logger: logging.Logger):
     output_dir = tmp_path / "md_out"
 
-    process_file(
-        str(baseline_path),
-        _make_settings(
+    process_merged_files([str(baseline_path)], _make_settings(
             individual_files=True,
             format="markdown",
             output_mode="file",
@@ -148,9 +140,7 @@ def test_individual_files_markdown_format(tmp_path: Path, baseline_path: Path, l
 def test_individual_files_mbox_format(tmp_path: Path, baseline_path: Path, logger: logging.Logger):
     output_dir = tmp_path / "mbox_out"
 
-    process_file(
-        str(baseline_path),
-        _make_settings(
+    process_merged_files([str(baseline_path)], _make_settings(
             individual_files=True,
             format="mbox",
             output_mode="file",

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -9,7 +9,7 @@ sys.path.insert(0, str(ROOT))
 
 from pyqwk.core import (
     load_data,
-    process_file,
+    process_merged_files,
     ProcessingSettings,
     MESSAGES_FILENAME
 )
@@ -54,7 +54,7 @@ def test_load_data_raises_if_messages_dat_missing_in_zip(
     assert "Neither" in str(exc_info.value)
     assert "found in the zip archive" in str(exc_info.value)
 
-def test_process_file_raises_if_stdout_with_output_path(
+def test_process_merged_files_raises_if_stdout_with_output_path(
     tmp_path: Path, logger: logging.Logger
 ) -> None:
     settings = _make_settings(
@@ -63,11 +63,11 @@ def test_process_file_raises_if_stdout_with_output_path(
     )
 
     with pytest.raises(ValueError) as exc_info:
-        process_file("dummy.qwk", settings, logger)
+        process_merged_files(["dummy.qwk"], settings, logger)
 
     assert "Output path cannot be provided when output mode is stdout" in str(exc_info.value)
 
-def test_process_file_raises_if_file_mode_without_output_path(
+def test_process_merged_files_raises_if_file_mode_without_output_path(
     logger: logging.Logger
 ) -> None:
     settings = _make_settings(
@@ -77,11 +77,11 @@ def test_process_file_raises_if_file_mode_without_output_path(
     )
 
     with pytest.raises(ValueError) as exc_info:
-        process_file("dummy.qwk", settings, logger)
+        process_merged_files(["dummy.qwk"], settings, logger)
 
     assert "output path is required when output mode is file" in str(exc_info.value)
 
-def test_process_file_raises_if_individual_files_without_output_path(
+def test_process_merged_files_raises_if_individual_files_without_output_path(
     logger: logging.Logger
 ) -> None:
     settings = _make_settings(
@@ -90,6 +90,6 @@ def test_process_file_raises_if_individual_files_without_output_path(
     )
 
     with pytest.raises(ValueError) as exc_info:
-        process_file("dummy.qwk", settings, logger)
+        process_merged_files(["dummy.qwk"], settings, logger)
 
     assert "output path is required when using individual files" in str(exc_info.value)

--- a/tests/test_json_import.py
+++ b/tests/test_json_import.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 from pyqwk.core import (
     load_data,
-    process_file,
+    process_merged_files,
     ProcessingSettings,
     ParsedMessage
 )
@@ -49,7 +49,7 @@ def test_json_export_reimport_symmetry(tmp_path, baseline_path, logger):
         output_mode="file",
         output_path=str(json_path)
     )
-    process_file(str(baseline_path), settings_export, logger)
+    process_merged_files([str(baseline_path)], settings_export, logger)
 
     assert json_path.exists()
 
@@ -74,8 +74,8 @@ def test_json_export_reimport_symmetry(tmp_path, baseline_path, logger):
         output_path=str(html_path)
     )
 
-    # We can use process_file on the json path directly now
-    process_file(str(json_path), settings_html, logger)
+    # We can use process_merged_files on the json path directly now
+    process_merged_files([str(json_path)], settings_html, logger)
 
     assert html_path.exists()
     html_content = html_path.read_text(encoding="utf-8")

--- a/tests/test_limit.py
+++ b/tests/test_limit.py
@@ -2,7 +2,7 @@
 import pytest
 import logging
 from dataclasses import replace
-from pyqwk.core import process_file, ProcessingSettings, ParsedMessage, MessageHeader
+from pyqwk.core import process_merged_files, ProcessingSettings, ParsedMessage, MessageHeader
 
 @pytest.fixture
 def mock_logger():
@@ -46,7 +46,7 @@ def test_limit_restricts_output(tmp_path, mock_messages, mock_logger, monkeypatc
         limit=limit
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     # Should contain Message 1, 2, 3 but not 4
@@ -80,7 +80,7 @@ def test_limit_zero(tmp_path, mock_messages, mock_logger, monkeypatch):
         limit=0
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     assert content == ""
@@ -105,7 +105,7 @@ def test_limit_higher_than_total(tmp_path, mock_messages, mock_logger, monkeypat
         limit=20
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     assert "Message 10" in content

--- a/tests/test_metadata_coverage.py
+++ b/tests/test_metadata_coverage.py
@@ -3,8 +3,7 @@ from unittest.mock import patch
 import pytest
 from dataclasses import replace
 
-from pyqwk.core import (
-    process_file,
+from pyqwk.core import (process_merged_files,
     show_info,
     ProcessingSettings,
     BBSInfo,
@@ -72,7 +71,7 @@ def test_index_bbs_name_coverage(tmp_path, logger, default_settings):
 
     with patch('pyqwk.core.load_data') as mock_load:
         mock_load.return_value = (mock_data, board_dict)
-        process_file('mock.qwk', settings, logger)
+        process_merged_files(['mock.qwk'], settings, logger)
 
     index_path = output_dir / "index.html"
     assert index_path.exists()

--- a/tests/test_oneline.py
+++ b/tests/test_oneline.py
@@ -101,7 +101,7 @@ def test_cli_oneline(tmp_path):
     test_qwk = "testdata/test1_qwk.zip"
 
     with patch("sys.argv", ["qwk.py", test_qwk, "--oneline", "--dry-run"]):
-        with patch("pyqwk.cli.process_file") as mock_process:
+        with patch("pyqwk.cli.process_merged_files") as mock_process:
             try:
                 main()
             except SystemExit:

--- a/tests/test_qwk.py
+++ b/tests/test_qwk.py
@@ -22,7 +22,7 @@ from pyqwk.core import (
     _order_messages_by_thread,
     load_data,
     parse_messages,
-    process_file,
+    process_merged_files,
     _write_xml,
     _write_html,
 )
@@ -206,13 +206,11 @@ def test_invalid_messages_dat_reports_clear_error(
 
 
 
-def test_process_file_writes_individual_files(
+def test_process_merged_files_writes_individual_files(
     tmp_path, baseline_path: Path, expected_output_path: Path, logger: logging.Logger
 ) -> None:
     output_dir = tmp_path / "messages"
-    process_file(
-        str(baseline_path),
-        _make_settings(
+    process_merged_files([str(baseline_path)], _make_settings(
             individual_files=True,
             output_mode="file",
             output_path=str(output_dir),
@@ -233,10 +231,8 @@ def test_process_file_writes_individual_files(
 
 
 
-def test_process_file_prints_to_stdout(capsys, baseline_path: Path, expected_output_path: Path, logger: logging.Logger) -> None:
-    process_file(
-        str(baseline_path),
-        _make_settings(quiet=True),
+def test_process_merged_files_prints_to_stdout(capsys, baseline_path: Path, expected_output_path: Path, logger: logging.Logger) -> None:
+    process_merged_files([str(baseline_path)], _make_settings(quiet=True),
         logger=logger,
     )
 
@@ -485,13 +481,11 @@ def test_parse_messages_from_qwk_packet(testdata_dir: Path, logger: logging.Logg
     assert all("Conference:" not in message.text for message in messages)
 
 
-def test_process_file_writes_json(
+def test_process_merged_files_writes_json(
     tmp_path, baseline_path: Path, expected_output_path: Path, logger: logging.Logger
 ) -> None:
     output_path = tmp_path / "messages.json"
-    process_file(
-        str(baseline_path),
-        _make_settings(format="json", output_mode="file", output_path=str(output_path)),
+    process_merged_files([str(baseline_path)], _make_settings(format="json", output_mode="file", output_path=str(output_path)),
         logger=logger,
     )
 
@@ -512,7 +506,7 @@ def test_process_file_writes_json(
     assert message["header"]["msgnum"] == 28
 
 
-def test_process_file_preserves_thread_order_in_json(
+def test_process_merged_files_preserves_thread_order_in_json(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, logger: logging.Logger
 ) -> None:
     header = MessageHeader(
@@ -560,9 +554,7 @@ def test_process_file_preserves_thread_order_in_json(
 
     output_path = tmp_path / "threaded.json"
 
-    process_file(
-        "ignored.dat",
-        _make_settings(
+    process_merged_files(["ignored.dat"], _make_settings(
             threaded=True,
             format="json",
             no_header=True,
@@ -578,13 +570,11 @@ def test_process_file_preserves_thread_order_in_json(
     assert [message["text"] for message in data] == ["parent\r\n", "child\r\n"]
 
 
-def test_process_file_writes_xml(
+def test_process_merged_files_writes_xml(
     tmp_path, baseline_path: Path, expected_output_path: Path, logger: logging.Logger
 ) -> None:
     output_path = tmp_path / "messages.xml"
-    process_file(
-        str(baseline_path),
-        _make_settings(format="xml", output_mode="file", output_path=str(output_path)),
+    process_merged_files([str(baseline_path)], _make_settings(format="xml", output_mode="file", output_path=str(output_path)),
         logger=logger,
     )
 
@@ -604,13 +594,11 @@ def test_process_file_writes_xml(
     assert ("-" * 80) not in content
 
 
-def test_process_file_writes_html(
+def test_process_merged_files_writes_html(
     tmp_path, baseline_path: Path, expected_output_path: Path, logger: logging.Logger
 ) -> None:
     output_path = tmp_path / "messages.html"
-    process_file(
-        str(baseline_path),
-        _make_settings(format="html", output_mode="file", output_path=str(output_path)),
+    process_merged_files([str(baseline_path)], _make_settings(format="html", output_mode="file", output_path=str(output_path)),
         logger=logger,
     )
 
@@ -634,7 +622,7 @@ def test_process_file_writes_html(
     assert "-" * 80 not in content
 
 
-def test_process_file_writes_xml_with_special_characters(
+def test_process_merged_files_writes_xml_with_special_characters(
     tmp_path, logger: logging.Logger
 ) -> None:
     from pyqwk.core import _write_xml
@@ -899,12 +887,10 @@ def test_cli_batch_success(
     assert files[0].name == "test1_qwk.txt"
     assert files[1].name == "test2_qwk.txt"
 
-def test_process_file_noheader_combined_has_separator(
+def test_process_merged_files_noheader_combined_has_separator(
     capsys: pytest.CaptureFixture[str], baseline_path: Path, logger: logging.Logger
 ) -> None:
-    process_file(
-        str(baseline_path),
-        _make_settings(no_header=True),
+    process_merged_files([str(baseline_path)], _make_settings(no_header=True),
         logger=logger,
     )
 
@@ -915,12 +901,10 @@ def test_process_file_noheader_combined_has_separator(
     assert "Subject:" not in captured.out
 
 
-def test_process_file_separator_blank(
+def test_process_merged_files_separator_blank(
     capsys: pytest.CaptureFixture[str], baseline_path: Path, logger: logging.Logger
 ) -> None:
-    process_file(
-        str(baseline_path),
-        _make_settings(separator="blank"),
+    process_merged_files([str(baseline_path)], _make_settings(separator="blank"),
         logger=logger,
     )
 
@@ -963,9 +947,7 @@ def test_json_noheader_removes_header_text(
     tmp_path: Path, baseline_path: Path, logger: logging.Logger
 ) -> None:
     output_path = tmp_path / "messages.json"
-    process_file(
-        str(baseline_path),
-        _make_settings(format="json", no_header=True, output_mode="file", output_path=str(output_path)),
+    process_merged_files([str(baseline_path)], _make_settings(format="json", no_header=True, output_mode="file", output_path=str(output_path)),
         logger=logger,
     )
 
@@ -981,9 +963,7 @@ def test_xml_noheader_removes_header_text(
     tmp_path: Path, baseline_path: Path, logger: logging.Logger
 ) -> None:
     output_path = tmp_path / "messages.xml"
-    process_file(
-        str(baseline_path),
-        _make_settings(format="xml", no_header=True, output_mode="file", output_path=str(output_path)),
+    process_merged_files([str(baseline_path)], _make_settings(format="xml", no_header=True, output_mode="file", output_path=str(output_path)),
         logger=logger,
     )
 
@@ -1033,7 +1013,7 @@ def test_text_output_respects_encoding(tmp_path: Path, monkeypatch: pytest.Monke
         output_path=str(output_path), encoding="cp437"
     )
 
-    process_file("dummy.qwk", settings, logger)
+    process_merged_files(["dummy.qwk"], settings, logger)
 
     with open(output_path, "rb") as f:
         content = f.read()
@@ -1046,12 +1026,12 @@ def test_text_output_respects_encoding(tmp_path: Path, monkeypatch: pytest.Monke
 def test_process_multiple_files_handles_controldat_error(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, logger: logging.Logger
 ) -> None:
-    def mock_process_file(input_path: str, settings: ProcessingSettings, logger: logging.Logger) -> None:
+    def mock_process_merged_files(input_paths: str, settings: ProcessingSettings, logger: logging.Logger) -> None:
         if "bad" in input_path:
             raise ControlDatFormatError("Bad control.dat")
 
     import pyqwk.cli as cli
-    monkeypatch.setattr(cli, "process_file", mock_process_file)
+    monkeypatch.setattr(cli, "process_merged_files", mock_process_merged_files)
 
     input_paths = ["bad.zip", "good.zip"]
     output_dir = tmp_path / "output"
@@ -1073,11 +1053,11 @@ def test_clean_flag_activates_cleaning_options(
 
     captured_settings = []
 
-    def mock_process_file(input_path: str, settings: ProcessingSettings, logger: logging.Logger) -> None:
+    def mock_process_merged_files(input_paths: str, settings: ProcessingSettings, logger: logging.Logger) -> None:
         captured_settings.append(settings)
 
     import pyqwk.cli as cli
-    monkeypatch.setattr(cli, "process_file", mock_process_file)
+    monkeypatch.setattr(cli, "process_merged_files", mock_process_merged_files)
 
     main()
 

--- a/tests/test_rep_support.py
+++ b/tests/test_rep_support.py
@@ -1,7 +1,7 @@
 import struct
 import zipfile
 import logging
-from pyqwk.core import load_data, parse_messages, ProcessingSettings, process_file, show_info
+from pyqwk.core import load_data, parse_messages, ProcessingSettings, process_merged_files, show_info
 
 def create_rep_packet(path, bbs_id=b"TESTBBS", msg_count=1):
     # Header record
@@ -76,7 +76,7 @@ def test_process_rep_file(tmp_path, capsys):
     )
 
     logger = logging.getLogger("pyqwk.test")
-    process_file(str(rep_path), settings, logger)
+    process_merged_files([str(rep_path)], settings, logger)
 
     captured = capsys.readouterr()
     assert "This is message 1." in captured.out

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -2,7 +2,7 @@
 import pytest
 import logging
 from dataclasses import replace
-from pyqwk.core import process_file, ProcessingSettings, ParsedMessage, MessageHeader
+from pyqwk.core import process_merged_files, ProcessingSettings, ParsedMessage, MessageHeader
 
 @pytest.fixture
 def mock_logger():
@@ -57,7 +57,7 @@ def test_search_in_author(tmp_path, mock_messages, mock_logger, monkeypatch):
         search_term="alice"
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     assert "The quick brown fox" in content
@@ -83,7 +83,7 @@ def test_search_in_subject(tmp_path, mock_messages, mock_logger, monkeypatch):
         search_term="tech"
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     assert "Python is a programming language" in content
@@ -109,7 +109,7 @@ def test_search_in_body(tmp_path, mock_messages, mock_logger, monkeypatch):
         search_term="bbs"
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     assert "BBS systems are cool" in content
@@ -139,7 +139,7 @@ def test_search_combined_with_filters(tmp_path, mock_messages, mock_logger, monk
         conferences=["2"]
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     assert "Python is a programming language" in content
@@ -165,7 +165,7 @@ def test_search_no_match(tmp_path, mock_messages, mock_logger, monkeypatch):
         search_term="nonexistent"
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     assert content == ""

--- a/tests/test_skip.py
+++ b/tests/test_skip.py
@@ -2,7 +2,7 @@
 import pytest
 import logging
 from dataclasses import replace
-from pyqwk.core import process_file, ProcessingSettings, ParsedMessage, MessageHeader
+from pyqwk.core import process_merged_files, ProcessingSettings, ParsedMessage, MessageHeader
 
 @pytest.fixture
 def mock_logger():
@@ -46,7 +46,7 @@ def test_skip_ignores_first_n_messages(tmp_path, mock_messages, mock_logger, mon
         skip=skip
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     # Should NOT contain Message 1 to 5
@@ -79,7 +79,7 @@ def test_skip_and_limit_together(tmp_path, mock_messages, mock_logger, monkeypat
         limit=limit
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     # Should skip 1, 2. Process 3, 4, 5. Stop before 6.
@@ -110,7 +110,7 @@ def test_skip_exceeds_total(tmp_path, mock_messages, mock_logger, monkeypatch):
         skip=20
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     assert content == ""
@@ -146,7 +146,7 @@ def test_skip_with_unique(tmp_path, mock_messages, mock_logger, monkeypatch):
         limit=2
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     assert "Msg:01" not in content

--- a/tests/test_sqlite_import.py
+++ b/tests/test_sqlite_import.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 from pyqwk.core import (
     load_data,
-    process_file,
+    process_merged_files,
     ProcessingSettings,
     ParsedMessage
 )
@@ -49,7 +49,7 @@ def test_sqlite_export_reimport_symmetry(tmp_path, baseline_path, logger):
         output_mode="file",
         output_path=str(db_path)
     )
-    process_file(str(baseline_path), settings_export, logger)
+    process_merged_files([str(baseline_path)], settings_export, logger)
 
     assert db_path.exists()
 
@@ -82,8 +82,8 @@ def test_sqlite_export_reimport_symmetry(tmp_path, baseline_path, logger):
         output_path=str(html_path)
     )
 
-    # We can use process_file on the db path directly now
-    process_file(str(db_path), settings_html, logger)
+    # We can use process_merged_files on the db path directly now
+    process_merged_files([str(db_path)], settings_html, logger)
 
     assert html_path.exists()
     html_content = html_path.read_text(encoding="utf-8")

--- a/tests/test_sqlite_metadata.py
+++ b/tests/test_sqlite_metadata.py
@@ -66,7 +66,7 @@ def test_sqlite_metadata_preservation(tmp_path, baseline_path, logger):
 
     # We need to manually call load_data then write_messages to use our custom metadata
     # Or mock the environment. Easier: use the existing baseline but ensure its metadata is set.
-    # Actually, process_file will call load_data which finds messages.dat and (optionally) control.dat.
+    # Actually, process_merged_files will call load_data which finds messages.dat and (optionally) control.dat.
     # To test OUR metadata, let's write a small helper that uses write_messages directly.
 
     from pyqwk.core import parse_messages, write_messages

--- a/tests/test_to_filtering.py
+++ b/tests/test_to_filtering.py
@@ -2,7 +2,7 @@
 import pytest
 import logging
 from dataclasses import replace
-from pyqwk.core import process_file, ProcessingSettings, ParsedMessage, MessageHeader
+from pyqwk.core import process_merged_files, ProcessingSettings, ParsedMessage, MessageHeader
 
 @pytest.fixture
 def mock_logger():
@@ -51,7 +51,7 @@ def test_filtering_by_recipient_single(tmp_path, mock_messages, mock_logger, mon
         recipients=["Bob"]
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     assert "Hello Bob" in content
@@ -72,7 +72,7 @@ def test_filtering_by_recipient_multiple(tmp_path, mock_messages, mock_logger, m
         recipients=["Bob", "Dave"]
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     assert "Hello Bob" in content
@@ -93,7 +93,7 @@ def test_filtering_by_recipient_case_insensitive(tmp_path, mock_messages, mock_l
         recipients=["alice"] # lowercase
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     assert "Hello Alice" in content
@@ -114,7 +114,7 @@ def test_search_includes_recipient(tmp_path, mock_messages, mock_logger, monkeyp
         search_term="Dave"
     )
 
-    process_file("dummy.qwk", settings, mock_logger)
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
 
     content = output_path.read_text(encoding="latin1")
     assert "Secret message" in content

--- a/tests/test_xml_import.py
+++ b/tests/test_xml_import.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 from pyqwk.core import (
     load_data,
-    process_file,
+    process_merged_files,
     ProcessingSettings,
     ParsedMessage
 )
@@ -49,7 +49,7 @@ def test_xml_export_reimport_symmetry(tmp_path, baseline_path, logger):
         output_mode="file",
         output_path=str(xml_path)
     )
-    process_file(str(baseline_path), settings_export, logger)
+    process_merged_files([str(baseline_path)], settings_export, logger)
 
     assert xml_path.exists()
 
@@ -74,8 +74,8 @@ def test_xml_export_reimport_symmetry(tmp_path, baseline_path, logger):
         output_path=str(html_path)
     )
 
-    # We can use process_file on the xml path directly now
-    process_file(str(xml_path), settings_html, logger)
+    # We can use process_merged_files on the xml path directly now
+    process_merged_files([str(xml_path)], settings_html, logger)
 
     assert html_path.exists()
     html_content = html_path.read_text(encoding="utf-8")


### PR DESCRIPTION
* **What:** Removed the redundant `process_file` wrapper function from `pyqwk/core.py`. Updated `pyqwk/cli.py` and all relevant test files to use `process_merged_files` directly.
* **Why:** To improve code quality by eliminating a redundant abstraction. The external behavior remains identical, but the internal API is now cleaner and more consistent.
* **Safety:** All 756 tests passed, confirming that the change is non-breaking and that all call sites (including mocks in tests) were correctly updated.

---
*PR created automatically by Jules for task [9249206287295953439](https://jules.google.com/task/9249206287295953439) started by @RainRat*