### PR TITLE
[DOCS] Update Graphical Reader keyboard shortcuts and examples in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ qwk-gui
 
 # Or open a specific file immediately
 qwk-gui archive.qwk
+qwk-gui archive.rep
 qwk-gui archive.jsonl
 qwk-gui archive.csv
 qwk-gui archive.xml
@@ -91,7 +92,7 @@ qwk-gui archive.eml
 ```
 
 **Key Features:**
-- **Search:** Quickly find messages by keyword. Use the **Regex** checkbox to search with advanced patterns (regular expressions). Results are highlighted in the text. You can cycle through matches using **F3** (Next) and **Shift + F3** (Previous). You can also highlight any text in a message, right-click, and select **Search for '[Selected Text]'** to instantly find related messages.
+- **Search:** Quickly find messages by keyword. Use the **Regex** checkbox to search with advanced patterns (regular expressions). Results are highlighted in the text. You can cycle through matches using **F3** or **Enter** (Next) and **Shift + F3** or **Shift + Enter** (Previous). You can also highlight any text in a message, right-click, and select **Search for '[Selected Text]'** to instantly find related messages.
 - **Attachments:** Messages containing attachments (UUE, Base64, yEnc) display clickable links in the header. Click any attachment name to save it to your computer. You can also use **File > Extract All Attachments...** to batch-save all attachments from the current filtered view to a folder.
 - **Filtering:** View messages from specific BBSes or conferences, include private messages, filter by the presence of attachments, or only show messages from/to yourself.
 - **Context Menus:** Right-click on any message in the list to copy its information (Subject, From, To) or instantly filter the entire view by that author, conference, or BBS. You can also right-click in the message text to copy selected sections.
@@ -113,7 +114,8 @@ qwk-gui archive.eml
 - **j** or **n**: Move to the next message in the list.
 - **k** or **p**: Move to the previous message in the list.
 - **Esc**: Clear the search filter and return focus to the message list. This works from anywhere in the application.
-- **Enter**: Execute the search immediately and move focus to the message list.
+- **Enter**: Move to the next search match (or execute the search and move focus to the list if a search was just typed).
+- **Shift + Enter**: Move to the previous search match in the current message.
 
 ## Usage Examples
 


### PR DESCRIPTION
This PR updates the `README.md` to accurately reflect the Graphical Reader's capabilities and keyboard shortcuts.

### Changes:
- Added `archive.rep` to the list of example files that can be opened directly with `qwk-gui`.
- Updated the **Search** feature description to include **Enter** and **Shift + Enter** as match navigation keys.
- Revised the **Keyboard Shortcuts** list to clarify that **Enter** navigates search matches and added **Shift + Enter** for backward navigation.

These changes ensure that the documentation stays "Truth First" and helps users discover efficient ways to navigate their message archives.

---
*PR created automatically by Jules for task [5612730833002317505](https://jules.google.com/task/5612730833002317505) started by @RainRat*