### PR TITLE
[FEAT] Add RSS 2.0 Import Support

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -41,7 +41,7 @@ def expand_paths(paths: list[str]) -> list[str]:
             for root, _, files in os.walk(path):
                 for file in files:
                     lower_file = file.lower()
-                    if lower_file.endswith(('.qwk', '.zip', '.rep', '.json', '.jsonl', '.csv', '.db', '.sqlite', '.xml', '.mbox', '.eml', '.md', '.markdown', '.html', '.htm')) or lower_file == 'messages.dat':
+                    if lower_file.endswith(('.qwk', '.zip', '.rep', '.json', '.jsonl', '.csv', '.db', '.sqlite', '.xml', '.rss', '.mbox', '.eml', '.md', '.markdown', '.html', '.htm')) or lower_file == 'messages.dat':
                         expanded_paths.append(os.path.join(root, file))
         else:
             expanded_paths.append(path)
@@ -970,6 +970,78 @@ def _safe_to_int(v: Any) -> int | None:
         return None
 
 
+def _parse_rss_messages(root: ET.Element) -> list[ParsedMessage]:
+    """Convert an RSS XML tree into ParsedMessage objects."""
+    messages = []
+    channel = root.find('channel')
+    if channel is None:
+        return messages
+
+    # Global BBS info from channel title/description if available
+    channel_title = channel.findtext('title') or ""
+    if channel_title == 'QWK Message Archive':
+        bbs_name = ""
+    else:
+        bbs_name = channel_title.removesuffix(' Archive') if channel_title.endswith(' Archive') else channel_title
+
+    for item in channel.findall('item'):
+        title = item.findtext('title') or ""
+        author = item.findtext('author') or ""
+        pub_date_str = item.findtext('pubDate')
+        guid = item.findtext('guid') or ""
+        description = item.findtext('description') or ""
+        category = item.findtext('category') or ""
+
+        # Parse date
+        msg_date = "01-01-70"
+        msg_time = "00:00"
+        if pub_date_str:
+            try:
+                dt = email.utils.parsedate_to_datetime(pub_date_str)
+                msg_date = dt.strftime('%m-%d-%y')
+                msg_time = dt.strftime('%H:%M')
+            except (ValueError, TypeError):
+                pass
+
+        # Parse GUID: {confnum}.{msgnum}@qwk
+        confnum = 0
+        msgnum = None
+        if '@qwk' in guid:
+            parts = guid.split('@')[0].split('.')
+            if len(parts) == 2:
+                confnum = _safe_to_int(parts[0]) or 0
+                msgnum = _safe_to_int(parts[1])
+
+        header = MessageHeader(
+            status=' ',
+            msgnum=msgnum,
+            msgdate=msg_date,
+            msgtime=msg_time,
+            msgto='All',
+            msgfrom=author,
+            msgsubject=title,
+            msgpassword='',
+            refnum=None,
+            numblocks=None,
+            msgflag=' ',
+            confnum=confnum,
+            lognum=0,
+            nettag=' ',
+        )
+
+        msg = ParsedMessage(
+            text=description,
+            msgnum=msgnum,
+            refnum=None,
+            confnum=confnum,
+            header=header,
+            confname=category or None,
+            bbs_name=bbs_name or None,
+        )
+        messages.append(msg)
+    return messages
+
+
 def _parse_xml_messages(root: ET.Element) -> list[ParsedMessage]:
     """Convert an XML tree into ParsedMessage objects."""
     messages = []
