### PR TITLE
Fix conference name reconstruction logic

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -1024,8 +1024,11 @@ def _reconstruct_archive_information(messages: list[ParsedMessage]) -> Conferenc
     bbs_info = BBSInfo()
     for msg in messages:
         if msg.confnum is not None:
-            if msg.confnum not in board_dict or (not board_dict[msg.confnum] and msg.confname):
-                board_dict[msg.confnum] = msg.confname or f"Conference {msg.confnum}"
+            default_name = f"Conference {msg.confnum}"
+            if msg.confnum not in board_dict:
+                board_dict[msg.confnum] = msg.confname or default_name
+            elif msg.confname and board_dict[msg.confnum] == default_name:
+                board_dict[msg.confnum] = msg.confname
         if msg.bbs_name:
             bbs_info.name = msg.bbs_name
         if msg.bbs_id:


### PR DESCRIPTION
* **What:** Updated `_reconstruct_archive_information` in `pyqwk/core.py` to allow replacing generic placeholder conference names (e.g., "Conference 1") with descriptive names if they are encountered in subsequent messages within the same archive.
* **Why:** This ensures that archives without a central `CONTROL.DAT` but with per-message conference information (like some JSON or CSV exports) correctly display human-readable conference names instead of generic numbered ones. This is a non-breaking change that improves metadata accuracy.

---
*PR created automatically by Jules for task [2920084748642804930](https://jules.google.com/task/2920084748642804930) started by @RainRat*