### PR TITLE
Fix greedy UUE block detection

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -110,7 +110,7 @@ def resolve_output_format(
 RE_QUOTE_PATTERN = re.compile(r'^\s*[A-Za-z\-\=]{0,4}\s?(>|\xb3|\||\}|│)')
 RE_UUE_PATTERN = re.compile(r'^begin\s+\d{3}\s+')
 RE_UUE_DATA_PATTERN = re.compile(r'^M[\x21-\x60]{60}$')
-RE_UUE_LOOSE_PATTERN = re.compile(r'[\x21-\x4c][\x21-\x60]{4,60}$')
+RE_UUE_LOOSE_PATTERN = re.compile(r'^[\x21-\x4d][\x21-\x60]{1,60}$')
 RE_BASE64_PATTERN = re.compile(r'^[A-Za-z0-9+/=]{60,}$')
 RE_YENC_PATTERN = re.compile(r'^=y(begin|part|end)')
 RE_BASE64_LOOSE_PATTERN = re.compile(r'^[A-Za-z0-9+/=]{4,}$')
@@ -209,7 +209,12 @@ def _is_binary_line(
     if in_uue_block:
         if stripped_line in ('end', '`'):
             return True, in_yenc_block, False, in_base64_block
-        return True, in_yenc_block, True, in_base64_block
+        if (
+            RE_UUE_DATA_PATTERN.match(stripped_line)
+            or RE_UUE_LOOSE_PATTERN.match(stripped_line)
+        ):
+            return True, in_yenc_block, True, in_base64_block
+        in_uue_block = False
 
     if RE_BASE64_PATTERN.match(stripped_line):
         return True, in_yenc_block, in_uue_block, True

--- a/tests/test_binary_detection.py
+++ b/tests/test_binary_detection.py
@@ -62,14 +62,14 @@ class TestBinaryDetection:
         assert skip is True
         assert in_uue is False
 
-    def test_uue_skips_until_end(self):
-        # Any garbage inside a UUE block should be skipped until 'end'
+    def test_uue_exits_on_non_uue_data(self):
+        # Improved logic should exit UUE block if line is not UUE data or terminator
         line = "This is not UUE data"
         skip, in_yenc, in_uue, in_b64 = _is_binary_line(
             line, previous_line=None, in_yenc_block=False, in_uue_block=True, in_base64_block=False
         )
-        assert skip is True
-        assert in_uue is True
+        assert skip is False
+        assert in_uue is False
 
     def test_detects_yenc_body(self):
         line = "random_yenc_data"
@@ -158,15 +158,15 @@ class TestBinaryDetection:
         assert in_yenc is False
         assert in_uue is False
 
-    def test_stays_in_uue_on_invalid_line(self):
+    def test_exits_uue_on_invalid_line(self):
         line = "Not a uue line"
         skip, in_yenc, in_uue, in_b64 = _is_binary_line(
             line, previous_line=None, in_yenc_block=False, in_uue_block=True, in_base64_block=False
         )
-        # We should stay in UUE block and skip the line
-        assert skip is True
+        # We should exit UUE block if it's garbage
+        assert skip is False
         assert in_yenc is False
-        assert in_uue is True
+        assert in_uue is False
 
     def test_detects_base64(self):
         line = "VGhpcyBpcyBhIHRlc3QgbWVzc2FnZQ==" # Base64 for "This is a test message"


### PR DESCRIPTION
This PR resolves a logic bug in the UUEncoded (UUE) attachment detection.

**What:**
- Refactored `_is_binary_line` in `pyqwk/core.py` to check for valid UUE data patterns or terminators while inside a UUE block.
- Improved the `RE_UUE_LOOSE_PATTERN` regex by adding a start-of-line anchor and including the 'M' character (representing 45-byte lines).
- Updated `tests/test_binary_detection.py` to ensure the parser correctly exits UUE blocks when encountering non-encoded text.

**Why:**
Previously, the parser would "swallow" all remaining message text if it entered a UUE block that lacked a proper terminator. This fix ensures that only actual encoded data is stripped when `binaries_removal` is active, preserving the rest of the message content.

No breaking changes were introduced; existing behavior for correctly formatted UUE blocks remains identical. All 841 tests passed.

---
*PR created automatically by Jules for task [3784285314034299088](https://jules.google.com/task/3784285314034299088) started by @RainRat*