### PR TITLE
[UI/UX] Implement interactive empty state for Graphical Reader

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -285,6 +285,62 @@ class QwkGuiApp:
             self.detail_text.insert(tk.END, f"{key:<12}", "header_label")
             self.detail_text.insert(tk.END, f"{desc}\n", "body")
 
+    def _render_empty_state(self) -> None:
+        """Render an interactive empty state when no messages match the filters."""
+        self.detail_text.delete("1.0", tk.END)
+        self.search_count_label.config(text="")
+
+        self.detail_text.insert(tk.END, "No Messages Found\n", "header_subject")
+        self.detail_text.insert(tk.END, " \n", "header_hr")
+        self.detail_text.insert(tk.END, "\n")
+
+        self.detail_text.insert(tk.END, "Your current filters returned no results. Check the settings below:\n\n", "body")
+
+        # List active filters
+        search_val = self.search_var.get().strip()
+        if search_val:
+            label = "Regex Search" if self.regex_var.get() else "Search"
+            self.detail_text.insert(tk.END, f"  {label:<15}: ", "header_label")
+            self.detail_text.insert(tk.END, f"'{search_val}'\n", "body")
+
+        bbs_val = self.bbs_combo.get()
+        if bbs_val and not bbs_val.startswith("All BBSes"):
+            self.detail_text.insert(tk.END, f"  {'BBS':<15}: ", "header_label")
+            self.detail_text.insert(tk.END, f"{bbs_val}\n", "body")
+
+        conf_val = self.conf_combo.get()
+        if conf_val and not conf_val.startswith("All Conferences"):
+            self.detail_text.insert(tk.END, f"  {'Conference':<15}: ", "header_label")
+            self.detail_text.insert(tk.END, f"{conf_val}\n", "body")
+
+        active_bools = []
+        for text, var in [
+            ("Attachments", self.has_attach_var),
+            ("My Messages", self.mine_var),
+            ("On This Day", self.on_this_day_var),
+            ("Links", self.has_links_var),
+            ("Emails", self.has_emails_var),
+            ("Phones", self.has_phones_var),
+            ("ANSI", self.has_ansi_var),
+        ]:
+            if var.get():
+                active_bools.append(text)
+
+        if active_bools:
+            self.detail_text.insert(tk.END, f"  {'Filters':<15}: ", "header_label")
+            self.detail_text.insert(tk.END, f"{', '.join(active_bools)}\n", "body")
+
+        self.detail_text.insert(tk.END, "\n")
+
+        # Action links
+        self.detail_text.insert(tk.END, "Reset all filters and search", ("link", "body", "reset_all"))
+        self.detail_text.tag_bind("reset_all", "<Button-1>", self.clear_filters)
+
+        self.detail_text.insert(tk.END, "\n\n", "body")
+        self.detail_text.insert(tk.END, "Tip: Press ", "body")
+        self.detail_text.insert(tk.END, "Esc", "header_label")
+        self.detail_text.insert(tk.END, " to progressively clear search and filters.", "body")
+
     def _build_menu(self) -> None:
         menubar = tk.Menu(self.root)
         file_menu = tk.Menu(menubar, tearoff=0)
@@ -1373,8 +1429,7 @@ class QwkGuiApp:
                 self.message_list.focus(item_to_select)
                 self.message_list.see(item_to_select)
             else:
-                self.search_count_label.config(text="")
-                self._set_detail_text("No messages found.")
+                self._render_empty_state()
         except Exception as exc:
             # Restore previous state on failure
             self.messages = old_messages

