### PR TITLE
[FEAT] RSS 2.0 Export Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ pyqwk helps you open these archives and convert them into modern, readable forma
 
 ## Features
 
-- **Support many formats:** Import and export between QWK, JSON, HTML, Markdown, mbox, and more.
+- **Support many formats:** Import and export between QWK, JSON, HTML, Markdown, mbox, RSS, and more.
 - **Group conversations:** Use "threading" to group replies and follow discussions easily.
 - **Clean content:** Automatically remove signatures, old quotes, and attachments.
 - **Protect privacy:** Hide personal information or private messages.
@@ -196,6 +196,11 @@ qwk archive.qwk --redact-pii -o safe.txt
 qwk archive.qwk --format sqlite -o messages.db
 ```
 
+**Export to an RSS feed:**
+```bash
+qwk archive.qwk --format rss -o messages.rss
+```
+
 **Import from a spreadsheet (CSV):**
 ```bash
 qwk messages.csv -o updated.html
@@ -289,7 +294,7 @@ for msg in messages:
 | :--- | :--- |
 | `-o`, `--output` | Save results to a file or folder. |
 | `-i`, `--individual-files` | Save each message as a separate file. |
-| `-F, --format` | Set output format (html, json, markdown, etc.). |
+| `-F, --format` | Set output format (html, json, markdown, rss, etc.). |
 | `-T`, `--threaded` | Group replies into conversations. |
 | `--clean` | Remove signatures, quotes, and attachments. |
 | `-x, --extract-attachments` | Save attachments to a folder. |

--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -214,7 +214,7 @@ examples:
             'If omitted, the format is determined by the output file extension.'
         ),
         default=None,
