### PR TITLE
[FEAT] HTML Import Support

### DIFF
--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -89,7 +89,7 @@ examples:
     )
     parser.add_argument(
         'input_paths',
-        help='Path to message archives, ZIP files, or folders. Supports QWK, REP, JSON, JSONL, CSV, XML, MBOX, EML, SQLite, and Markdown.',
+        help='Path to message archives, ZIP files, or folders. Supports QWK, REP, JSON, JSONL, CSV, XML, MBOX, EML, SQLite, Markdown, and HTML.',
         nargs='+',
     )
 

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -41,7 +41,7 @@ def expand_paths(paths: list[str]) -> list[str]:
             for root, _, files in os.walk(path):
                 for file in files:
                     lower_file = file.lower()
-                    if lower_file.endswith(('.qwk', '.zip', '.rep', '.json', '.jsonl', '.csv', '.db', '.sqlite', '.xml', '.mbox', '.eml', '.md', '.markdown')) or lower_file == 'messages.dat':
+                    if lower_file.endswith(('.qwk', '.zip', '.rep', '.json', '.jsonl', '.csv', '.db', '.sqlite', '.xml', '.mbox', '.eml', '.md', '.markdown', '.html', '.htm')) or lower_file == 'messages.dat':
                         expanded_paths.append(os.path.join(root, file))
         else:
             expanded_paths.append(path)
@@ -1143,6 +1143,127 @@ def _parse_eml_messages(path: str) -> list[ParsedMessage]:
     return [_message_from_email(msg_obj)]
 
 
+def _parse_html_messages(path: str) -> list[ParsedMessage]:
+    """Import messages from an HTML file."""
+    with open(path, 'r', encoding='utf-8') as f:
+        content = f.read()
+
+    messages = []
+
+    # Identify message blocks
+    msg_blocks = list(re.finditer(r'<div class="message"(?: id="[^"]*")?>', content))
+
+    re_date = re.compile(r'<strong>Date:</strong>\s*(.*?)\s*</div>')
+    re_from = re.compile(r'<strong>From:</strong>\s*(.*?)\s*</div>')
+    re_to = re.compile(r'<strong>To:</strong>\s*(.*?)\s*</div>')
+    re_subject = re.compile(r'<strong>Subject:</strong>\s*(.*?)\s*</div>')
+    re_conf = re.compile(r'<strong>Conference:</strong>\s*(.*?)\s*\((\d+)\)\s*</div>')
+    re_bbs = re.compile(r'<strong>BBS:</strong>\s*(.*?)\s*</div>')
+    re_source = re.compile(r'<strong>Source:</strong>\s*(.*?)\s*</div>')
+    re_number = re.compile(r'<strong>Number:</strong>\s*(\d+)\s*</div>')
+    re_attachments = re.compile(r'<strong>Attachments:</strong>\s*(.*?)\s*</div>')
+    re_body = re.compile(r'<pre class="body">(.*?)</pre>', re.DOTALL)
+
+    def clean_html(text: str) -> str:
+        # Remove tags like <mark>, </mark>, <span class="quote">, </span>, and <a> tags
+        text = re.sub(r'<[^>]+>', '', text)
+        return html.unescape(text).strip()
+
+    for i, match in enumerate(msg_blocks):
+        start = match.start()
+        end = msg_blocks[i+1].start() if i+1 < len(msg_blocks) else len(content)
+        block = content[start:end]
+
+        # Determine depth by tracking div nesting
+        depth = 0
+        stack = []
+        for m_tag in re.finditer(r"<(div|/div)([^>]*)>", content):
+            if m_tag.start() >= start:
+                break
+            tag_name = m_tag.group(1)
+            attrs = m_tag.group(2)
+            if tag_name == "div":
+                if "class=\"reply\"" in attrs:
+                    stack.append("reply")
+                    depth += 1
+                else:
+                    stack.append("other")
+            elif tag_name == "/div":
+                if stack:
+                    if stack.pop() == "reply":
+                        depth -= 1
+        depth = max(0, depth)
+        header_match = re.search(r'<div class="header">(.*?)</div>\s*<pre', block, re.DOTALL)
+        header_part = header_match.group(1) if header_match else block
+
+        date_match = re_date.search(header_part)
+        from_match = re_from.search(header_part)
+        to_match = re_to.search(header_part)
+        subject_match = re_subject.search(header_part)
+        conf_match = re_conf.search(header_part)
+        bbs_match = re_bbs.search(header_part)
+        source_match = re_source.search(header_part)
+        number_match = re_number.search(header_part)
+        attach_match = re_attachments.search(header_part)
+
+        msg_date = "01-01-70"
+        msg_time = "00:00"
+        if date_match:
+            dt_parts = clean_html(date_match.group(1)).split()
+            if len(dt_parts) >= 1:
+                msg_date = dt_parts[0]
+            if len(dt_parts) >= 2:
+                msg_time = dt_parts[1]
+
+        conf_num = 0
+        conf_name = None
+        if conf_match:
+            conf_name = clean_html(conf_match.group(1))
+            conf_num = int(conf_match.group(2))
+
+        attachments = None
+        if attach_match:
+            attachments = [clean_html(a) for a in attach_match.group(1).split(',')]
+
+        body = ""
+        body_match = re_body.search(block)
+        if body_match:
+            body = clean_html(body_match.group(1))
+
+        header = MessageHeader(
+            status=" ",
+            msgnum=int(number_match.group(1)) if number_match else None,
+            msgdate=msg_date,
+            msgtime=msg_time,
+            msgto=clean_html(to_match.group(1)) if to_match else "",
+            msgfrom=clean_html(from_match.group(1)) if from_match else "",
+            msgsubject=clean_html(subject_match.group(1)) if subject_match else "(no subject)",
+            msgpassword="",
+            refnum=None,
+            numblocks=None,
+            msgflag=" ",
+            confnum=conf_num,
+            lognum=0,
+            nettag="",
+        )
+
+        msg = ParsedMessage(
+            text=body,
+            msgnum=header.msgnum,
+            refnum=None,
+            confnum=conf_num,
+            header=header,
+            depth=depth,
+            confname=conf_name,
+            bbs_name=clean_html(bbs_match.group(1)) if bbs_match else None,
+            source_file=clean_html(source_match.group(1)) if source_match else None,
+            attachments=attachments,
+        )
+        messages.append(msg)
+
+    return messages
+
+
 def _parse_markdown_messages(path: str) -> list[ParsedMessage]:
     """Import messages from a Markdown file."""
     with open(path, 'r', encoding='utf-8') as f:
