### PR TITLE
[TEST] Add coverage for extensionless attachments in statistics

### DIFF
--- a/tests/test_attachment_no_ext_stats.py
+++ b/tests/test_attachment_no_ext_stats.py
@@ -1,0 +1,28 @@
+import pytest
+from pyqwk.core import _compute_stats_from_messages, ParsedMessage, MessageHeader
+
+def test_attachment_no_extension_stats():
+    # Message with UUE attachment that has no extension
+    body = "Hello\nbegin 644 noextension\n!\nend\n"
+
+    msg = ParsedMessage(
+        body,
+        1,
+        None,
+        1,
+        MessageHeader(" ", 1, "01-01-24", "12:00", "To", "From", "Subj", "", None, 1, " ", 1, 0, "")
+    )
+
+    stats = _compute_stats_from_messages(iter([msg]))
+
+    assert stats["attachments_count"] == 1
+
+    # Check top attachments
+    top_atts = {a["name"]: a["count"] for a in stats["top_attachments"]}
+    assert "noextension" in top_atts
+    assert top_atts["noextension"] == 1
+
+    # Check top attachment types
+    top_types = {t["extension"]: t["count"] for t in stats["top_attachment_types"]}
+    assert "(no extension)" in top_types
+    assert top_types["(no extension)"] == 1


### PR DESCRIPTION
### [TEST] Add coverage for extensionless attachments in statistics

**Type:** New Coverage

**What:**
Added a new test case `test_attachment_no_extension_stats` in a new test file `tests/test_attachment_no_ext_stats.py`. This test verifies that `_compute_stats_from_messages` correctly identifies and counts attachments that lack a file extension, categorizing them under `(no extension)`.

**Why:**
A Gap Analysis revealed that line 4253 in `pyqwk/core.py` was not covered by the existing test suite. By adding this test, I have ensured that this edge case is handled correctly and have reached 100% statement coverage for the core module. All 798 tests passed successfully.

---
*PR created automatically by Jules for task [4974988321376202665](https://jules.google.com/task/4974988321376202665) started by @RainRat*