@@ -1552,11 +1624,14 @@ def load_data(
         board_dict = _reconstruct_archive_information(messages)
         return messages, board_dict
 
-    if input_path.lower().endswith('.xml'):
+    if input_path.lower().endswith(('.xml', '.rss')):
         try:
             tree = ET.parse(input_path)
             root = tree.getroot()
-            messages = _parse_xml_messages(root)
+            if input_path.lower().endswith('.rss') or root.tag == 'rss':
+                messages = _parse_rss_messages(root)
+            else:
+                messages = _parse_xml_messages(root)
         except Exception as e:
             raise ValueError(f"Failed to load XML archive: {e}")
 

--- a/tests/test_rss_import.py
+++ b/tests/test_rss_import.py
@@ -1,0 +1,75 @@
+import os
+import logging
+from pyqwk.core import load_data, ProcessedMessage, ProcessingSettings
+
+def test_rss_roundtrip(tmp_path):
+    # Create a dummy message
+    from pyqwk.core import MessageHeader, ParsedMessage, _write_rss
+
+    header = MessageHeader(
+        status=' ',
+        msgnum=123,
+        msgdate='05-20-24',
+        msgtime='14:30',
+        msgto='All',
+        msgfrom='Tester',
+        msgsubject='Test RSS',
+        msgpassword='',
+        refnum=None,
+        numblocks=None,
+        msgflag=' ',
+        confnum=10,
+        lognum=0,
+        nettag=' ',
+    )
+
+    msg = ParsedMessage(
+        text='This is a test message for RSS roundtrip.',
+        msgnum=123,
+        refnum=None,
+        confnum=10,
+        header=header,
+        confname='Test Conference',
+        bbs_name='Test BBS',
+    )
+
+    from pyqwk.core import BBSInfo
+    rss_file = tmp_path / "test.rss"
+    _write_rss([msg], str(rss_file), bbs_info=BBSInfo(name='Test BBS'))
+
+    # Load it back
+    logger = logging.getLogger("test")
+    messages, board_dict = load_data(str(rss_file), logger)
+
+    assert len(messages) == 1
+    loaded_msg = messages[0]
+
+    assert loaded_msg.text == msg.text
+    assert loaded_msg.msgnum == msg.msgnum
+    assert loaded_msg.confnum == msg.confnum
+    assert loaded_msg.header.msgfrom.strip() == msg.header.msgfrom.strip()
+    assert loaded_msg.header.msgsubject.strip() == msg.header.msgsubject.strip()
+    # RSS format uses RFC 822 for dates, so precision might differ but should be close
+    assert loaded_msg.header.msgdate == msg.header.msgdate
+    assert loaded_msg.header.msgtime == msg.header.msgtime
+    assert loaded_msg.bbs_name == 'Test BBS'
+    assert loaded_msg.confname == 'Test Conference'
+
+def test_rss_import_from_cli_generated_file(tmp_path):
+    # Use an actual test archive to generate RSS and read it back
+    import subprocess
+    import sys
+
+    input_zip = "testdata/test1_qwk.zip"
+    rss_output = tmp_path / "output.rss"
+
+    # Run cli to generate rss
+    subprocess.run([sys.executable, "qwk.py", input_zip, "--format", "rss", "-o", str(rss_output)], check=True)
+
+    # Read it back with load_data
+    logger = logging.getLogger("test")
+    messages, board_dict = load_data(str(rss_output), logger)
+
+    assert len(messages) > 0
+    assert messages[0].header.msgsubject.startswith("Re: Fujitsu hard drive")
+    assert messages[0].bbs_name == "Benden Weyr, Pern, Sagittarius Sector"


### PR DESCRIPTION
**PR Title:** [FEAT] Add RSS 2.0 Import Support

**Description:**
* **What:** Added the ability to import message archives from RSS 2.0 feeds. This includes parsing standard RSS fields like `<title>`, `<author>`, `<pubDate>`, and `<description>`, as well as reconstructing QWK-specific metadata (message numbers and conference numbers) from the `<guid>` tag.
* **Why:** I noticed that while the codebase had a robust RSS 2.0 export feature, it lacked the corresponding import capability. Following the "Symmetry" heuristic, adding RSS import allows users to re-import archives they previously exported to RSS, or use RSS feeds from other sources as input for pyqwk's processing and conversion tools.

**Changes:**
- Modified `pyqwk/core.py` to add `_parse_rss_messages` and update `load_data` and `expand_paths`.
- Created `tests/test_rss_import.py` to verify the new functionality.

---
*PR created automatically by Jules for task [6832060454869186983](https://jules.google.com/task/6832060454869186983) started by @RainRat*