### PR TITLE
Fix UUE block termination and detection robustness

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -110,7 +110,7 @@ def resolve_output_format(
 RE_QUOTE_PATTERN = re.compile(r'^\s*[A-Za-z\-\=]{0,4}\s?(>|\xb3|\||\}|│)')
 RE_UUE_PATTERN = re.compile(r'^begin\s+\d{3}\s+')
 RE_UUE_DATA_PATTERN = re.compile(r'^M[\x21-\x60]{60}$')
-RE_UUE_LOOSE_PATTERN = re.compile(r'[\x21-\x4c][\x21-\x60]{4,60}$')
+RE_UUE_LOOSE_PATTERN = re.compile(r'^[\x21-\x4d][\x21-\x60]{1,60}$')
 RE_BASE64_PATTERN = re.compile(r'^[A-Za-z0-9+/=]{60,}$')
 RE_YENC_PATTERN = re.compile(r'^=y(begin|part|end)')
 RE_BASE64_LOOSE_PATTERN = re.compile(r'^[A-Za-z0-9+/=]{4,}$')
@@ -207,9 +207,11 @@ def _is_binary_line(
         return True, True, in_uue_block, in_base64_block
 
     if in_uue_block:
-        if stripped_line in ('end', '`'):
+        if stripped_line == 'end':
             return True, in_yenc_block, False, in_base64_block
-        return True, in_yenc_block, True, in_base64_block
+        if stripped_line == '`' or RE_UUE_DATA_PATTERN.match(stripped_line) or RE_UUE_LOOSE_PATTERN.match(stripped_line):
+            return True, in_yenc_block, True, in_base64_block
+        return False, in_yenc_block, False, in_base64_block
 
     if RE_BASE64_PATTERN.match(stripped_line):
         return True, in_yenc_block, in_uue_block, True


### PR DESCRIPTION
### What:
This change improves the detection and removal of UUEncoded (UUE) binary blocks in message bodies. Specifically:
- It fixes a logic bug where the final `end` marker of a UUE block remained visible after binary removal.
- it improves the `RE_UUE_LOOSE_PATTERN` regex by anchoring it to the start of the line and extending the length-indicator range to include 'M' (standard 45-byte lines).
- It adds a safety check to the UUE state machine to exit the block early if a line does not look like UUE data or a valid terminator, preventing it from incorrectly stripping subsequent non-binary text.

### Why:
These changes ensure that UUE attachments are cleanly and completely removed when the `binaries_removal` option is used, and improve the robustness of the parser against malformed or unterminated binary blocks. The external behavior remains identical for well-formed data, but is more accurate and safe.

### Verification:
- Verified with a reproduction script that specifically tested UUE termination and malformed block handling.
- Confirmed that all existing tests in `tests/test_content_processing.py` pass.
- Code review performed and rated as correct.

---
*PR created automatically by Jules for task [1096799200786508050](https://jules.google.com/task/1096799200786508050) started by @RainRat*