### PR TITLE
[TEST] Fix message deduplication isolation across multiple BBSes

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -2374,13 +2374,16 @@ def process_merged_files(
 
                 if settings.unique:
                     msg_id: tuple[str, int, int | str]
+                    # Use the message's own BBS information for the ID to ensure
+                    # correct deduplication across mixed sources (e.g. JSONL)
+                    current_bbs_key = f"{parsed_message.bbs_name}|{parsed_message.bbs_id}" if parsed_message.bbs_name or parsed_message.bbs_id else bbs_key
                     if parsed_message.msgnum is not None:
-                        msg_id = (bbs_key, parsed_message.confnum, parsed_message.msgnum)
+                        msg_id = (current_bbs_key, parsed_message.confnum, parsed_message.msgnum)
                     else:
                         content_hash = hashlib.sha1(
                             parsed_message.text.encode(settings.encoding, errors='replace')
                         ).hexdigest()
-                        msg_id = (bbs_key, parsed_message.confnum, content_hash)
+                        msg_id = (current_bbs_key, parsed_message.confnum, content_hash)
 
                     if msg_id in seen_ids:
                         continue

--- a/tests/test_unique_bbs_isolation.py
+++ b/tests/test_unique_bbs_isolation.py
@@ -1,0 +1,82 @@
+import logging
+import hashlib
+from unittest.mock import MagicMock, patch
+from pyqwk.core import process_merged_files, ProcessingSettings, ParsedMessage, MessageHeader
+
+def test_unique_bbs_isolation(tmp_path):
+    """Verify that messages with same msgnum but different BBS are not deduplicated."""
+    output_path = tmp_path / "output.txt"
+    settings = ProcessingSettings(
+        verbose=False, private=True, no_header=True, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False, merge=True,
+        binaries_removal=False, redact_pii=False, format='text', separator='none',
+        output_mode='file', output_path=str(output_path), encoding='cp437',
+        unique=True, strip_ansi=False, quiet=True, headers_only=False
+    )
+
+    # Message 1 from BBS A
+    h1 = MessageHeader(
+        status=' ', msgnum=1, msgdate='01-01-23', msgtime='12:00',
+        msgto='All', msgfrom='User1', msgsubject='Subj1', msgpassword='',
+        refnum=None, numblocks=1, msgflag='', confnum=100, lognum=1, nettag=''
+    )
+    msg1 = ParsedMessage(text="Message from BBS A", msgnum=1, refnum=None, confnum=100, header=h1, bbs_name="BBS A", bbs_id="A")
+
+    # Message 2 from BBS B with SAME msgnum and confnum
+    h2 = MessageHeader(
+        status=' ', msgnum=1, msgdate='01-01-23', msgtime='12:00',
+        msgto='All', msgfrom='User1', msgsubject='Subj1', msgpassword='',
+        refnum=None, numblocks=1, msgflag='', confnum=100, lognum=1, nettag=''
+    )
+    msg2 = ParsedMessage(text="Message from BBS B", msgnum=1, refnum=None, confnum=100, header=h2, bbs_name="BBS B", bbs_id="B")
+
+    mock_logger = MagicMock()
+
+    with patch('pyqwk.core.load_data') as mock_load:
+        # Returning both messages in a single "file" stream
+        mock_load.return_value = ([msg1, msg2], {})
+
+        process_merged_files(['combined.jsonl'], settings, mock_logger)
+
+    content = output_path.read_text()
+    # Both messages should be present
+    assert "Message from BBS A" in content
+    assert "Message from BBS B" in content
+    assert content.count("\n") == 2
+
+def test_unique_content_hash_bbs_isolation(tmp_path):
+    """Verify that messages with same content but different BBS are not deduplicated."""
+    output_path = tmp_path / "output.txt"
+    settings = ProcessingSettings(
+        verbose=False, private=True, no_header=True, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False, merge=True,
+        binaries_removal=False, redact_pii=False, format='text', separator='none',
+        output_mode='file', output_path=str(output_path), encoding='cp437',
+        unique=True, strip_ansi=False, quiet=True, headers_only=False
+    )
+
+    # Message 1 from BBS A (No msgnum, triggers content hashing)
+    h1 = MessageHeader(
+        status=' ', msgnum=None, msgdate='01-01-23', msgtime='12:00',
+        msgto='All', msgfrom='User1', msgsubject='Subj1', msgpassword='',
+        refnum=None, numblocks=1, msgflag='', confnum=100, lognum=1, nettag=''
+    )
+    msg1 = ParsedMessage(text="Same Content", msgnum=None, refnum=None, confnum=100, header=h1, bbs_name="BBS A", bbs_id="A")
+
+    # Message 2 from BBS B with SAME content
+    h2 = MessageHeader(
+        status=' ', msgnum=None, msgdate='01-01-23', msgtime='12:00',
+        msgto='All', msgfrom='User1', msgsubject='Subj1', msgpassword='',
+        refnum=None, numblocks=1, msgflag='', confnum=100, lognum=1, nettag=''
+    )
+    msg2 = ParsedMessage(text="Same Content", msgnum=None, refnum=None, confnum=100, header=h2, bbs_name="BBS B", bbs_id="B")
+
+    mock_logger = MagicMock()
+
+    with patch('pyqwk.core.load_data') as mock_load:
+        mock_load.return_value = ([msg1, msg2], {})
+        process_merged_files(['combined.jsonl'], settings, mock_logger)
+
+    content = output_path.read_text()
+    # Should contain "Same Content" twice
+    assert content.count("Same Content") == 2


### PR DESCRIPTION
### [TEST] Fix message deduplication isolation across multiple BBSes

**Type:** Bug Fix / New Coverage

**What:**
- Fixed a logic error in `pyqwk/core.py` where the `--unique` filter incorrectly deduplicated messages from different BBSes if they shared the same message number and were processed from the same input stream (e.g., a merged JSONL file).
- Added `tests/test_unique_bbs_isolation.py` to provide 100% coverage for this edge case, verifying isolation for both `msgnum` and content-hash-based deduplication.

**Why:**
- Modern formats like JSONL can store messages from multiple BBSes in a single file. The previous implementation relied on a single `bbs_key` per file, leading to data loss when different BBSes used the same message numbering scheme.
- This ensures that "Unique" means unique *within the context of a specific BBS and conference*, rather than just unique across the entire processing run without regard for the source system.

---
*PR created automatically by Jules for task [6662522853397105190](https://jules.google.com/task/6662522853397105190) started by @RainRat*