### PR TITLE
[TEST] Increase coverage for ZIP batch processing and BBS info merging

### DIFF
--- a/tests/test_core_zip_batch_coverage.py
+++ b/tests/test_core_zip_batch_coverage.py
@@ -1,0 +1,95 @@
+import os
+import zipfile
+import tempfile
+import logging
+import pytest
+from unittest.mock import MagicMock, patch
+from pyqwk.core import load_data
+
+def test_zip_merge_bbs_info_overwrite_logic():
+    logger = logging.getLogger("test")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        zip_path = os.path.join(tmpdir, "batch.zip")
+        with zipfile.ZipFile(zip_path, 'w') as zf:
+            f1_path = os.path.join(tmpdir, "1.json")
+            with open(f1_path, "w") as f:
+                f.write('[{"header": {"msgfrom": "A", "msgsubject": "S", "confnum": 1}, "text": "B"}]')
+            zf.write(f1_path, arcname="1.json")
+
+            f2_path = os.path.join(tmpdir, "2.json")
+            with open(f2_path, "w") as f:
+                f.write('[{"header": {"msgfrom": "A2", "msgsubject": "S2", "confnum": 2}, "text": "B2", "bbs_name": "RealBBS"}]')
+            zf.write(f2_path, arcname="2.json")
+
+            for i in range(15):
+                zf.writestr(f"dummy{i}.txt", "data")
+
+        messages, board_dict = load_data(zip_path, logger)
+        assert board_dict.bbs_info is not None
+        assert board_dict.bbs_info.name == "RealBBS"
+
+def test_zip_batch_skips_corrupt_file():
+    logger = logging.getLogger("test")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        zip_path = os.path.join(tmpdir, "corrupt.zip")
+
+        good_path = os.path.join(tmpdir, "good.json")
+        with open(good_path, "w") as f:
+            f.write('[{"header": {"msgfrom": "A", "msgsubject": "S", "confnum": 1}, "text": "B"}]')
+
+        bad_path = os.path.join(tmpdir, "bad.json")
+        with open(bad_path, "w") as f:
+            f.write('not json')
+
+        with zipfile.ZipFile(zip_path, 'w') as zf:
+            zf.write(good_path, arcname="good.json")
+            zf.write(bad_path, arcname="bad.json")
+            for i in range(15):
+                zf.writestr(f"dummy{i}.txt", "data")
+
+        with patch('pyqwk.core.logging.Logger.warning') as mock_warn:
+            messages, board_dict = load_data(zip_path, logger)
+            assert len(messages) == 1
+            assert any("Skipping file" in str(args[0]) for args, kwargs in mock_warn.call_args_list)
+
+def test_zip_batch_no_messages_raises_error():
+    logger = logging.getLogger("test")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        zip_path = os.path.join(tmpdir, "empty_batch.zip")
+
+        empty_path = os.path.join(tmpdir, "empty.json")
+        with open(empty_path, "w") as f:
+            f.write('[]')
+
+        with zipfile.ZipFile(zip_path, 'w') as zf:
+            zf.write(empty_path, arcname="empty.json")
+            for i in range(15):
+                zf.writestr(f"dummy{i}.txt", "data")
+
+        with pytest.raises(ValueError, match="No messages could be loaded from ZIP archive"):
+            load_data(zip_path, logger)
+
+def test_zip_batch_qwk_bytes_recursive():
+    logger = logging.getLogger("test")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        status_block = b"Produced by test".ljust(128, b" ")
+        msg_header = b" " * 128
+        inner_dat = status_block + msg_header
+
+        inner_control = [b"Test BBS", b"City", b"123", b"Sysop", b"Serial", b"0", b"User", b"Date", b"0", b"0", b"1", b"1", b"General"]
+
+        zip_path = os.path.join(tmpdir, "outer_batch.zip")
+        with zipfile.ZipFile(zip_path, 'w') as zf:
+            zf.writestr("packet/MESSAGES.DAT", inner_dat)
+            zf.writestr("packet/CONTROL.DAT", b"\r\n".join(inner_control))
+            for i in range(15):
+                zf.writestr(f"dummy{i}.txt", "data")
+
+        with patch('pyqwk.core.parse_messages') as mock_parse:
+            mock_msg = MagicMock()
+            mock_msg.confnum = 1
+            mock_parse.return_value = [mock_msg]
+
+            messages, board_dict = load_data(zip_path, logger)
+            assert len(messages) >= 1
+            assert mock_msg.confname == "General"


### PR DESCRIPTION
This PR introduces a new test suite, `tests/test_core_zip_batch_coverage.py`, which achieves 100% statement coverage for `pyqwk/core.py` by targeting previously untested logic branches in the ZIP batch processing system.

### Changes:
- **New Test Coverage**: Added tests for:
    - Merging BBS info when initial source lacks a name but subsequent sources provide one.
    - Recursive parsing of classic QWK/REP packets within a modern multi-format ZIP archive.
    - Robust error handling (skipping corrupt files) during batch ZIP extraction.
    - Explicit validation that a ZIP archive must contain at least one valid message.
- **Hygiene**: Removed all explanatory comments from test functions to align with lead technical guidelines. Verified that all 840 tests pass and no build artifacts or temporary files are included in the commit.

### Verification:
- Ran `pytest --cov=pyqwk --cov-report=term-missing` to confirm 100% package-wide statement coverage.
- All 840 tests passed in 18.91s.
- Manual inspection of `pyqwk/core.py` to ensure all targeted lines (1750, 1759-1763, 1766-1767, 1770) are fully covered.

---
*PR created automatically by Jules for task [254668334480600121](https://jules.google.com/task/254668334480600121) started by @RainRat*