### PR TITLE
[TEST] Fix content stripping bug in Markdown message import

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -1252,12 +1252,14 @@ def _parse_markdown_messages(path: str) -> list[ParsedMessage]:
                 attachments = [a.strip() for a in attach_str.split(',') if a.strip()]
 
         # Message body: everything after the information lines
+        # In our Markdown format, metadata ends at the first blank line.
         lines = working_section.splitlines()
         body_start_idx = 0
         for i, line in enumerate(lines):
             line_strip = line.strip()
             if not line_strip:
-                continue
+                body_start_idx = i + 1
+                break
             if line_strip.startswith('## ') or line_strip.startswith('- **'):
                 body_start_idx = i + 1
             else:

--- a/tests/test_markdown_import.py
+++ b/tests/test_markdown_import.py
@@ -251,5 +251,31 @@ This is the second part (after a horizontal rule).
         self.assertIn("---", messages[0].text)
         self.assertIn("second part", messages[0].text)
 
+    def test_markdown_import_preserves_body_headers(self):
+        """Verify that Markdown headers in the body are not stripped during import."""
+        markdown_content = """
+# Archive
+
+## Metadata Subject
+- **Date:** 01-01-24 12:00
+- **From:** Alice
+- **To:** Bob
+- **Conference:** General (1)
+
+## Body Header
+Body text here.
+
+- **Bullet in body**
+More text.
+"""
+        markdown_path = os.path.join(self.test_dir, "test_body_headers.md")
+        with open(markdown_path, 'w', encoding='utf-8') as f:
+            f.write(markdown_content)
+
+        messages, _ = load_data(markdown_path, self.logger)
+        self.assertEqual(len(messages), 1)
+        self.assertIn("## Body Header", messages[0].text)
+        self.assertIn("- **Bullet in body**", messages[0].text)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR fixes a bug in the Markdown import logic where headers or bullet points at the beginning of a message body were incorrectly stripped as metadata.

### Changes:
- Modified `_parse_markdown_messages` in `pyqwk/core.py` to stop stripping metadata at the first encountered blank line.
- Added `test_markdown_import_preserves_body_headers` to `tests/test_markdown_import.py` to verify the fix and prevent regressions.

The fix ensures that metadata is treated as a contiguous block at the top of each message section, correctly separating it from the body content.

---
*PR created automatically by Jules for task [16795942020927622254](https://jules.google.com/task/16795942020927622254) started by @RainRat*