### PR TITLE
Remove unused redundant wrapper `_set_detail_text` from `QwkGuiApp`

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -1496,10 +1496,6 @@ class QwkGuiApp:
                 
             messagebox.showerror("Failed to load QWK", str(exc))
 
-    def _set_detail_text(self, text: str) -> None:
-        self.detail_text.delete("1.0", tk.END)
-        self.detail_text.insert(tk.END, text)
-
     def save_attachment(self, filename: str, attachment_index: int) -> None:
         """Save a specific attachment from the currently selected message."""
         current_selection = self.message_list.selection()

--- a/tests/test_lead_qa_gui_coverage_final.py
+++ b/tests/test_lead_qa_gui_coverage_final.py
@@ -58,15 +58,6 @@ def test_is_any_filter_active_none(app):
         m_conf.get.return_value = "All Conferences"
         assert app._is_any_filter_active() is False
 
-def test_set_detail_text(app):
-    """Test _set_detail_text helper method (lines 1511-1512)."""
-    app.detail_text = MagicMock()
-    app._set_detail_text("Hello World")
-    # Using ANY for the mock.END value which is mocked as a MagicMock
-    from unittest.mock import ANY
-    app.detail_text.delete.assert_called_with("1.0", ANY)
-    app.detail_text.insert.assert_called_with(ANY, "Hello World")
-
 def test_jump_to_message_found_after_reset(app):
     """Test jump_to_message finds message after filter reset (lines 1744-1745)."""
     h1 = MessageHeader(" ", 101, "01-01-23", "12:00", "To1", "From1", "Subj1", "", None, 1, " ", 1, 1, "")


### PR DESCRIPTION
* **What:** Removed the `_set_detail_text` private method from the `QwkGuiApp` class in `pyqwk/gui.py` and its corresponding unit test in `tests/test_lead_qa_gui_coverage_final.py`.
* **Why:** The method was a redundant wrapper around standard Tkinter `delete` and `insert` operations and was not used anywhere in the application source code. Removing this dead code improves maintainability and reduces noise. No breaking changes were introduced as the method had no call sites.

---
*PR created automatically by Jules for task [8247049631495683074](https://jules.google.com/task/8247049631495683074) started by @RainRat*