### PR TITLE
Consolidate lazy attachment discovery in ParsedMessage

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -450,6 +450,12 @@ class ParsedMessage:
     source_file: str | None = None
     attachments: list[str] | None = None
 
+    def discover_attachments(self) -> list[str] | None:
+        """Lazily discover and cache attachment filenames from the message text."""
+        if self.text and self.attachments is None:
+            found_binaries = extract_binaries(self.text)
+            self.attachments = [name for name, data in found_binaries]
+        return self.attachments
 
 
 # Keep old names for compatibility
@@ -2136,10 +2142,7 @@ def matches_filters(
 
     # 7. Full-Text Search
     if settings.search_term:
-        if message.text and message.attachments is None:
-            found_attachments = extract_binaries(message.text)
-            message.attachments = [name for name, data in found_attachments]
-
+        message.discover_attachments()
         found = (
             check_str_match(settings.search_term, message.header.msgfrom)
             or check_str_match(settings.search_term, message.header.msgto)
@@ -2168,9 +2171,7 @@ def matches_filters(
 
     # 9. Attachment Filter
     if settings.has_attachments or settings.extract_attachments:
-        if message.text and message.attachments is None:
-            found = extract_binaries(message.text)
-            message.attachments = [name for name, data in found]
+        message.discover_attachments()
 
         if settings.has_attachments and not message.attachments:
             return False
@@ -4419,12 +4420,7 @@ def _compute_stats_from_messages(
             total_chars += len(message.text)
 
             # Use cached attachments if available to avoid re-scanning
-            current_attachments = message.attachments
-            if current_attachments is None:
-                found_binaries = extract_binaries(message.text)
-                current_attachments = [name for name, data in found_binaries]
-                # Lazily cache them back for other filters to use
-                message.attachments = current_attachments
+            current_attachments = message.discover_attachments()
 
             if current_attachments:
                 attachments_count += len(current_attachments)

--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -1366,10 +1366,7 @@ class QwkGuiApp:
                             )
 
                             # Ensure attachments are detected for the status icon
-                            attachments = parsed_message.attachments
-                            if attachments is None and parsed_message.text:
-                                found = extract_binaries(parsed_message.text)
-                                attachments = [name for name, data in found]
+                            attachments = parsed_message.discover_attachments()
 
                             all_messages.append(replace(parsed_message, text=processed_buffer, attachments=attachments))
 


### PR DESCRIPTION
This Pull Request resolves a code duplication issue in the attachment discovery logic.

### Changes:
- Introduced a new `discover_attachments()` method to the `ParsedMessage` dataclass in `pyqwk/core.py`.
- Replaced redundant inline discovery and caching blocks in `matches_filters` and `_compute_stats_from_messages` with calls to the new method.
- Updated `QwkGuiApp.load_messages` in `pyqwk/gui.py` to also use the centralized method.

### Benefits:
- **Maintainability:** Consolidates logic that was previously repeated in four locations across two files.
- **Readability:** Simplifies the call sites by hiding the implementation details of lazy discovery.
- **Safety:** Ensures consistent behavior across all parts of the application that rely on attachment filename caching.

### Verification:
- Ran all relevant unit tests (`tests/test_attachment_filter.py`, `tests/test_attachments.py`, `tests/test_stats.py`, etc.).
- Verified GUI behavior with comprehensive attachment and statistics tests.
- All 75 relevant tests passed.
- No breaking changes or side effects were introduced.

---
*PR created automatically by Jules for task [2074698141278046729](https://jules.google.com/task/2074698141278046729) started by @RainRat*