### PR TITLE
[DOCS] Clarify Archive Statistics interactivity in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ qwk-gui archive.eml
 - **Viewing Options:** Toggle the **Clean** view to hide signatures, quoted replies, and attachments. Use **Remove Colors** to strip ANSI color codes from the text.
 - **Threading:** Group replies together to follow the flow of a conversation.
 - **Sorting:** Click on column headers (like "Num" or "Date") to sort the message list.
-- **Statistics:** View detailed activity reports, top authors, and charts showing activity over time for the current archive and filters.
+- **Statistics:** View detailed activity reports, top authors, and charts showing activity over time for the current archive and filters. You can click on chart labels for Authors, BBSes, or Conferences to instantly filter the message list to that selection.
 
 **Keyboard Shortcuts:**
 - **Ctrl + O**: Open any supported message archive.


### PR DESCRIPTION
* **Type:** Documentation
* **What:** README.md (Graphical Reader section)
* **Why:** Clarified that chart labels in the Archive Statistics window are interactive and can be used to filter messages. This helps users discover and use the advanced filtering capabilities of the GUI.

---
*PR created automatically by Jules for task [1662015128723497928](https://jules.google.com/task/1662015128723497928) started by @RainRat*