### PR TITLE
Refactor redundant byte size formatting into a unified helper

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -2211,6 +2211,16 @@ def _slugify(text: str, default: str) -> str:
     return slug if slug else default
 
 
+def format_size(size: int) -> str:
+    """Format byte count into a human-readable string (B, KB, MB)."""
+    if size < 1024:
+        return f"{size} B"
+    elif size < 1024 * 1024:
+        return f"{size / 1024:.1f} KB"
+    else:
+        return f"{size / (1024 * 1024):.1f} MB"
+
+
 def _generate_safe_filename(message: ParsedMessage, settings_or_format: ProcessingSettings | str, count: int) -> str:
     """Generate a human-readable filename for an individual message."""
     if isinstance(settings_or_format, ProcessingSettings):
@@ -2747,7 +2757,7 @@ def process_merged_files(
         else:
             print("Files to create:    1 (merged)")
 
-        size_str = f"{estimated_bytes / 1024:.1f} KB" if estimated_bytes < 1024 * 1024 else f"{estimated_bytes / (1024 * 1024):.1f} MB"
+        size_str = format_size(estimated_bytes)
         print(f"Estimated size:     {size_str}")
         print(f"{_colorize('No changes were made to the disk.', BOLD)}")
 

--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -12,6 +12,7 @@ from tkinter import filedialog, messagebox, ttk, simpledialog
 from pyqwk.core import (
     ProcessingSettings,
     _order_messages_by_thread,
+    format_size,
     load_data,
     parse_messages,
     process_message,
@@ -190,15 +191,6 @@ class QwkGuiApp:
             pass
 
         menu.post(event.x_root, event.y_root)
-
-    def _format_size(self, size: int) -> str:
-        """Format byte count into a human-readable string (B, KB, MB)."""
-        if size < 1024:
-            return f"{size} B"
-        elif size < 1024 * 1024:
-            return f"{size / 1024:.1f} KB"
-        else:
-            return f"{size / (1024 * 1024):.1f} MB"
 
     def _search_from_selection(self) -> None:
         """Search for the currently selected text in the detail viewer."""
@@ -1475,7 +1467,7 @@ class QwkGuiApp:
                         header.msgfrom.strip(),
                         header.msgto.strip(),
                         f"{header.msgdate} {header.msgtime}",
-                        self._format_size(len(message.text)) if message.text else "0 B",
+                        format_size(len(message.text)) if message.text else "0 B",
                         conf_name,
                         message.bbs_name or message.bbs_id or "",
                     ),

--- a/tests/test_gui_ultimate_coverage.py
+++ b/tests/test_gui_ultimate_coverage.py
@@ -26,7 +26,7 @@ if "tkinter.simpledialog" not in sys.modules:
 
 import pyqwk.gui
 from pyqwk.gui import QwkGuiApp
-from pyqwk.core import ParsedMessage, MessageHeader
+from pyqwk.core import ParsedMessage, MessageHeader, format_size
 
 @pytest.fixture
 def app():
@@ -53,9 +53,9 @@ def app():
         return a
 
 def test_format_size_kb_mb(app):
-    """Cover lines 188-191: KB and MB formatting in _format_size."""
-    assert app._format_size(1500) == "1.5 KB"
-    assert app._format_size(2000000) == "1.9 MB"
+    """Cover KB and MB formatting in format_size."""
+    assert format_size(1500) == "1.5 KB"
+    assert format_size(2000000) == "1.9 MB"
 
 def test_show_stats_window_with_links(app):
     """Cover line 1545: Top Links in stats window."""


### PR DESCRIPTION
### What
Extracted identical byte size formatting logic (converting bytes to B, KB, or MB) from `pyqwk/gui.py` and `pyqwk/core.py` into a new public utility function `format_size` in `pyqwk/core.py`.

### Why
This change resolves code duplication (DRY principle) between the core engine and the graphical interface. By centralizing this utility, we ensure that both the CLI summary and the Graphical Reader's message list represent file sizes consistently. 

The refactor is non-breaking:
- The external behavior remains identical (with a minor improvement in `core.py` for very small files that now show as "B" instead of "0.0 KB").
- All existing tests (814 total) passed after updating the relevant test case that specifically targeted the removed private method.

---
*PR created automatically by Jules for task [3748639332547404760](https://jules.google.com/task/3748639332547404760) started by @RainRat*