### PR TITLE
[DOCS] Improve _is_binary_line docstring for clarity and accessibility

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -180,13 +180,14 @@ def _is_binary_line(
 ) -> tuple[bool, bool, bool, bool]:
     """Check if a line of text is part of an attachment (like an image).
 
-    This function uses a simple state machine to identify the start, data, and end
-    of common binary attachment formats (yEnc, UUE, and Base64) embedded in
-    plain text messages.
+    This function tracks whether we are currently inside an attachment block
+    (yEnc, UUE, or Base64) to find where they start and end within a message.
 
     Returns a group of four values:
-    - A boolean that is True if the line should be hidden.
-    - Three booleans representing if we are currently inside a specific type of attachment (yEnc, UUE, or Base64).
+    - True if the line is part of an attachment and should be hidden.
+    - True if we are currently in a yEnc block.
+    - True if we are currently in a UUE block.
+    - True if we are currently in a Base64 block.
     """
     stripped_line = line.strip()
 


### PR DESCRIPTION
* **Type:** Internal Help (API Docstrings)
* **What:** The `_is_binary_line` function docstring in `pyqwk/core.py` was improved.
* **Why:** Replaced technical jargon ("state machine") with a Plain English explanation of the function's purpose and explicitly listed the return values for better clarity. This follows the Lead Technical Writer guidelines for accessibility and simplicity.

---
*PR created automatically by Jules for task [9656605886614423893](https://jules.google.com/task/9656605886614423893) started by @RainRat*