### PR TITLE
[FEAT] RSS 2.0 Export Support

### DIFF
--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -214,7 +214,7 @@ examples:
             'If omitted, the format is determined by the output file extension.'
         ),
         default=None,
-        choices=['text', 'json', 'jsonl', 'xml', 'html', 'markdown', 'csv', 'mbox', 'eml', 'sqlite'],
+        choices=['text', 'json', 'jsonl', 'xml', 'html', 'markdown', 'csv', 'mbox', 'eml', 'sqlite', 'rss'],
     )
     format_group.add_argument(
         '-j',

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -60,6 +60,7 @@ FORMAT_EXTENSIONS = {
     'eml': '.eml',
     'qwk': '.qwk',
     'rep': '.rep',
+    'rss': '.rss',
 }
 
 
@@ -97,6 +98,7 @@ def resolve_output_format(
             '.db': 'sqlite',
             '.qwk': 'qwk',
             '.rep': 'rep',
+            '.rss': 'rss',
         }
         if ext in mapping:
             return mapping[ext]
@@ -2750,6 +2752,68 @@ def _write_xml(
     _write_text_output(xml_text, output_path, encoding='utf-8')
 
 
+def _write_rss(
+    messages: list[ProcessedMessage],
+    output_path: str | None,
+    encoding: str = 'utf-8',
+    settings: ProcessingSettings | None = None,
+    bbs_info: BBSInfo | None = None,
+    board_dict: Mapping[int, str] | None = None,
+) -> None:
+    """Write messages to an RSS 2.0 feed."""
+    rss = ET.Element('rss', version='2.0')
+    channel = ET.SubElement(rss, 'channel')
+
+    if bbs_info and bbs_info.name:
+        title = f"{bbs_info.name} Feed"
+        description = f"Message feed from {bbs_info.name}"
+    else:
+        title = 'QWK Message Feed'
+        description = "Message feed from QWK archive"
+
+    ET.SubElement(channel, 'title').text = title
+    ET.SubElement(channel, 'link').text = 'https://github.com/mprokop/pyqwk'
+    ET.SubElement(channel, 'description').text = description
+
+    if messages:
+        try:
+            latest_msg = max(messages, key=lambda m: _parse_qwk_date(m.header.msgdate, m.header.msgtime))
+            dt = _parse_qwk_date(latest_msg.header.msgdate, latest_msg.header.msgtime)
+            ET.SubElement(channel, 'pubDate').text = email.utils.format_datetime(dt)
+        except Exception:
+            pass
+
+    for message in messages:
+        item = ET.SubElement(channel, 'item')
+        header = message.header
+
+        conf_name = message.confname or (board_dict.get(header.confnum) if board_dict else str(header.confnum))
+        item_title = f"[{conf_name}] {header.msgsubject.strip()}"
+        ET.SubElement(item, 'title').text = item_title
+
+        # RSS items should ideally have a link, but these are offline messages.
+        ET.SubElement(item, 'link').text = ""
+
+        # Description contains the message text
+        desc = ET.SubElement(item, 'description')
+        desc.text = message.text
+
+        # Author (RSS 2.0 expects an email address if possible, but we use the name)
+        ET.SubElement(item, 'author').text = header.msgfrom.strip()
+
+        # Publication Date
+        dt = _parse_qwk_date(header.msgdate, header.msgtime)
+        ET.SubElement(item, 'pubDate').text = email.utils.format_datetime(dt)
+
+        # Unique identifier
+        guid_val = f"{header.confnum}.{header.msgnum if header.msgnum is not None else id(message)}@qwk"
+        guid = ET.SubElement(item, 'guid', isPermaLink='false')
+        guid.text = guid_val
+
+    xml_text = _xml_element_to_str(rss)
+    _write_text_output(xml_text, output_path, encoding='utf-8')
+
+
 def _get_html_header(title: str) -> list[str]:
     return [
         '<!DOCTYPE html>',
@@ -3790,6 +3854,7 @@ def write_messages(
         'sqlite': _write_sqlite,
         'qwk': _write_qwk,
         'rep': _write_qwk,
+        'rss': _write_rss,
     }
 
     writer = writers.get(settings.format, _write_text)

--- a/test.rss
+++ b/test.rss
@@ -1,0 +1,18 @@
+<rss version="2.0">
+  <channel>
+    <title>TestBBS Feed</title>
+    <link>https://github.com/mprokop/pyqwk</link>
+    <description>Message feed from TestBBS Feed</description>
+    <pubDate>Sun, 01 Jan 2023 10:00:00 -0000</pubDate>
+    <item>
+      <title>[General] Test Subject</title>
+      <link />
+      <description>Hello world
+This is a test.
+</description>
+      <author>Author</author>
+      <pubDate>Sun, 01 Jan 2023 10:00:00 -0000</pubDate>
+      <guid isPermaLink="false">1.1@qwk</guid>
+    </item>
+  </channel>
+</rss>

--- a/tests/test_rss_export.py
+++ b/tests/test_rss_export.py
@@ -1,0 +1,76 @@
+import os
+import xml.etree.ElementTree as ET
+import logging
+from pyqwk.core import (
+    ParsedMessage,
+    MessageHeader,
+    ProcessingSettings,
+    _write_rss,
+    BBSInfo,
+    ConferenceMap
+)
+
+def test_write_rss(tmp_path):
+    output_path = os.path.join(tmp_path, "test.rss")
+
+    header = MessageHeader(
+        status=" ",
+        msgnum=123,
+        msgdate="01-01-23",
+        msgtime="10:00",
+        msgto="Recipient",
+        msgfrom="Author",
+        msgsubject="Test Subject",
+        msgpassword="",
+        refnum=None,
+        numblocks=1,
+        msgflag=" ",
+        confnum=1,
+        lognum=0,
+        nettag="",
+    )
+
+    msg = ParsedMessage(
+        text="Hello world\nThis is a test.",
+        msgnum=123,
+        refnum=None,
+        confnum=1,
+        header=header,
+        confname="General",
+        bbs_name="TestBBS"
+    )
+
+    bbs_info = BBSInfo(name="TestBBS")
+    board_dict = ConferenceMap({1: "General"})
+    board_dict.bbs_info = bbs_info
+
+    settings = ProcessingSettings(
+        verbose=False, private=True, no_header=False, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False,
+        binaries_removal=False, redact_pii=False, format='rss',
+        separator='none', output_mode='file', output_path=output_path,
+        encoding='utf-8'
+    )
+
+    _write_rss([msg], output_path, settings=settings, bbs_info=bbs_info, board_dict=board_dict)
+
+    assert os.path.exists(output_path)
+
+    tree = ET.parse(output_path)
+    root = tree.getroot()
+
+    assert root.tag == "rss"
+    assert root.attrib["version"] == "2.0"
+
+    channel = root.find("channel")
+    assert channel is not None
+    assert channel.find("title").text == "TestBBS Feed"
+
+    items = channel.findall("item")
+    assert len(items) == 1
+
+    item = items[0]
+    assert item.find("title").text == "[General] Test Subject"
+    assert item.find("description").text == "Hello world\nThis is a test."
+    assert item.find("author").text == "Author"
+    assert item.find("guid").text == "1.123@qwk"


### PR DESCRIPTION
This PR implements RSS 2.0 export support for pyqwk.

**What:**
A technical description of the new functionality:
- Added a new `_write_rss` function in `pyqwk/core.py` that uses `xml.etree.ElementTree` to generate a valid RSS 2.0 feed.
- The feed includes channel metadata (title, link, description, pubDate) derived from BBS information and message dates.
- Each message is exported as an RSS `<item>` with its conference name, subject, author, body text, and a unique GUID.
- Registered the `rss` format in `FORMAT_EXTENSIONS` and `resolve_output_format` in `pyqwk/core.py`.
- Added `rss` to the allowed choices for the `--format` CLI argument in `pyqwk/cli.py`.
- Included a new test file `tests/test_rss_export.py` to verify the generated RSS XML.

**Why:**
Explain the logical deduction that led you to this feature:
I noticed that while `pyqwk` supports many export formats like HTML, Markdown, and EML for reading and archiving, it lacked a standard way to syndicate or broadcast message updates. RSS 2.0 is a perfect fit for this, allowing users to integrate BBS message archives into modern feed readers or notification systems. This follows the "Interoperability" and "Symmetry" heuristics by providing another way to consume the message data in a structured, standard format.

---
*PR created automatically by Jules for task [17645044270434955258](https://jules.google.com/task/17645044270434955258) started by @RainRat*