### PR TITLE
[FEAT] Enhanced ZIP container support for nested and mixed formats

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -1559,7 +1559,7 @@ def load_data(
         Note: When loading an original 'MESSAGES.DAT' file, it automatically searches
         for a corresponding 'CONTROL.DAT' in the same folder to load conference names.
     """
-    board_dict: dict[int, str] = {}
+    board_dict = ConferenceMap()
 
     if input_path.lower().endswith(('.db', '.sqlite')) or input_path == ':memory:':
         try:
@@ -1647,41 +1647,85 @@ def load_data(
             return messages, board_dict
 
     if zipfile.is_zipfile(input_path):
-        messages_name = ''
-        reply_name = ''
-        control_name = ''
-
         # First try using Python's built-in zipfile
         try:
             with zipfile.ZipFile(input_path) as myzip:
                 file_list = myzip.namelist()
-                for file_name in file_list:
-                    lower_name = file_name.lower()
-                    if lower_name == MESSAGES_FILENAME:
-                        messages_name = file_name
-                    elif lower_name == REPLY_FILENAME:
-                        reply_name = file_name
-                    if lower_name == CONTROL_FILENAME:
-                        control_name = file_name
+
+                messages_paths = []
+                reply_paths = []
+                other_paths = []
+
+                supported_others = ('.json', '.jsonl', '.csv', '.db', '.sqlite', '.xml', '.rss', '.mbox', '.eml', '.md', '.markdown', '.html', '.htm')
+
+                for f_name in file_list:
+                    lower_f = f_name.lower()
+                    base_f = os.path.basename(lower_f)
+
+                    if base_f == MESSAGES_FILENAME:
+                        messages_paths.append(f_name)
+                    elif base_f == REPLY_FILENAME:
+                        reply_paths.append(f_name)
+                    elif lower_f.endswith(supported_others):
+                        other_paths.append(f_name)
 
                 # Prioritize MESSAGES.DAT, then REPLY.DAT
-                actual_messages_name = messages_name or reply_name
+                actual_messages_path = None
+                if messages_paths:
+                    # Prefer root or shallowest path
+                    actual_messages_path = sorted(messages_paths, key=lambda x: x.count('/'))[0]
+                elif reply_paths:
+                    actual_messages_path = sorted(reply_paths, key=lambda x: x.count('/'))[0]
 
-                if not actual_messages_name:
-                    raise FileNotFoundError(
-                        f"Error: Neither '{MESSAGES_FILENAME}' nor '{REPLY_FILENAME}' found in the zip archive {input_path}."
-                    )
-                
-                # Check if we can actually read the messages file
-                with myzip.open(actual_messages_name) as f:
-                    file_data = bytearray(f.read())
-                
-                if control_name:
-                    with myzip.open(control_name) as f:
-                        control_data = f.read().splitlines()
-                    board_dict = _parse_control_dat(control_data, logger, encoding)
-                else:
-                    logger.warning("CONTROL.DAT not found, conference names will not be available.")
+                if actual_messages_path:
+                    # Look for CONTROL.DAT in the same directory
+                    target_dir = os.path.dirname(actual_messages_path)
+                    control_path = None
+                    for f_name in file_list:
+                        if os.path.dirname(f_name) == target_dir and os.path.basename(f_name).lower() == CONTROL_FILENAME:
+                            control_path = f_name
+                            break
+
+                    with myzip.open(actual_messages_path) as f:
+                        file_data = bytearray(f.read())
+
+                    if control_path:
+                        with myzip.open(control_path) as f:
+                            control_data = f.read().splitlines()
+                        board_dict = _parse_control_dat(control_data, logger, encoding)
+                    else:
+                        logger.warning("CONTROL.DAT not found in the same directory as %s.", actual_messages_path)
+                        board_dict = ConferenceMap()
+
+                    return file_data, board_dict
+
+                # If no QWK files, look for other supported formats
+                if other_paths:
+                    # Pick the shallowest supported file
+                    actual_other_path = sorted(other_paths, key=lambda x: x.count('/'))[0]
+
+                    # Extract to temp file because some parsers expect a real path
+                    ext = os.path.splitext(actual_other_path)[1]
+                    with tempfile.NamedTemporaryFile(suffix=ext, delete=False) as tmp:
+                        with myzip.open(actual_other_path) as f:
+                            tmp.write(f.read())
+                        tmp_path = tmp.name
+
+                    try:
+                        # Recursively call load_data on the extracted file
+                        messages, board_dict = load_data(tmp_path, logger, encoding)
+                        if isinstance(messages, list):
+                            for m in messages:
+                                if not m.source_file:
+                                    m.source_file = f"{os.path.basename(input_path)}/{actual_other_path}"
+                        return messages, board_dict
+                    finally:
+                        if os.path.exists(tmp_path):
+                            os.remove(tmp_path)
+
+                raise FileNotFoundError(
+                    f"Error: No supported message files found in the zip archive {input_path}."
+                )
                     
         except (RuntimeError, NotImplementedError, zipfile.BadZipFile) as e:
             # Fallback to system 'unzip' if built-in zipfile fails (e.g., unsupported compression)

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -50,8 +50,7 @@ def test_load_data_raises_if_messages_dat_missing_in_zip(
     with pytest.raises(FileNotFoundError) as exc_info:
         load_data(str(zip_path), logger)
 
-    assert MESSAGES_FILENAME in str(exc_info.value)
-    assert "Neither" in str(exc_info.value)
+    assert "No supported message files found" in str(exc_info.value)
     assert "found in the zip archive" in str(exc_info.value)
 
 def test_process_merged_files_raises_if_stdout_with_output_path(

--- a/tests/test_zip_container.py
+++ b/tests/test_zip_container.py
@@ -1,0 +1,82 @@
+import os
+import zipfile
+import logging
+import pytest
+from pyqwk.core import load_data, BLOCK_SIZE, MESSAGES_FILENAME, CONTROL_FILENAME
+
+@pytest.fixture
+def logger():
+    return logging.getLogger("test_zip")
+
+def test_load_zip_containing_json(tmp_path, logger):
+    json_content = '[{"header": {"confnum": 1, "msgfrom": "TestAuthor", "msgsubject": "TestSubject", "msgdate": "01-01-24", "msgtime": "12:00", "status": " "}, "text": "Test message body"}]'
+    json_file = tmp_path / "messages.json"
+    json_file.write_text(json_content)
+
+    zip_path = tmp_path / "container.zip"
+    with zipfile.ZipFile(zip_path, "w") as z:
+        z.write(json_file, "messages.json")
+
+    messages, board_dict = load_data(str(zip_path), logger)
+
+    assert len(messages) == 1
+    assert messages[0].header.msgfrom == "TestAuthor"
+    assert messages[0].text == "Test message body"
+    assert "container.zip/messages.json" in messages[0].source_file
+
+def test_load_zip_containing_nested_qwk(tmp_path, logger):
+    # Create a dummy MESSAGES.DAT
+    msg_dat = bytearray(BLOCK_SIZE * 2)
+    msg_dat[0:BLOCK_SIZE] = "Produced by pyqwk".ljust(BLOCK_SIZE).encode('cp437')
+
+    # 128-byte header
+    # status ' ', msgnum 1, date '01-01-24', time '12:00', to 'All', from 'Author', subj 'Subj', pass '', ref 0, blocks 2, flag ' ', conf 1, log 0, net ' '
+    # struct.pack('<c7s8s5s25s25s25s12s8s6scHHc', ...)
+    import struct
+    header = struct.pack(
+        '<c7s8s5s25s25s25s12s8s6scHHc',
+        b' ', b'      1', b'01-01-24', b'12:00', b'All'.ljust(25), b'Author'.ljust(25),
+        b'Subj'.ljust(25), b''.ljust(12), b'       0', b'     2', b' ', 1, 0, b' '
+    )
+    msg_dat[BLOCK_SIZE:BLOCK_SIZE+128] = header
+
+    # Create a dummy CONTROL.DAT
+    control_content = [b"BBS Name", b"Loc", b"123", b"Sysop", b"1,ID", b"At", b"User", b"", b"", b"", b"0", b"1", b"General"]
+
+    zip_path = tmp_path / "nested_qwk.zip"
+    with zipfile.ZipFile(zip_path, "w") as z:
+        z.writestr("subfolder/MESSAGES.DAT", msg_dat)
+        z.writestr("subfolder/CONTROL.DAT", b"\r\n".join(control_content) + b"\r\n")
+
+    file_data, board_dict = load_data(str(zip_path), logger)
+
+    assert isinstance(file_data, bytearray)
+    assert 1 in board_dict
+    assert board_dict[1] == "General"
+    assert board_dict.bbs_info.name == "BBS Name"
+
+def test_load_zip_multiple_formats_priority(tmp_path, logger):
+    # ZIP with both JSON and CSV. Should pick the first one (shallowest).
+    # We'll put them at different depths to be sure.
+
+    json_content = '[{"header": {"confnum": 1, "msgfrom": "JSON", "msgsubject": "JSON"}, "text": "JSON"}]'
+    csv_content = 'confnum,msgfrom,msgsubject,text\n2,CSV,CSV,CSV'
+
+    zip_path = tmp_path / "multi.zip"
+    with zipfile.ZipFile(zip_path, "w") as z:
+        z.writestr("a_json/messages.json", json_content)
+        z.writestr("b_csv.csv", csv_content) # Shallowest
+
+    messages, board_dict = load_data(str(zip_path), logger)
+
+    # b_csv.csv is shallowest (0 slashes vs 1 slash)
+    assert len(messages) == 1
+    assert messages[0].header.msgfrom == "CSV"
+
+def test_load_zip_empty_or_unsupported(tmp_path, logger):
+    zip_path = tmp_path / "empty.zip"
+    with zipfile.ZipFile(zip_path, "w") as z:
+        z.writestr("random.txt", "nothing interesting here")
+
+    with pytest.raises(FileNotFoundError, match="No supported message files found"):
+        load_data(str(zip_path), logger)


### PR DESCRIPTION
### **PR Title:** [FEAT] Enhanced ZIP container support for nested and mixed formats

#### **Description:**
* **What:** Enhanced the `load_data` function in `pyqwk/core.py` to handle ZIP archives as general-purpose containers. It now recursively searches for QWK/REP files (`MESSAGES.DAT`, `REPLY.DAT`, `CONTROL.DAT`) anywhere within the archive. Additionally, if no QWK files are found, it identifies and loads modern formats (JSON, CSV, SQLite, etc.) stored inside the ZIP.
* **Why:** I noticed that while the tool supports many modern formats and ZIP files, the ZIP loading logic was strictly tied to root-level QWK packets. This enhancement allows users to process archives that have been reorganized into subfolders or compressed as modern formats within a ZIP container, providing greater flexibility for archive management and distribution.

#### **Changes:**
- **pyqwk/core.py**: Updated `load_data` to implement recursive searching within ZIP files and fallback support for modern formats. Initialized `board_dict` as `ConferenceMap` to ensure consistent return types across all formats.
- **tests/test_zip_container.py**: Created new tests to verify loading ZIPs with JSON, nested QWK packets, and multiple formats with priority.
- **tests/test_input_validation.py**: Updated regression tests to match the improved error messaging for unsupported ZIP contents.

---
*PR created automatically by Jules for task [16186000708103484275](https://jules.google.com/task/16186000708103484275) started by @RainRat*