### PR TITLE
Fix attachment discovery for CSV and SQLite imports

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -869,7 +869,7 @@ def _parse_sqlite_messages(db_path: str) -> tuple[list[ParsedMessage], Conferenc
 
             header = MessageHeader.from_dict(header_dict)
 
-            attachments = row['attachments'].split(';') if row['attachments'] else []
+            attachments = row['attachments'].split(';') if row['attachments'] else None
 
             msg = ParsedMessage(
                 text=row['text'],
@@ -997,7 +997,7 @@ def _parse_csv_messages(data: Iterator[dict[str, Any]]) -> list[ParsedMessage]:
     for row in data:
         header = MessageHeader.from_dict(row)
 
-        attachments = row.get('attachments', "").split(';') if row.get('attachments') else []
+        attachments = row.get('attachments', "").split(';') if row.get('attachments') else None
 
         msg = ParsedMessage(
             text=row.get('text', ""),


### PR DESCRIPTION
* **What:** Updated `_parse_sqlite_messages` and `_parse_csv_messages` in `pyqwk/core.py` to initialize the `attachments` attribute to `None` (instead of `[]`) when the source field is missing or empty.
* **Why:** The codebase uses `None` as a sentinel value for the `attachments` field of `ParsedMessage` to indicate that the message text has not yet been scanned for embedded binaries (like UUE or yEnc). The `matches_filters` function relies on this sentinel to trigger lazy discovery. Initializing to `[]` was preventing discovery for CSV and SQLite imports, causing searches for filenames within embedded attachments to fail. No breaking changes were introduced as all downstream usages of `attachments` already handle `None` values (e.g., via `or []` or existence checks).

---
*PR created automatically by Jules for task [15204302277677192432](https://jules.google.com/task/15204302277677192432) started by @RainRat*