### PR TITLE
[UI/UX] Add message navigation buttons to Graphical Reader toolbar

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -594,6 +594,15 @@ class QwkGuiApp:
 
         ttk.Separator(row1, orient=tk.VERTICAL).pack(side=tk.LEFT, fill=tk.Y, padx=10)
 
+        nav_frame = ttk.Frame(row1)
+        nav_frame.pack(side=tk.LEFT, padx=5)
+        ttk.Label(nav_frame, text="Msg:").pack(side=tk.LEFT)
+        ttk.Button(nav_frame, text="Prev", width=6, command=lambda: self._select_relative_message(-1)).pack(side=tk.LEFT, padx=(5, 2))
+        ttk.Button(nav_frame, text="Next", width=6, command=lambda: self._select_relative_message(1)).pack(side=tk.LEFT, padx=2)
+        ttk.Button(nav_frame, text="Jump", width=6, command=self.prompt_jump_to_message).pack(side=tk.LEFT, padx=2)
+
+        ttk.Separator(row1, orient=tk.VERTICAL).pack(side=tk.LEFT, fill=tk.Y, padx=10)
+
         search_frame = ttk.Frame(row1)
         search_frame.pack(side=tk.LEFT, padx=5)
         ttk.Label(search_frame, text="Search:").pack(side=tk.LEFT)


### PR DESCRIPTION
### [UI/UX] Add message navigation buttons to Graphical Reader toolbar

**Context:** GUI

**Problem:** 
Navigating between messages in the Graphical Reader currently requires either using keyboard shortcuts ('j', 'k', 'n', 'p') or manually clicking items in the message list. This can be high-friction for users who prefer mouse-based navigation or are unaware of the shortcuts.

**Solution:** 
Added a "Messages" navigation group to the toolbar containing "Prev", "Next", and "Jump" buttons. This improves discoverability of navigation features and provides a convenient mouse-driven alternative to existing keyboard shortcuts. The new group is logically separated from "File" actions and "Search" tools using vertical separators, maintaining a clean visual hierarchy and adhering to "Invisible Design" principles.

**Changes:**
- Inserted `nav_frame` within `row1` of the toolbar in `pyqwk/gui.py`.
- Added "Prev" (Next Message), "Next" (Previous Message), and "Jump" (Jump to Message Number) buttons.
- Integrated vertical separators for consistent logical grouping.
- Verified functionality via existing GUI test suites.

---
*PR created automatically by Jules for task [15491591142192990451](https://jules.google.com/task/15491591142192990451) started by @RainRat*