### PR TITLE
[UI/UX] Consolidate Graphical Reader toolbar clusters

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -632,24 +632,13 @@ class QwkGuiApp:
             ("Attachments", self.has_attach_var),
             ("My Messages", self.mine_var),
             ("On This Day", self.on_this_day_var),
-        ]:
-            ttk.Checkbutton(
-                filters_frame, text=text, variable=var, command=self.reload_messages
-            ).pack(side=tk.LEFT, padx=5)
-
-        ttk.Separator(row2, orient=tk.VERTICAL).pack(side=tk.LEFT, fill=tk.Y, padx=10)
-
-        discovery_frame = ttk.Frame(row2)
-        discovery_frame.pack(side=tk.LEFT, padx=5)
-        ttk.Label(discovery_frame, text="Discovery:").pack(side=tk.LEFT)
-        for text, var in [
             ("Links", self.has_links_var),
             ("Emails", self.has_emails_var),
             ("Phones", self.has_phones_var),
             ("ANSI", self.has_ansi_var),
         ]:
             ttk.Checkbutton(
-                discovery_frame, text=text, variable=var, command=self.reload_messages
+                filters_frame, text=text, variable=var, command=self.reload_messages
             ).pack(side=tk.LEFT, padx=5)
 
         ttk.Separator(row2, orient=tk.VERTICAL).pack(side=tk.LEFT, fill=tk.Y, padx=10)

--- a/tests/test_ui_toolbar_consolidation.py
+++ b/tests/test_ui_toolbar_consolidation.py
@@ -1,0 +1,68 @@
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+def test_toolbar_consolidation():
+    """Verify that the toolbar has been consolidated and 'Discovery' label is removed."""
+
+    with patch("pyqwk.gui.tk") as mock_tk, \
+         patch("pyqwk.gui.ttk") as mock_ttk, \
+         patch("pyqwk.gui.messagebox"), \
+         patch("pyqwk.gui.filedialog"), \
+         patch("pyqwk.gui.simpledialog"):
+
+        # Ensure classes return mocks
+        mock_tk.BooleanVar.side_effect = lambda **kwargs: MagicMock()
+        mock_tk.StringVar.side_effect = lambda **kwargs: MagicMock()
+        mock_tk.IntVar.side_effect = lambda **kwargs: MagicMock()
+
+        from pyqwk.gui import QwkGuiApp
+        root = MagicMock()
+        app = QwkGuiApp(root)
+
+        # Check that "Filters:" label exists
+        filter_label_calls = [
+            call for call in mock_ttk.Label.call_args_list
+            if call[1].get('text') == "Filters:"
+        ]
+        assert len(filter_label_calls) == 1, "Expected one 'Filters:' label"
+
+        # Check that "Discovery:" label DOES NOT exist
+        discovery_label_calls = [
+            call for call in mock_ttk.Label.call_args_list
+            if call[1].get('text') == "Discovery:"
+        ]
+        assert len(discovery_label_calls) == 0, "Expected 'Discovery:' label to be removed"
+
+        # Verify all 7 filter checkboxes exist
+        expected_filters = {
+            "Attachments", "My Messages", "On This Day",
+            "Links", "Emails", "Phones", "ANSI"
+        }
+
+        checkbutton_calls = [
+            call[1].get('text') for call in mock_ttk.Checkbutton.call_args_list
+        ]
+
+        for f in expected_filters:
+            assert f in checkbutton_calls, f"Expected filter checkbox '{f}' not found"
+
+        # Verify they are all in the same cluster (packed into the same parent)
+        # Find the parent of "Attachments"
+        attachments_call = [
+            call for call in mock_ttk.Checkbutton.call_args_list
+            if call[1].get('text') == "Attachments"
+        ][0]
+        filters_parent = attachments_call[0][0]
+
+        # Check that "Links" (formerly in Discovery) shares the same parent
+        links_call = [
+            call for call in mock_ttk.Checkbutton.call_args_list
+            if call[1].get('text') == "Links"
+        ][0]
+        assert links_call[0][0] == filters_parent, "Filters and Discovery checkboxes should share the same parent frame"
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
This PR improves the visual hierarchy of the Graphical Reader's toolbar by consolidating two related filter groups.

### Problem
The toolbar's second row was fragmented into four small clusters: 'Archives', 'Filters', 'Discovery', and 'View'. 'Filters' and 'Discovery' both contained message visibility toggles, and their separation created unnecessary visual noise (extra label and vertical separator) and horizontal clutter.

### Solution
I consolidated the 'Discovery' checkboxes (Links, Emails, Phones, ANSI) into the 'Filters' group. This creates a cleaner three-cluster layout for Row 2:
1.  **Archives:** Scope selection (BBS/Conference).
2.  **Filters:** Message visibility toggles (7 checkboxes).
3.  **View:** Presentation toggles (Threaded, Clean, Wrap, Remove Colors).

### Changes
- **pyqwk/gui.py:** Refactored `_build_toolbar` to merge the checkbox loops and remove the redundant frame and label.
- **tests/test_ui_toolbar_consolidation.py:** Added a new test to verify the combined widget hierarchy and ensure no regressions in widget parenting.

Verified by running the full test suite (782 tests passed).

---
*PR created automatically by Jules for task [3658988990942978452](https://jules.google.com/task/3658988990942978452) started by @RainRat*