### PR TITLE
Fix empty attachments handling in HTML and Markdown imports

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -1232,7 +1232,11 @@ def _parse_html_messages(path: str) -> list[ParsedMessage]:
 
         attachments = None
         if attach_match:
-            attachments = [clean_html(a) for a in attach_match.group(1).split(',')]
+            attachments = [
+                clean_html(a) for a in attach_match.group(1).split(',') if clean_html(a)
+            ]
+            if not attachments:
+                attachments = None
 
         body = ""
         body_match = re_body.search(block)
@@ -1380,6 +1384,8 @@ def _parse_markdown_messages(path: str) -> list[ParsedMessage]:
                 attachments = re.findall(r'\[(.*?)\]', attach_str)
             else:
                 attachments = [a.strip() for a in attach_str.split(',') if a.strip()]
+            if not attachments:
+                attachments = None
 
         # Message body: everything after the information lines
         # In our Markdown format, metadata ends at the first blank line.


### PR DESCRIPTION
This change improves the robustness of message parsing from HTML and Markdown files. Specifically:
- In `_parse_html_messages`, attachment strings are now cleaned and filtered to remove empty or whitespace-only entries.
- If the resulting attachment list is empty, it is normalized to `None`.
- Similar normalization is applied to `_parse_markdown_messages`.

These adjustments ensure that `ParsedMessage` objects consistently use `None` for absent attachments, which is necessary for the lazy discovery logic in `matches_filters` to correctly scan message bodies for embedded binaries when search or attachment filters are active.

---
*PR created automatically by Jules for task [15325883910335842950](https://jules.google.com/task/15325883910335842950) started by @RainRat*