### PR TITLE
[UI/UX] Standardize Graphical Reader toolbar labels and improve search counter

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -372,7 +372,7 @@ class QwkGuiApp:
             ("Links", self.has_links_var),
             ("Emails", self.has_emails_var),
             ("Phones", self.has_phones_var),
-            ("ANSI", self.has_ansi_var),
+            ("Colors", self.has_ansi_var),
         ]:
             if var.get():
                 active_bools.append(text)
@@ -578,7 +578,7 @@ class QwkGuiApp:
 
         actions_frame = ttk.Frame(row1)
         actions_frame.pack(side=tk.LEFT, padx=5)
-        ttk.Label(actions_frame, text="File:").pack(side=tk.LEFT)
+        ttk.Label(actions_frame, text="File").pack(side=tk.LEFT)
         ttk.Button(actions_frame, text="Open", command=self.open_file).pack(side=tk.LEFT, padx=(5, 2))
         ttk.Button(actions_frame, text="Folder", command=self.open_folder).pack(side=tk.LEFT, padx=2)
         ttk.Button(actions_frame, text="Export", command=self.export_messages).pack(side=tk.LEFT, padx=2)
@@ -588,7 +588,7 @@ class QwkGuiApp:
 
         nav_frame = ttk.Frame(row1)
         nav_frame.pack(side=tk.LEFT, padx=5)
-        ttk.Label(nav_frame, text="Msg:").pack(side=tk.LEFT)
+        ttk.Label(nav_frame, text="Messages").pack(side=tk.LEFT)
         ttk.Button(nav_frame, text="Prev", width=6, command=lambda: self._select_relative_message(-1)).pack(side=tk.LEFT, padx=(5, 2))
         ttk.Button(nav_frame, text="Next", width=6, command=lambda: self._select_relative_message(1)).pack(side=tk.LEFT, padx=2)
         ttk.Button(nav_frame, text="Jump", width=6, command=self.prompt_jump_to_message).pack(side=tk.LEFT, padx=2)
@@ -597,7 +597,7 @@ class QwkGuiApp:
 
         search_frame = ttk.Frame(row1)
         search_frame.pack(side=tk.LEFT, padx=5)
-        ttk.Label(search_frame, text="Search:").pack(side=tk.LEFT)
+        ttk.Label(search_frame, text="Search").pack(side=tk.LEFT)
         self.search_entry = ttk.Entry(
             search_frame, textvariable=self.search_var, width=22
         )
@@ -606,7 +606,7 @@ class QwkGuiApp:
             search_frame, text="✕", width=2, command=lambda: self.search_var.set("")
         ).pack(side=tk.LEFT, padx=(0, 2))
 
-        self.search_count_label = ttk.Label(search_frame, text="", width=8, anchor=tk.CENTER)
+        self.search_count_label = ttk.Label(search_frame, text="", width=12, anchor=tk.CENTER)
         self.search_count_label.pack(side=tk.LEFT)
 
         ttk.Button(
@@ -626,7 +626,7 @@ class QwkGuiApp:
 
         archives_frame = ttk.Frame(row2)
         archives_frame.pack(side=tk.LEFT, padx=5)
-        ttk.Label(archives_frame, text="Archives:").pack(side=tk.LEFT)
+        ttk.Label(archives_frame, text="Archives").pack(side=tk.LEFT)
         self.bbs_combo = ttk.Combobox(archives_frame, state="readonly", width=18)
         self.bbs_combo.pack(side=tk.LEFT, padx=(5, 2))
         self.conf_combo = ttk.Combobox(archives_frame, state="readonly", width=18)
@@ -636,7 +636,7 @@ class QwkGuiApp:
 
         filters_frame = ttk.Frame(row2)
         filters_frame.pack(side=tk.LEFT, padx=5)
-        ttk.Label(filters_frame, text="Filters:").pack(side=tk.LEFT)
+        ttk.Label(filters_frame, text="Filters").pack(side=tk.LEFT)
         for text, var in [
             ("Attachments", self.has_attach_var),
             ("My Messages", self.mine_var),
@@ -644,7 +644,7 @@ class QwkGuiApp:
             ("Links", self.has_links_var),
             ("Emails", self.has_emails_var),
             ("Phones", self.has_phones_var),
-            ("ANSI", self.has_ansi_var),
+            ("Colors", self.has_ansi_var),
         ]:
             ttk.Checkbutton(
                 filters_frame, text=text, variable=var, command=self.reload_messages
@@ -654,7 +654,7 @@ class QwkGuiApp:
 
         options_frame = ttk.Frame(row2)
         options_frame.pack(side=tk.LEFT, padx=5)
-        ttk.Label(options_frame, text="View:").pack(side=tk.LEFT, padx=(0, 5))
+        ttk.Label(options_frame, text="View").pack(side=tk.LEFT, padx=(0, 5))
 
         for text, var, cmd in [
             ("Threaded", self.threaded_var, self.reload_messages),

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -80,7 +80,7 @@ class TestQwkGui:
         app.root.bind.assert_any_call("<Escape>", app.clear_search)
 
         # Verify toolbar elements
-        mock_gui_deps["ttk"].Label.assert_any_call(ANY, text="File:")
+        mock_gui_deps["ttk"].Label.assert_any_call(ANY, text="File")
         mock_gui_deps["ttk"].Button.assert_any_call(ANY, text="Open", command=app.open_file)
         mock_gui_deps["ttk"].Button.assert_any_call(ANY, text="Export", command=app.export_messages)
 

--- a/tests/test_ui_toolbar_consolidation.py
+++ b/tests/test_ui_toolbar_consolidation.py
@@ -22,12 +22,12 @@ def test_toolbar_consolidation():
         root = MagicMock()
         app = QwkGuiApp(root)
 
-        # Check that "Filters:" label exists
+        # Check that "Filters" label exists
         filter_label_calls = [
             call for call in mock_ttk.Label.call_args_list
-            if call[1].get('text') == "Filters:"
+            if call[1].get('text') == "Filters"
         ]
-        assert len(filter_label_calls) == 1, "Expected one 'Filters:' label"
+        assert len(filter_label_calls) == 1, "Expected one 'Filters' label"
 
         # Check that "Discovery:" label DOES NOT exist
         discovery_label_calls = [
@@ -39,7 +39,7 @@ def test_toolbar_consolidation():
         # Verify all 7 filter checkboxes exist
         expected_filters = {
             "Attachments", "My Messages", "On This Day",
-            "Links", "Emails", "Phones", "ANSI"
+            "Links", "Emails", "Phones", "Colors"
         }
 
         checkbutton_calls = [


### PR DESCRIPTION
This PR improves the Graphical Reader's UI/UX by standardizing toolbar labels and improving terminology for better clarity and accessibility.

Key changes:
- **Friction Reduction:** Renamed "ANSI" to "Colors" to use more intuitive terminology for non-technical users.
- **Visual Hierarchy:** Removed trailing colons from group labels (File, Messages, Search, Archives, Filters, View) to create a cleaner, modern "Invisible Design" look.
- **Feedback & Clarity:** Renamed "Msg" to "Messages" and increased the width of the search match counter to ensure feedback remains visible in large archives.
- **Consistency:** Updated corresponding unit tests (`tests/test_gui.py` and `tests/test_ui_toolbar_consolidation.py`) to ensure the test suite accurately reflects the current UI state.

---
*PR created automatically by Jules for task [3136372937464539472](https://jules.google.com/task/3136372937464539472) started by @RainRat*