### PR TITLE
[FEAT] Add support for TAR archives

### DIFF
--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -89,7 +89,7 @@ examples:
     )
     parser.add_argument(
         'input_paths',
-        help='Path to message archives, ZIP files, or folders. Supports QWK, REP, JSON, JSONL, CSV, XML, RSS, MBOX, EML, SQLite, Markdown, and HTML. ZIP archives can contain multiple files and formats which will be merged.',
+        help='Path to message archives, ZIP and TAR archives, or folders. Supports QWK, REP, JSON, JSONL, CSV, XML, RSS, MBOX, EML, SQLite, Markdown, and HTML. ZIP and TAR archives can contain multiple files and formats which will be merged.',
         nargs='+',
     )
 

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -1,5 +1,6 @@
 import sys
 import zipfile
+import tarfile
 import subprocess
 import tempfile
 import struct
@@ -41,7 +42,7 @@ def expand_paths(paths: list[str]) -> list[str]:
             for root, _, files in os.walk(path):
                 for file in files:
                     lower_file = file.lower()
-                    if lower_file.endswith(('.qwk', '.zip', '.rep', '.json', '.jsonl', '.csv', '.db', '.sqlite', '.xml', '.rss', '.mbox', '.eml', '.md', '.markdown', '.html', '.htm')) or lower_file in (MESSAGES_FILENAME, REPLY_FILENAME):
+                    if lower_file.endswith(('.qwk', '.zip', '.tar', '.tar.gz', '.tar.bz2', '.tgz', '.rep', '.json', '.jsonl', '.csv', '.db', '.sqlite', '.xml', '.rss', '.mbox', '.eml', '.md', '.markdown', '.html', '.htm')) or lower_file in (MESSAGES_FILENAME, REPLY_FILENAME):
                         expanded_paths.append(os.path.join(root, file))
         else:
             expanded_paths.append(path)
@@ -1768,6 +1769,55 @@ def load_data(
 
             if not all_messages:
                  raise ValueError(f"No messages could be loaded from ZIP archive: {input_path}")
+
+            return all_messages, merged_board_dict
+    elif tarfile.is_tarfile(input_path) if os.path.isfile(input_path) else False:
+        # Support multi-format batch loading from TAR archives.
+        with tempfile.TemporaryDirectory() as temp_dir:
+            try:
+                with tarfile.open(input_path) as mytar:
+                    # In Python 3.12+, we should use the 'data' filter for safety
+                    if hasattr(tarfile, 'data_filter'):
+                        mytar.extractall(temp_dir, filter='data')
+                    else:
+                        mytar.extractall(temp_dir)
+            except Exception as e:
+                raise RuntimeError(f"An error occurred while extracting TAR archive: {str(e)}")
+
+            candidate_paths = expand_paths([temp_dir])
+
+            if not candidate_paths:
+                raise ValueError(f"No supported message files found in TAR archive: {input_path}")
+
+            all_messages = []
+            merged_board_dict = ConferenceMap()
+
+            for p in candidate_paths:
+                try:
+                    data, b_dict = load_data(p, logger, encoding)
+
+                    if b_dict.bbs_info:
+                        if not merged_board_dict.bbs_info:
+                            merged_board_dict.bbs_info = b_dict.bbs_info
+                        elif b_dict.bbs_info.name and not merged_board_dict.bbs_info.name:
+                            merged_board_dict.bbs_info = b_dict.bbs_info
+
+                    for cid, name in b_dict.items():
+                        if cid not in merged_board_dict:
+                            merged_board_dict[cid] = name
+
+                    if isinstance(data, bytearray):
+                        msgs = list(parse_messages(data, None, encoding))
+                        for m in msgs:
+                             m.confname = b_dict.get(m.confnum)
+                        all_messages.extend(msgs)
+                    else:
+                        all_messages.extend(data)
+                except Exception as e:
+                    logger.warning("Skipping file %s in TAR due to error: %s", os.path.basename(p), e)
+
+            if not all_messages:
+                 raise ValueError(f"No messages could be loaded from TAR archive: {input_path}")
 
             return all_messages, merged_board_dict
     else:
@@ -4885,7 +4935,7 @@ def _order_messages_by_thread(messages: list[ProcessedMessage]) -> list[Processe
 
 def organize_by_bbs(input_paths: list[str], settings: ProcessingSettings, logger: logging.Logger) -> None:
     """Organize archive files into directories based on their BBS name and ID."""
-    supported_extensions = ('.qwk', '.rep', '.json', '.csv', '.xml', '.db', '.sqlite', '.mbox', '.eml')
+    supported_extensions = ('.qwk', '.rep', '.json', '.csv', '.xml', '.db', '.sqlite', '.mbox', '.eml', '.tar', '.tar.gz', '.tar.bz2', '.tgz', '.zip')
 
     for input_path in input_paths:
         if not os.path.isfile(input_path):

--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -1136,7 +1136,7 @@ class QwkGuiApp:
         filetypes = [
             (
                 "All supported formats",
-                "*.qwk *.rep *.json *.jsonl *.csv *.db *.sqlite *.xml *.rss *.mbox *.eml *.md *.markdown *.html *.htm",
+                "*.qwk *.rep *.json *.jsonl *.csv *.db *.sqlite *.xml *.rss *.mbox *.eml *.md *.markdown *.html *.htm *.tar *.tar.gz *.tar.bz2 *.tgz",
             ),
             ("QWK archives", "*.qwk"),
             ("REP archives", "*.rep"),

--- a/tests/test_tar_support.py
+++ b/tests/test_tar_support.py
@@ -1,0 +1,35 @@
+import os
+import tarfile
+import tempfile
+import logging
+import pytest
+from pyqwk.core import load_data
+
+def test_tar_batch_loading():
+    logger = logging.getLogger("test")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # 1. Create a JSON file with one message
+        json_content = '[{"header": {"msgfrom": "TarAuthor", "msgsubject": "TarSubj", "confnum": 1}, "text": "TarBody"}]'
+        json_filename = "test.json"
+        json_path = os.path.join(tmpdir, json_filename)
+        with open(json_path, "w") as f:
+            f.write(json_content)
+
+        # 2. Create a TAR file containing the JSON
+        tar_path = os.path.join(tmpdir, "batch.tar")
+        with tarfile.open(tar_path, 'w') as tf:
+            tf.add(json_path, arcname=json_filename)
+
+        # Load the TAR - this should currently fail to find messages or not recognize it
+        try:
+            messages, board_dict = load_data(tar_path, logger)
+            # If it's already supported, this test will pass (but I expect it to fail to find messages)
+            assert isinstance(messages, list)
+            assert any(m.header.msgfrom.strip() == "TarAuthor" for m in messages)
+        except Exception as e:
+            pytest.fail(f"TAR loading failed: {e}")
+
+if __name__ == "__main__":
+    # Manually run if needed
+    test_tar_batch_loading()


### PR DESCRIPTION
* **What:** Added support for loading message data from TAR archives (including `.tar.gz`, `.tar.bz2`, and `.tgz`). Updated core loading logic, path expansion, BBS organization, CLI help text, and GUI file dialogs.
* **Why:** Mirroring existing ZIP support ("Symmetry") and enabling batch processing of multiple message files stored in common TAR formats ("Batching").

---
*PR created automatically by Jules for task [14800333937655137726](https://jules.google.com/task/14800333937655137726) started by @RainRat*