### PR TITLE
Fix logic bug in GUI jump-to-message guard clause

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -1689,7 +1689,7 @@ class QwkGuiApp:
 
     def prompt_jump_to_message(self, _event: object | None = None) -> None:
         """Prompt the user for a message number and jump to it."""
-        if not self.current_paths:
+        if not self.messages:
             return
 
         msgnum = simpledialog.askinteger("Jump to Message", "Enter message number:")


### PR DESCRIPTION
This PR fixes a logic bug in the Graphical Reader's "Jump to Message" (Ctrl+G) feature. 

The feature previously checked `self.current_paths` to determine if it should allow jumping to a message number. However, the operation depends on the availability of message data in `self.messages`, not necessarily on the presence of tracked input paths. This mismatch caused the feature to be incorrectly disabled in certain contexts, including several automated tests.

By updating the guard to check `self.messages` directly, the feature becomes more robust and reliable. This change is non-breaking and resolves pre-existing failures in the test suite.

---
*PR created automatically by Jules for task [17822573090816097386](https://jules.google.com/task/17822573090816097386) started by @RainRat*