### PR TITLE
[DOCS] Simplify and clarify CLI encoding help text

### DIFF
--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -140,7 +140,7 @@ examples:
     io_group.add_argument(
         '-E',
         '--encoding',
-        help="Set the character set of the input files. Default is 'cp437' (standard for DOS-based BBSs). Use this if messages show strange characters.",
+        help="Set the text encoding of the input files. Default is 'cp437' (standard for older BBSs). Use this if messages show incorrect characters.",
         default='cp437',
     )
 


### PR DESCRIPTION
**Type:** Internal Help
**What:** Updated the help string for the `--encoding` argument in `pyqwk/cli.py`.
**Why:** Replaced technical jargon ("character set", "DOS-based") with simpler terms ("text encoding", "older") and aligned the troubleshooting terminology ("incorrect characters") with the README.md to make the tool more accessible to a global audience.

---
*PR created automatically by Jules for task [12302757571984964494](https://jules.google.com/task/12302757571984964494) started by @RainRat*