### PR TITLE
[UI/UX] Implement seamless cross-message search navigation in Graphical Reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ qwk-gui messages.db
 ```
 
 **Key Features:**
-- **Search:** Find messages by keyword or use "Regex" for advanced patterns. Cycle through matches with **F3** or **Shift + F3**. You can also right-click any highlighted text to search for it instantly.
+- **Search:** Find messages by keyword or use "Regex" for advanced patterns. Traversal is seamless: cycle through matches with **F3** or **Shift + F3**, and the reader will automatically move to the next or previous message when you reach the end of the current one. You can also right-click any highlighted text to search for it instantly.
 - **Attachments:** Click attachment links in the header to save files. Use **File > Extract All Attachments...** to save all files from your current view.
 - **Filtering:** Narrow your view by BBS, conference, author, or recipient. You can also filter for private messages or messages with attachments.
 - **Context Menus:** Right-click a message to copy its details or filter the view by its author or conference.

--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -60,6 +60,7 @@ class QwkGuiApp:
         self.bbs_mapping = {}
         self._search_matches = []
         self._current_match_idx = -1
+        self._pending_match_idx: int | None = None
 
         self.column_labels = {
             "#0": "Subject",
@@ -481,18 +482,22 @@ class QwkGuiApp:
             traverse(root_item)
         return items
 
-    def _select_relative_message(self, delta: int, force: bool = False) -> None:
-        """Move the selection up or down in the treeview display order."""
+    def _select_relative_message(self, delta: int, force: bool = False) -> bool:
+        """Move the selection up or down in the treeview display order.
+
+        Returns:
+            True if the selection changed, False otherwise.
+        """
         if not self.messages:
-            return
+            return False
 
         # If the search entry has focus, don't hijack keyboard navigation unless forced
         if not force and self.root.focus_get() == self.search_entry:
-            return
+            return False
 
         all_items = self._get_all_tree_items()
         if not all_items:
-            return
+            return False
 
         current_selection = self.message_list.selection()
         if not current_selection:
@@ -503,12 +508,15 @@ class QwkGuiApp:
                 current_idx = all_items.index(current_iid)
                 new_idx = max(0, min(len(all_items) - 1, current_idx + delta))
                 new_item = all_items[new_idx]
+                if new_item == current_iid:
+                    return False
             except ValueError:
                 new_item = all_items[0]
 
         self.message_list.selection_set(new_item)
         self.message_list.see(new_item)
         self.message_list.focus(new_item)
+        return True
 
     def clear_search(self, _event: object | None = None) -> None:
         """Clear the search bar first, and if already empty, reset all filters."""
@@ -1045,43 +1053,79 @@ class QwkGuiApp:
 
             self.detail_text.tag_raise("search_highlight")
             if self._search_matches:
-                self._current_match_idx = 0
-                self.detail_text.see(self._search_matches[0][0])
-                self.detail_text.tag_add("current_search_highlight", self._search_matches[0][0], self._search_matches[0][1])
+                # Determine initial match index
+                if self._pending_match_idx is not None:
+                    self._current_match_idx = self._pending_match_idx % len(self._search_matches)
+                    self._pending_match_idx = None
+                else:
+                    self._current_match_idx = 0
+
+                start_pos, end_pos = self._search_matches[self._current_match_idx]
+                self.detail_text.see(start_pos)
+                self.detail_text.tag_add("current_search_highlight", start_pos, end_pos)
                 self.detail_text.tag_raise("current_search_highlight")
 
                 # Update counters
-                self.search_count_label.config(text=f"1 / {len(self._search_matches)}")
+                self.search_count_label.config(text=f"{self._current_match_idx + 1} / {len(self._search_matches)}")
 
                 # Update status feedback
                 source_display = self.root.title().split(" - ")[0]
                 self.status_label.config(
-                    text=f"Match 1 of {len(self._search_matches)}  •  Showing {len(self.messages)} messages from {source_display}"
+                    text=f"Match {self._current_match_idx + 1} of {len(self._search_matches)}  •  Showing {len(self.messages)} messages from {source_display}"
                 )
             else:
                 self.search_count_label.config(text="0 / 0")
 
     def _navigate_search_matches(self, delta: int, _event: object | None = None) -> None:
-        """Cycle through search matches in the detail view."""
+        """Cycle through search matches in the detail view, navigating across messages if needed."""
         if not self._search_matches:
+            # If no matches in current message, but search is active, try to find in other messages
+            if self.search_var.get().strip():
+                if self._select_relative_message(delta, force=True):
+                    self._pending_match_idx = 0 if delta > 0 else -1
+                    return
             return
 
-        # Remove existing current highlight
+        new_idx = self._current_match_idx + delta
+
+        # Cross-message navigation
+        if new_idx < 0 or new_idx >= len(self._search_matches):
+            if self._select_relative_message(delta, force=True):
+                self._pending_match_idx = 0 if delta > 0 else -1
+                return
+            else:
+                # Boundary reached, implement archive-wide wrap-around
+                all_items = self._get_all_tree_items()
+                if not all_items:
+                    return
+                target_iid = all_items[0] if delta > 0 else all_items[-1]
+
+                # Handle case where the wrap-around target is the current message
+                current_sel = self.message_list.selection()
+                if current_sel and current_sel[0] == target_iid:
+                    # Manually trigger render since selection_set won't trigger event
+                    self._pending_match_idx = 0 if delta > 0 else -1
+                    try:
+                        self._render_message(int(target_iid))
+                    except (ValueError, IndexError):
+                        pass
+                else:
+                    self.message_list.selection_set(target_iid)
+                    self.message_list.see(target_iid)
+                    self.message_list.focus(target_iid)
+                    self._pending_match_idx = 0 if delta > 0 else -1
+                return
+
+        # Single-message navigation
         self.detail_text.tag_remove("current_search_highlight", "1.0", tk.END)
-
-        # Update index
-        self._current_match_idx = (self._current_match_idx + delta) % len(self._search_matches)
-
-        # Apply new highlight and scroll
+        self._current_match_idx = new_idx
         start_pos, end_pos = self._search_matches[self._current_match_idx]
         self.detail_text.tag_add("current_search_highlight", start_pos, end_pos)
         self.detail_text.tag_raise("current_search_highlight")
         self.detail_text.see(start_pos)
 
-        # Update counters
+        # Update counters and status
         self.search_count_label.config(text=f"{self._current_match_idx + 1} / {len(self._search_matches)}")
-
-        # Update status feedback
         source_display = self.root.title().split(" - ")[0]
         self.status_label.config(
             text=f"Match {self._current_match_idx + 1} of {len(self._search_matches)}  •  Showing {len(self.messages)} messages from {source_display}"

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -565,14 +565,13 @@ class TestQwkGui:
         app._select_relative_message(1)
         app.message_list.selection_set.assert_called_with("1")
 
-        # Selection at index 2 -> move to next (stay at 2)
+        # Selection at index 2 -> move to next (stay at 2, returns False)
         app.message_list.selection.return_value = ("2",)
-        app._select_relative_message(1)
-        app.message_list.selection_set.assert_called_with("2")
+        assert app._select_relative_message(1) is False
 
         # Move back
         app.message_list.selection.return_value = ("1",)
-        app._select_relative_message(-1)
+        assert app._select_relative_message(-1) is True
         app.message_list.selection_set.assert_called_with("0")
 
     def test_render_message_stripping(self, mock_gui_deps):

--- a/tests/test_gui_search_nav_cross.py
+++ b/tests/test_gui_search_nav_cross.py
@@ -1,0 +1,110 @@
+import sys
+from unittest.mock import MagicMock, patch
+import pytest
+import tkinter as tk
+
+# Mock tkinter before any pyqwk.gui imports
+mock_tk = MagicMock()
+mock_ttk = MagicMock()
+sys.modules["tkinter"] = mock_tk
+sys.modules["tkinter.filedialog"] = MagicMock()
+sys.modules["tkinter.messagebox"] = MagicMock()
+sys.modules["tkinter.ttk"] = mock_ttk
+sys.modules["tkinter.simpledialog"] = MagicMock()
+
+from pyqwk.gui import QwkGuiApp
+from pyqwk.core import ParsedMessage, MessageHeader
+
+@pytest.fixture
+def app():
+    root = MagicMock()
+    root.title.return_value = "pyqwk - Graphical Reader"
+    with patch("pyqwk.gui.tk") as m_tk, \
+         patch("pyqwk.gui.ttk") as m_ttk, \
+         patch("pyqwk.gui.simpledialog"):
+
+        m_tk.BooleanVar.side_effect = lambda **kwargs: MagicMock()
+        m_tk.StringVar.side_effect = lambda **kwargs: MagicMock()
+        m_tk.IntVar.side_effect = lambda **kwargs: MagicMock()
+
+        # Define constants used in _navigate_search_matches
+        m_tk.END = "end"
+
+        app = QwkGuiApp(root)
+        app.message_list = MagicMock()
+        app.detail_text = MagicMock()
+        app.status_label = MagicMock()
+        app.search_count_label = MagicMock()
+        app.search_var.get.return_value = "test"
+        return app
+
+def test_render_message_with_pending_match(app):
+    """Test that _render_message respects _pending_match_idx."""
+    header = MessageHeader(' ', 1, "01-01-90", "12:00", "To", "From", "Sub", "", None, 1, " ", 1, 1, "")
+    app.messages = [ParsedMessage("test test", 1, None, 1, header)]
+
+    # Mock search to find two matches
+    mock_count_var = MagicMock()
+    mock_count_var.get.return_value = 4
+    with patch("pyqwk.gui.tk.IntVar", return_value=mock_count_var):
+        def mock_search(pattern, start, **kwargs):
+            if start == "1.0": return "1.10"
+            if start == "1.10+4c": return "1.20"
+            return None
+        app.detail_text.search.side_effect = mock_search
+        app.detail_text.tag_ranges.return_value = []
+
+        # Use -1 to land on the last match
+        app._pending_match_idx = -1
+        app._render_message(0)
+
+        assert len(app._search_matches) == 2
+        assert app._current_match_idx == 1
+        assert app._pending_match_idx is None
+        # 2nd match is at 1.20
+        app.detail_text.see.assert_called_with("1.20")
+
+def test_navigate_across_messages(app):
+    """Test that _navigate_search_matches moves to the next message."""
+    app._search_matches = [("1.0", "1.5")]
+    app._current_match_idx = 0
+    app._select_relative_message = MagicMock(return_value=True)
+
+    # Move forward from the last match
+    app._navigate_search_matches(1)
+
+    app._select_relative_message.assert_called_with(1, force=True)
+    assert app._pending_match_idx == 0
+
+def test_navigate_across_messages_backward(app):
+    """Test that _navigate_search_matches moves to the previous message."""
+    app._search_matches = [("1.0", "1.5")]
+    app._current_match_idx = 0
+    app._select_relative_message = MagicMock(return_value=True)
+
+    # Move backward from the first match
+    app._navigate_search_matches(-1)
+
+    app._select_relative_message.assert_called_with(-1, force=True)
+    assert app._pending_match_idx == -1
+
+def test_navigate_wrap_around_single_message(app):
+    """Test that _navigate_search_matches wraps around in a single-message archive."""
+    app._search_matches = [("1.0", "1.5"), ("2.0", "2.5")]
+    app._current_match_idx = 1 # On last match
+    app._select_relative_message = MagicMock(return_value=False)
+    app._get_all_tree_items = MagicMock(return_value=["0"])
+    app.message_list.selection.return_value = ("0",)
+
+    with patch.object(app, "_render_message") as mock_render:
+        # Mock _render_message to actually reset _pending_match_idx as the real one would
+        def side_effect(idx):
+            app._pending_match_idx = None
+        mock_render.side_effect = side_effect
+
+        # Move forward from the last match
+        app._navigate_search_matches(1)
+
+        # Should manually trigger render for same-message wrap
+        mock_render.assert_called_with(0)
+        assert app._pending_match_idx is None

--- a/tests/test_lead_qa_gui_navigation_final.py
+++ b/tests/test_lead_qa_gui_navigation_final.py
@@ -38,9 +38,13 @@ def app():
         return app
 
 def test_navigate_search_matches_cycling(app):
-    """Test _navigate_search_matches cycling and UI updates (lines 1090-1110)."""
+    """Test _navigate_search_matches cycling and UI updates."""
     app._search_matches = [("1.0", "1.5"), ("2.0", "2.5")]
     app._current_match_idx = 0
+    # Mock _select_relative_message to return False (no other messages)
+    app._select_relative_message = MagicMock(return_value=False)
+    # Mock treeview items for wrap-around
+    app._get_all_tree_items = MagicMock(return_value=["0", "1"])
 
     # Cycle forward
     app._navigate_search_matches(1)
@@ -48,15 +52,19 @@ def test_navigate_search_matches_cycling(app):
     app.detail_text.tag_add.assert_called_with("current_search_highlight", "2.0", "2.5")
     app.search_count_label.config.assert_called_with(text="2 / 2")
 
-    # Cycle forward again (wrap around)
+    # Cycle forward again (wrap around archive-wide)
     app._navigate_search_matches(1)
-    assert app._current_match_idx == 0
-    app.detail_text.tag_add.assert_called_with("current_search_highlight", "1.0", "1.5")
-    app.search_count_label.config.assert_called_with(text="1 / 2")
+    app.message_list.selection_set.assert_called_with("0")
+    assert app._pending_match_idx == 0
 
-    # Cycle backward (wrap around to end)
+    # Reset for backward test
+    app._current_match_idx = 0
+    app.message_list.selection_set.reset_mock()
+
+    # Cycle backward (wrap around archive-wide)
     app._navigate_search_matches(-1)
-    assert app._current_match_idx == 1
+    app.message_list.selection_set.assert_called_with("1")
+    assert app._pending_match_idx == -1
 
 def test_on_search_changed_debouncing(app):
     """Test _on_search_changed debouncing logic (lines 1158-1160)."""

--- a/tests/test_search_navigation.py
+++ b/tests/test_search_navigation.py
@@ -106,10 +106,11 @@ class TestSearchNavigation:
         app._navigate_search_matches(-1)
         assert app._current_match_idx == 0
 
-        # Navigate backward again (wrap around to end)
+        # Navigate backward again (wrap around)
+        app._select_relative_message = MagicMock(return_value=False)
+        app._get_all_tree_items = MagicMock(return_value=["0", "1", "2"])
         app._navigate_search_matches(-1)
-        assert app._current_match_idx == 2
-        app.detail_text.see.assert_called_with("3.0")
+        assert app._pending_match_idx == -1
 
     def test_menu_and_bindings(self, mock_gui_deps):
         app = get_app()


### PR DESCRIPTION
This improvement reduces friction when searching through large message archives by allowing the user to cycle through all matches across all messages without manual list navigation. 

Previously, search navigation was confined to the currently active message. This required the user to manually select the next message if they wanted to continue searching. The new logic automatically selects the next/previous message when the match boundary is reached and implements a full archive wrap-around.

* **Context:** GUI
* **Problem:** Search navigation was isolated to single messages, forcing manual intervention to continue searching across an archive.
* **Solution:** Traversal now seamlessly crosses message boundaries. State management via `_pending_match_idx` ensures the correct match is highlighted immediately upon rendering a new message.


---
*PR created automatically by Jules for task [5019543010892543114](https://jules.google.com/task/5019543010892543114) started by @RainRat*