--- a/tests/test_gui_ux_empty_state.py
+++ b/tests/test_gui_ux_empty_state.py
@@ -1,0 +1,112 @@
+import sys
+from unittest.mock import MagicMock, patch
+import pytest
+
+# Mock tkinter before any pyqwk.gui imports
+class MockTclError(Exception):
+    pass
+
+if "tkinter" in sys.modules:
+    existing_tk = sys.modules["tkinter"]
+    existing_tk.TclError = MockTclError
+else:
+    mock_tk = MagicMock()
+    mock_tk.TclError = MockTclError
+    sys.modules["tkinter"] = mock_tk
+
+if "tkinter.ttk" not in sys.modules:
+    sys.modules["tkinter.ttk"] = MagicMock()
+if "tkinter.filedialog" not in sys.modules:
+    sys.modules["tkinter.filedialog"] = MagicMock()
+if "tkinter.messagebox" not in sys.modules:
+    sys.modules["tkinter.messagebox"] = MagicMock()
+if "tkinter.simpledialog" not in sys.modules:
+    sys.modules["tkinter.simpledialog"] = MagicMock()
+
+from pyqwk.gui import QwkGuiApp
+
+@pytest.fixture
+def app():
+    root = MagicMock()
+    root.after = MagicMock()
+
+    with patch("tkinter.BooleanVar", return_value=MagicMock()), \
+         patch("tkinter.StringVar", return_value=MagicMock()), \
+         patch("tkinter.ttk.Treeview", return_value=MagicMock()) as mock_tree, \
+         patch("tkinter.Text", return_value=MagicMock()) as mock_text, \
+         patch("tkinter.ttk.Combobox") as mock_combo, \
+         patch("tkinter.ttk.Label") as mock_label:
+
+        a = QwkGuiApp(root)
+        a.message_list = mock_tree.return_value
+        a.detail_text = mock_text.return_value
+        a.bbs_combo = MagicMock()
+        a.conf_combo = MagicMock()
+        a.search_count_label = mock_label.return_value
+
+        # Reset common mocks
+        a.detail_text.insert.reset_mock()
+        a.detail_text.delete.reset_mock()
+        a.search_count_label.config.reset_mock()
+
+        return a
+
+def test_render_empty_state_listing_filters(app):
+    # Set up some active filters
+    app.search_var.get.return_value = "vintage"
+    app.regex_var.get.return_value = True
+    app.bbs_combo.get.return_value = "The Cave BBS"
+    app.conf_combo.get.return_value = "General"
+    app.mine_var.get.return_value = True
+    app.has_attach_var.get.return_value = True
+
+    app._render_empty_state()
+
+    # Verify basic structure
+    inserted_texts = [call.args[1] for call in app.detail_text.insert.call_args_list if len(call.args) > 1]
+
+    assert any("No Messages Found" in text for text in inserted_texts)
+    assert any("Your current filters returned no results" in text for text in inserted_texts)
+
+    # Verify specific filter reporting
+    assert any("'vintage'" in text for text in inserted_texts)
+    assert any("Regex Search" in text for text in inserted_texts)
+    assert any("The Cave BBS" in text for text in inserted_texts)
+    assert any("General" in text for text in inserted_texts)
+    assert any("My Messages, Attachments" in text or ("My Messages" in text and "Attachments" in text) for text in inserted_texts)
+
+    # Verify reset link and tip
+    assert any("Reset all filters and search" in text for text in inserted_texts)
+    assert any("Esc" in text for text in inserted_texts)
+
+    # Verify match counter was cleared
+    app.search_count_label.config.assert_called_with(text="")
+
+def test_empty_state_reset_link_binding(app):
+    # Dictionary to store tag callbacks
+    tag_callbacks = {}
+    def mock_tag_bind(tag, event, callback):
+        tag_callbacks[tag] = callback
+    app.detail_text.tag_bind.side_effect = mock_tag_bind
+
+    with patch.object(app, "clear_filters") as mock_clear:
+        app._render_empty_state()
+
+        # Find the reset tag
+        assert "reset_all" in tag_callbacks
+
+        # Simulate click
+        tag_callbacks["reset_all"](None)
+        mock_clear.assert_called_once()
+
+def test_load_messages_triggers_empty_state(app):
+    # Mock load_data to return empty results
+    from pyqwk.core import ConferenceMap
+    empty_board = ConferenceMap()
+
+    with patch("pyqwk.gui.load_data", return_value=([], empty_board)), \
+         patch.object(app, "_render_empty_state") as mock_render_empty:
+
+        app.load_messages(["empty.qwk"])
+
+        mock_render_empty.assert_called_once()


### PR DESCRIPTION
### Context: GUI (Graphical Reader)

### Problem: 
When a user applies filters (Search, BBS, Conference, or discovery tags) that result in an empty message list, the interface provides very little feedback ("No messages found.") and no clear path to recovery. The user must manually scan the toolbar to figure out which filter is too restrictive and then click the "Reset All" button or individual controls to fix it. This is a high-friction workflow that lacks clarity.

### Solution: 
I implemented an interactive empty state rendering method (`_render_empty_state`) that is automatically triggered when `load_messages` results in zero matches. 

Key improvements:
1. **Feedback & Clarity**: The detail view now explicitly lists every active constraint (e.g., specific search terms, current BBS/Conference selection, and active boolean filters like "Attachments" or "My Messages"). This helps the user immediately diagnose why the list is empty.
2. **Friction Reduction**: I added a clickable "Reset all filters and search" link directly in the empty state view. This allows users to recover with a single click in their immediate focal area without needing to move their mouse to the toolbar.
3. **Discoverability**: The view includes a helpful tip about the `Esc` keyboard shortcut for progressive clearing, which is a powerful but often "invisible" feature.

This change adheres to "Invisible Design" by using the existing typography and styling system, providing a polished and native feel while significantly improving the user journey for common filtering tasks.

### Changes:
- Modified `pyqwk/gui.py`:
  - Added `_render_empty_state` method.
  - Integrated `_render_empty_state` into `load_messages`.
- Added `tests/test_gui_ux_empty_state.py`.

---
*PR created automatically by Jules for task [1648556861407153855](https://jules.google.com/task/1648556861407153855) started by @RainRat*