-        choices=['text', 'json', 'jsonl', 'xml', 'html', 'markdown', 'csv', 'mbox', 'eml', 'sqlite'],
+        choices=['text', 'json', 'jsonl', 'xml', 'html', 'markdown', 'csv', 'mbox', 'eml', 'sqlite', 'rss'],
     )
     format_group.add_argument(
         '-j',

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -60,6 +60,7 @@ FORMAT_EXTENSIONS = {
     'eml': '.eml',
     'qwk': '.qwk',
     'rep': '.rep',
+    'rss': '.rss',
 }
 
 
@@ -97,6 +98,7 @@ def resolve_output_format(
             '.db': 'sqlite',
             '.qwk': 'qwk',
             '.rep': 'rep',
+            '.rss': 'rss',
         }
         if ext in mapping:
             return mapping[ext]
@@ -2750,6 +2752,43 @@ def _write_xml(
     _write_text_output(xml_text, output_path, encoding='utf-8')
 
 
+def _write_rss(
+    messages: list[ProcessedMessage],
+    output_path: str | None,
+    encoding: str = 'utf-8',
+    settings: ProcessingSettings | None = None,
+    bbs_info: BBSInfo | None = None,
+    board_dict: Mapping[int, str] | None = None,
+) -> None:
+    """Write messages to an RSS 2.0 feed."""
+    title = 'QWK Messages'
+    if bbs_info and bbs_info.name:
+        title = f"{bbs_info.name} Archive"
+
+    rss = ET.Element('rss', version='2.0')
+    channel = ET.SubElement(rss, 'channel')
+    ET.SubElement(channel, 'title').text = title
+    ET.SubElement(channel, 'link').text = "http://example.com"
+    ET.SubElement(channel, 'description').text = f"Message feed from {title}"
+
+    for message in messages:
+        item = ET.SubElement(channel, 'item')
+        header = message.header
+        dt = _parse_qwk_date(header.msgdate, header.msgtime)
+        pub_date = email.utils.format_datetime(dt)
+
+        ET.SubElement(item, 'title').text = header.msgsubject.strip() or "(no subject)"
+        ET.SubElement(item, 'author').text = header.msgfrom.strip()
+        ET.SubElement(item, 'pubDate').text = pub_date
+        ET.SubElement(item, 'description').text = message.text
+
+        guid = f"{header.confnum}.{header.msgnum if header.msgnum is not None else id(message)}@qwk"
+        ET.SubElement(item, 'guid', isPermaLink='false').text = guid
+
+    rss_text = _xml_element_to_str(rss)
+    _write_text_output(rss_text, output_path, encoding='utf-8')
+
+
 def _get_html_header(title: str) -> list[str]:
     return [
         '<!DOCTYPE html>',
@@ -3787,6 +3826,7 @@ def write_messages(
         'csv': _write_csv,
         'mbox': _write_mbox,
         'eml': _write_eml,
+        'rss': _write_rss,
         'sqlite': _write_sqlite,
         'qwk': _write_qwk,
         'rep': _write_qwk,

--- a/tests/test_rss_export.py
+++ b/tests/test_rss_export.py
@@ -1,0 +1,74 @@
+import os
+import xml.etree.ElementTree as ET
+from pyqwk.core import ParsedMessage, MessageHeader, ProcessingSettings, write_messages, BBSInfo
+
+def test_rss_export(tmp_path):
+    output_path = tmp_path / "test.rss"
+
+    msg1 = ParsedMessage(
+        text="Hello World",
+        msgnum=1,
+        refnum=None,
+        confnum=1,
+        header=MessageHeader(
+            status=" ",
+            msgnum=1,
+            msgdate="01-01-24",
+            msgtime="12:00",
+            msgto="Everyone",
+            msgfrom="Sysop",
+            msgsubject="Test Message",
+            msgpassword="",
+            refnum=None,
+            numblocks=None,
+            msgflag=" ",
+            confnum=1,
+            lognum=0,
+            nettag="",
+        ),
+        confname="General",
+        bbs_name="Test BBS"
+    )
+
+    settings = ProcessingSettings(
+        verbose=False,
+        private=True,
+        no_header=False,
+        truncate_signatures=False,
+        cut_quoting=False,
+        individual_files=False,
+        threaded=False,
+        binaries_removal=False,
+        redact_pii=False,
+        format='rss',
+        separator='none',
+        output_mode='file',
+        output_path=str(output_path),
+        encoding='utf-8',
+    )
+
+    bbs_info = BBSInfo(name="Test BBS")
+
+    write_messages([msg1], str(output_path), settings, bbs_info=bbs_info)
+
+    assert output_path.exists()
+
+    tree = ET.parse(output_path)
+    root = tree.getroot()
+
+    assert root.tag == 'rss'
+    assert root.attrib['version'] == '2.0'
+
+    channel = root.find('channel')
+    assert channel is not None
+    assert channel.find('title').text == "Test BBS Archive"
+
+    items = channel.findall('item')
+    assert len(items) == 1
+
+    item = items[0]
+    assert item.find('title').text == "Test Message"
+    assert item.find('author').text == "Sysop"
+    assert item.find('description').text == "Hello World"
+    # Guid should be present
+    assert item.find('guid').text == "1.1@qwk"


### PR DESCRIPTION
This PR implements RSS 2.0 export support for message archives.

### Key Changes:
- **Core Engine:** Added `_write_rss` to `pyqwk/core.py`. It generates a compliant RSS 2.0 feed with message subjects as titles, authors, and RFC 822 formatted timestamps.
- **CLI:** Updated `pyqwk/cli.py` to expose the `rss` format to users.
- **Interoperability:** Added `.rss` to the automatically recognized output extensions.
- **Tests:** Added `tests/test_rss_export.py` to ensure XML validity and correct data mapping.
- **Docs:** Updated `README.md` to reflect the new capability.

This feature enables users to serve BBS archive content to modern feed readers, enhancing the tool's utility for preservation and accessibility.

---
*PR created automatically by Jules for task [9032781906260948546](https://jules.google.com/task/9032781906260948546) started by @RainRat*