@@ -1351,6 +1472,15 @@ def load_data(
                 if line.strip():
                     data = json.loads(line)
                     messages.extend(_parse_json_messages(data))
+
+        board_dict = _reconstruct_archive_information(messages)
+        return messages, board_dict
+
+    if input_path.lower().endswith(('.html', '.htm')):
+        try:
+            messages = _parse_html_messages(input_path)
+        except Exception as e:
+            raise ValueError(f"Failed to load HTML archive: {e}")
 
         board_dict = _reconstruct_archive_information(messages)
         return messages, board_dict

--- a/tests/test_html_import.py
+++ b/tests/test_html_import.py
@@ -1,0 +1,143 @@
+import os
+import logging
+from pyqwk.core import (
+    ParsedMessage, MessageHeader, process_merged_files, ProcessingSettings,
+    load_data, expand_paths
+)
+
+def test_html_import_roundtrip(tmp_path):
+    """Test that messages exported to HTML can be imported back correctly."""
+    output_html = tmp_path / "test.html"
+
+    # Setup test messages
+    h1 = MessageHeader(
+        status=' ', msgnum=101, msgdate='05-20-23', msgtime='14:30',
+        msgto='Alice', msgfrom='Bob', msgsubject='Hello HTML', msgpassword='',
+        refnum=None, numblocks=1, msgflag='', confnum=1, lognum=1, nettag=''
+    )
+    msg1 = ParsedMessage(
+        text="This is a test message body.",
+        msgnum=101, refnum=None, confnum=1, header=h1,
+        confname="General", bbs_name="TestBBS", source_file="original.qwk"
+    )
+
+    h2 = MessageHeader(
+        status=' ', msgnum=102, msgdate='05-20-23', msgtime='14:35',
+        msgto='Bob', msgfrom='Alice', msgsubject='Re: Hello HTML', msgpassword='',
+        refnum=101, numblocks=1, msgflag='', confnum=1, lognum=2, nettag=''
+    )
+    # Child message for threading
+    msg2 = ParsedMessage(
+        text="This is a reply.",
+        msgnum=102, refnum=101, confnum=1, header=h2,
+        confname="General", bbs_name="TestBBS", source_file="original.qwk",
+        depth=1
+    )
+
+    messages = [msg1, msg2]
+
+    # 1. Export to HTML
+    settings_export = ProcessingSettings(
+        verbose=True, private=True, no_header=False, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=True, merge=True,
+        binaries_removal=False, redact_pii=False, format='html', separator='none',
+        output_mode='file', output_path=str(output_html), encoding='utf-8',
+        include_toc=True, quiet=True
+    )
+
+    import unittest.mock
+    mock_logger = unittest.mock.MagicMock()
+
+    # We need to mock load_data to return our test messages during process_merged_files
+    with unittest.mock.patch('pyqwk.core.load_data') as mock_load:
+        mock_load.return_value = (messages, {1: "General"})
+        process_merged_files(['fake.qwk'], settings_export, mock_logger)
+
+    assert os.path.exists(output_html)
+
+    # 2. Import back from HTML
+    logger = logging.getLogger("test")
+    imported_messages, board_dict = load_data(str(output_html), logger)
+
+    assert len(imported_messages) == 2
+
+    # Check Message 1
+    im1 = imported_messages[0]
+    assert im1.msgnum == 101
+    assert im1.header.msgfrom == "Bob"
+    assert im1.header.msgto == "Alice"
+    assert im1.header.msgsubject == "Hello HTML"
+    assert im1.confnum == 1
+    assert im1.confname == "General"
+    assert im1.bbs_name == "TestBBS"
+    assert "test message body" in im1.text
+    assert im1.depth == 0
+
+    # Check Message 2
+    im2 = imported_messages[1]
+    assert im2.msgnum == 102
+    assert im2.header.msgfrom == "Alice"
+    assert im2.header.msgto == "Bob"
+    assert im2.header.msgsubject == "Re: Hello HTML"
+    assert im2.depth == 1
+    assert "reply" in im2.text
+
+def test_html_individual_files_import(tmp_path):
+    """Test importing from a directory of individual HTML message files."""
+    output_dir = tmp_path / "individual"
+    output_dir.mkdir()
+
+    h1 = MessageHeader(
+        status=' ', msgnum=50, msgdate='01-01-23', msgtime='10:00',
+        msgto='All', msgfrom='Sysop', msgsubject='Welcome', msgpassword='',
+        refnum=None, numblocks=1, msgflag='', confnum=0, lognum=1, nettag=''
+    )
+    msg1 = ParsedMessage(
+        text="Welcome to the BBS",
+        msgnum=50, refnum=None, confnum=0, header=h1,
+        confname="Public", bbs_name="MyBBS"
+    )
+
+    settings_export = ProcessingSettings(
+        verbose=True, private=True, no_header=False, truncate_signatures=False,
+        cut_quoting=False, individual_files=True, threaded=False, merge=False,
+        binaries_removal=False, redact_pii=False, format='html', separator='none',
+        output_mode='file', output_path=str(output_dir), encoding='utf-8',
+        quiet=True
+    )
+
+    import unittest.mock
+    mock_logger = unittest.mock.MagicMock()
+
+    with unittest.mock.patch('pyqwk.core.load_data') as mock_load:
+        mock_load.return_value = ([msg1], {0: "Public"})
+        process_merged_files(['fake.qwk'], settings_export, mock_logger)
+
+    # Find the generated HTML file (ignoring index.html)
+    html_files = [f for f in os.listdir(output_dir) if f.endswith(".html") and f != "index.html"]
+    assert len(html_files) == 1
+    msg_file_path = output_dir / html_files[0]
+
+    # Import it back
+    imported, _ = load_data(str(msg_file_path), mock_logger)
+    assert len(imported) == 1
+    assert imported[0].msgnum == 50
+    assert imported[0].header.msgsubject == "Welcome"
+    assert imported[0].bbs_name == "MyBBS"
+    assert "Welcome to the BBS" in imported[0].text
+
+def test_expand_paths_html():
+    """Verify that expand_paths finds .html and .htm files."""
+    files = expand_paths(["tests"])
+    # This should be true now, but let's test with a controlled environment if possible
+    # For simplicity, we just check if any .html file would be found in a mock structure
+    import unittest.mock
+    with unittest.mock.patch('os.path.isdir', return_value=True):
+        with unittest.mock.patch('os.walk') as mock_walk:
+            mock_walk.return_value = [
+                ('/fake', ('subdir',), ('msg1.html', 'msg2.htm', 'other.txt')),
+            ]
+            found = expand_paths(['/fake'])
+            assert '/fake/msg1.html' in found
+            assert '/fake/msg2.htm' in found
+            assert '/fake/other.txt' not in found


### PR DESCRIPTION
This PR introduces **HTML Import Support** to `pyqwk`, providing symmetry with the existing HTML export functionality.

### Changes
- **Core Parser:** Added `_parse_html_messages` in `pyqwk/core.py`. It uses robust regular expressions to extract all standard metadata fields (`Date`, `From`, `To`, `Subject`, `Conference`, `BBS`, `Number`, `Source`, `Attachments`) from the HTML structure generated by the tool.
- **Threading Reconstruction:** Implemented a stack-based tracking mechanism for `<div class="reply">` tags to accurately restore the original message depth and hierarchy during import.
- **Integration:** Updated `expand_paths` to recognize HTML files during directory scans and updated `load_data` to automatically route `.html` and `.htm` files to the new parser.
- **CLI Enhancement:** Updated the `input_paths` help string in `pyqwk/cli.py` to reflect the new capability.
- **Testing:** Added `tests/test_html_import.py` covering:
    - Round-trip integrity (Export -> Import) for merged HTML archives.
    - Importing from individual HTML message files.
    - Path expansion for HTML extensions.

### Why this is useful
By adding HTML import support, users can now treat HTML as a first-class human-readable archive format. This allows for manual editing or auditing of messages in a web browser while maintaining the ability to re-import them into the tool for further conversion to formats like SQLite, mbox, or JSON.

---
*PR created automatically by Jules for task [6394443052138378077](https://jules.google.com/task/6394443052138378077) started by @RainRat*