### PR TITLE
[FEAT] Add support for Plain Text message import

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ pyqwk helps you open these archives and convert them into modern, readable forma
 | **XML** | ✅ | ✅ | Generic structured data |
 | **SQLite** | ✅ | ✅ | Relational databases (.db) |
 | **mbox / EML** | ✅ | ✅ | Email applications |
-| **Plain Text** | ❌ | ✅ | Simple readable text |
+| **Plain Text** | ✅ | ✅ | Simple readable text |
 
 ## Prerequisites
 

--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -89,7 +89,7 @@ examples:
     )
     parser.add_argument(
         'input_paths',
-        help='Path to message archives, ZIP and TAR archives, or folders. Supports QWK, REP, JSON, JSONL, CSV, XML, RSS, MBOX, EML, SQLite, Markdown, and HTML. ZIP and TAR archives can contain multiple files and formats which will be merged.',
+        help='Path to message archives, ZIP and TAR archives, or folders. Supports QWK, REP, JSON, JSONL, CSV, XML, RSS, MBOX, EML, SQLite, Markdown, HTML, and Plain Text. ZIP and TAR archives can contain multiple files and formats which will be merged.',
         nargs='+',
     )
 

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -43,7 +43,7 @@ def expand_paths(paths: list[str]) -> list[str]:
             for root, _, files in os.walk(path):
                 for file in files:
                     lower_file = file.lower()
-                    if lower_file.endswith(('.qwk', '.zip', '.tar', '.tar.gz', '.tar.bz2', '.tgz', '.rep', '.json', '.jsonl', '.csv', '.db', '.sqlite', '.xml', '.rss', '.mbox', '.eml', '.md', '.markdown', '.html', '.htm')) or lower_file in (MESSAGES_FILENAME, REPLY_FILENAME):
+                    if lower_file.endswith(('.qwk', '.zip', '.tar', '.tar.gz', '.tar.bz2', '.tgz', '.rep', '.json', '.jsonl', '.csv', '.db', '.sqlite', '.xml', '.rss', '.mbox', '.eml', '.md', '.markdown', '.html', '.htm', '.txt')) or lower_file in (MESSAGES_FILENAME, REPLY_FILENAME):
                         expanded_paths.append(os.path.join(root, file))
         else:
             expanded_paths.append(path)
@@ -1379,6 +1379,134 @@ def _parse_html_messages(path: str) -> list[ParsedMessage]:
     return messages
 
 
+def _parse_text_messages(path: str, encoding: str = 'utf-8') -> list[ParsedMessage]:
+    """Import messages from a Plain Text file."""
+    try:
+        with open(path, 'r', encoding=encoding) as f:
+            content = f.read()
+    except (UnicodeDecodeError, LookupError):
+        with open(path, 'r', encoding='latin1') as f:
+            content = f.read()
+
+    # Split by horizontal separators (dashes) or double newlines
+    content_norm = content.replace('\r\n', '\n')
+    sections = re.split(r'\n-{20,}\n', content_norm)
+    if len(sections) <= 1:
+        # Try splitting by double newlines if no dashes found, looking ahead for headers
+        sections = re.split(r'\n\n(?=Conference:|Message #:|Date:)', content_norm)
+
+    messages = []
+
+    re_conf = re.compile(r'^Conference:\s*(.*?)(?:\s*\((\d+)\))?$', re.MULTILINE)
+    re_bbs = re.compile(r'^BBS:\s*(.*)$', re.MULTILINE)
+    re_status = re.compile(r'^Status:\s*(.*)$', re.MULTILINE)
+    re_msgnum_verbose = re.compile(r'^Message #:\s*(\d+)', re.MULTILINE)
+    re_date_verbose = re.compile(r'Date:\s*(\d{2}-\d{2}-\d{2,4}\s+\d{2}:\d{2}(?::\d{2})?)', re.MULTILINE)
+    re_date_std = re.compile(r'^Date:\s*(\d{2}-\d{2}-\d{2,4}\s+\d{2}:\d{2}(?::\d{2})?)', re.MULTILINE)
+    re_from = re.compile(r'^From:\s*(.*)$', re.MULTILINE)
+    re_to = re.compile(r'^To:\s*(.*)$', re.MULTILINE)
+    re_subject = re.compile(r'^Subject:\s*(.*)$', re.MULTILINE)
+    re_refnum = re.compile(r'^Reference #:\s*(\d+)', re.MULTILINE)
+    re_attachments = re.compile(r'^Attachments:\s*(.*)$', re.MULTILINE)
+
+    for section in sections:
+        section = section.strip()
+        if not section:
+            continue
+
+        from_match = re_from.search(section)
+        to_match = re_to.search(section)
+        subj_match = re_subject.search(section)
+
+        # Minimum required headers to consider it a message
+        if not (from_match and to_match and subj_match):
+            continue
+
+        conf_match = re_conf.search(section)
+        bbs_match = re_bbs.search(section)
+        status_match = re_status.search(section)
+        msgnum_v_match = re_msgnum_verbose.search(section)
+        date_v_match = re_date_verbose.search(section)
+        date_s_match = re_date_std.search(section)
+        ref_match = re_refnum.search(section)
+        attach_match = re_attachments.search(section)
+
+        msgnum = None
+        if msgnum_v_match:
+            msgnum = int(msgnum_v_match.group(1))
+
+        date_str = ""
+        if date_v_match:
+            date_str = date_v_match.group(1)
+        elif date_s_match:
+            date_str = date_s_match.group(1)
+
+        msg_date = "01-01-70"
+        msg_time = "00:00"
+        if date_str:
+            parts = date_str.split()
+            if len(parts) >= 1:
+                msg_date = parts[0]
+            if len(parts) >= 2:
+                msg_time = parts[1]
+
+        refnum = None
+        ref_match = re_refnum.search(section)
+        if ref_match:
+            refnum = int(ref_match.group(1))
+
+        attachments = None
+        attach_match = re_attachments.search(section)
+        if attach_match:
+            attachments = [a.strip() for a in attach_match.group(1).split(',') if a.strip()]
+
+        conf_num = 0
+        conf_name = None
+        if conf_match:
+            conf_name = conf_match.group(1).strip()
+            if conf_match.group(2):
+                conf_num = int(conf_match.group(2))
+
+        # Body starts after headers
+        header_end = 0
+        for m in [conf_match, bbs_match, status_match, msgnum_v_match, date_v_match, date_s_match, from_match, to_match, subj_match, ref_match, attach_match]:
+            if m:
+                header_end = max(header_end, m.end())
+
+        body = section[header_end:].strip()
+
+        header = MessageHeader(
+            status='*' if status_match and "[PRIVATE]" in status_match.group(1) else ' ',
+            msgnum=msgnum,
+            msgdate=msg_date,
+            msgtime=msg_time,
+            msgto=to_match.group(1).strip(),
+            msgfrom=from_match.group(1).strip(),
+            msgsubject=subj_match.group(1).strip(),
+            msgpassword="",
+            refnum=refnum,
+            numblocks=None,
+            msgflag=" ",
+            confnum=conf_num,
+            lognum=0,
+            nettag="",
+        )
+
+        msg = ParsedMessage(
+            text=body,
+            msgnum=msgnum,
+            refnum=refnum,
+            confnum=conf_num,
+            header=header,
+            confname=conf_name,
+            bbs_name=bbs_match.group(1).strip() if bbs_match else None,
+            attachments=attachments,
+        )
+        messages.append(msg)
+
+    return messages
+
+
 def _parse_markdown_messages(path: str) -> list[ParsedMessage]:
     """Import messages from a Markdown file."""
     with open(path, 'r', encoding='utf-8') as f:
@@ -1650,6 +1778,15 @@ def load_data(
 
             board_dict = _reconstruct_archive_information(messages)
             return messages, board_dict
+
+    if input_path.lower().endswith('.txt'):
+        try:
+            messages = _parse_text_messages(input_path, encoding)
+        except Exception as e:
+            raise ValueError(f"Failed to load text archive: {e}")
+
+        board_dict = _reconstruct_archive_information(messages)
+        return messages, board_dict
 
     if zipfile.is_zipfile(input_path):
         # Support multi-format batch loading from ZIP archives.

--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -1146,7 +1146,7 @@ class QwkGuiApp:
         filetypes = [
             (
                 "All supported formats",
-                "*.qwk *.rep *.json *.jsonl *.csv *.db *.sqlite *.xml *.rss *.mbox *.eml *.md *.markdown *.html *.htm *.tar *.tar.gz *.tar.bz2 *.tgz",
+                "*.qwk *.rep *.json *.jsonl *.csv *.db *.sqlite *.xml *.rss *.mbox *.eml *.md *.markdown *.html *.htm *.tar *.tar.gz *.tar.bz2 *.tgz *.txt",
             ),
             ("QWK archives", "*.qwk"),
             ("REP archives", "*.rep"),
@@ -1160,6 +1160,7 @@ class QwkGuiApp:
             ("EML files", "*.eml"),
             ("Markdown files", "*.md *.markdown"),
             ("HTML archives", "*.html *.htm"),
+            ("Plain Text", "*.txt"),
             ("messages.dat", "messages.dat"),
             ("All files", "*.*"),
         ]

--- a/test_import.txt
+++ b/test_import.txt
@@ -1,0 +1,15 @@
+Conference: General (1)
+From: Alice
+To: Bob
+Subject: Hello
+Date: 01-23-24 12:34
+
+This is a test message.
+--------------------------------------------------------------------------------
+Conference: Tech (2)
+From: Bob
+To: Alice
+Subject: Re: Hello
+Date: 01-23-24 12:35
+
+I received it!

--- a/test_import_verbose.txt
+++ b/test_import_verbose.txt
@@ -1,0 +1,10 @@
+--------------------------------------------------------------------------------
+Conference:  General (1)
+Status:      [PRIVATE]
+Message #:   123                   Date: 01-23-24 12:34
+From:        Alice
+To:          Bob
+Subject:     Hello
+Reference #: 0
+
+Body here.

--- a/tests/test_directory_expansion.py
+++ b/tests/test_directory_expansion.py
@@ -20,7 +20,7 @@ class TestDirectoryExpansion:
         (tmp_path / "messages.dat").touch()
 
         # Create invalid files
-        (tmp_path / "test.txt").touch()
+        (tmp_path / "test.exe").touch()
         (tmp_path / "image.png").touch()
 
         expanded = _expand_directories([str(tmp_path)])
@@ -30,7 +30,7 @@ class TestDirectoryExpansion:
         assert "test2.rep" in filenames
         assert "archive.zip" in filenames
         assert "messages.dat" in filenames
-        assert "test.txt" not in filenames
+        assert "test.exe" not in filenames
         assert "image.png" not in filenames
         assert len(expanded) == 4
 

--- a/tests/test_html_import.py
+++ b/tests/test_html_import.py
@@ -1,5 +1,6 @@
 import os
 import logging
+import unittest.mock
 from pyqwk.core import (
     ParsedMessage, MessageHeader, process_merged_files, ProcessingSettings,
     load_data, expand_paths
@@ -45,7 +46,6 @@ def test_html_import_roundtrip(tmp_path):
         include_toc=True, quiet=True
     )
 
-    import unittest.mock
     mock_logger = unittest.mock.MagicMock()
 
     # We need to mock load_data to return our test messages during process_merged_files
@@ -106,7 +106,6 @@ def test_html_individual_files_import(tmp_path):
         quiet=True
     )
 
-    import unittest.mock
     mock_logger = unittest.mock.MagicMock()
 
     with unittest.mock.patch('pyqwk.core.load_data') as mock_load:
@@ -128,16 +127,12 @@ def test_html_individual_files_import(tmp_path):
 
 def test_expand_paths_html():
     """Verify that expand_paths finds .html and .htm files."""
-    files = expand_paths(["tests"])
-    # This should be true now, but let's test with a controlled environment if possible
-    # For simplicity, we just check if any .html file would be found in a mock structure
-    import unittest.mock
     with unittest.mock.patch('os.path.isdir', return_value=True):
         with unittest.mock.patch('os.walk') as mock_walk:
             mock_walk.return_value = [
-                ('/fake', ('subdir',), ('msg1.html', 'msg2.htm', 'other.txt')),
+                ('/fake', ('subdir',), ('msg1.html', 'msg2.htm', 'other.exe')),
             ]
             found = expand_paths(['/fake'])
             assert '/fake/msg1.html' in found
             assert '/fake/msg2.htm' in found
-            assert '/fake/other.txt' not in found
+            assert '/fake/other.exe' not in found

--- a/tests/test_text_import.py
+++ b/tests/test_text_import.py
@@ -1,0 +1,153 @@
+import os
+import pytest
+import logging
+from pyqwk.core import load_data, ParsedMessage
+
+def test_text_import_standard(tmp_path):
+    text_content = """Conference: General (1)
+From: Alice
+To: Bob
+Subject: Hello
+Date: 01-23-24 12:34
+
+This is a test message.
+"""
+    path = tmp_path / "test.txt"
+    path.write_text(text_content)
+
+    logger = logging.getLogger("test")
+    messages, board_dict = load_data(str(path), logger)
+
+    assert len(messages) == 1
+    msg = messages[0]
+    assert msg.confnum == 1
+    assert msg.confname == "General"
+    assert msg.header.msgfrom == "Alice"
+    assert msg.header.msgto == "Bob"
+    assert msg.header.msgsubject == "Hello"
+    assert msg.header.msgdate == "01-23-24"
+    assert msg.header.msgtime == "12:34"
+    assert msg.text.strip() == "This is a test message."
+    assert board_dict[1] == "General"
+
+def test_text_import_verbose(tmp_path):
+    text_content = """--------------------------------------------------------------------------------
+Conference:  General (1)
+Status:      [PRIVATE]
+Message #:   123                   Date: 01-23-24 12:34
+From:        Alice
+To:          Bob
+Subject:     Hello
+Reference #: 0
+
+Body here.
+"""
+    path = tmp_path / "test_verbose.txt"
+    path.write_text(text_content)
+
+    logger = logging.getLogger("test")
+    messages, board_dict = load_data(str(path), logger)
+
+    assert len(messages) == 1
+    msg = messages[0]
+    assert msg.header.msgnum == 123
+    assert msg.header.is_private is True
+    assert msg.text.strip() == "Body here."
+
+def test_text_import_multiple(tmp_path):
+    text_content = """Conference: General (1)
+From: Alice
+To: Bob
+Subject: Hello
+Date: 01-23-24 12:34
+
+Msg 1
+--------------------------------------------------------------------------------
+Conference: Tech (2)
+From: Bob
+To: Alice
+Subject: Re: Hello
+Date: 01-23-24 12:35
+
+Msg 2
+"""
+    path = tmp_path / "test_multi.txt"
+    path.write_text(text_content)
+
+    logger = logging.getLogger("test")
+    messages, board_dict = load_data(str(path), logger)
+
+    assert len(messages) == 2
+    assert messages[0].confnum == 1
+    assert messages[0].text.strip() == "Msg 1"
+    assert messages[1].confnum == 2
+    assert messages[1].text.strip() == "Msg 2"
+    assert board_dict[1] == "General"
+    assert board_dict[2] == "Tech"
+
+def test_text_import_double_newline_separator(tmp_path):
+    # Test fallback to double newline splitting if no dashes present
+    text_content = """Conference: General (1)
+From: Alice
+To: Bob
+Subject: One
+Date: 01-23-24 12:34
+
+Body One
+
+Conference: Tech (2)
+From: Bob
+To: Alice
+Subject: Two
+Date: 01-23-24 12:35
+
+Body Two
+"""
+    path = tmp_path / "test_newline.txt"
+    path.write_text(text_content)
+
+    logger = logging.getLogger("test")
+    messages, board_dict = load_data(str(path), logger)
+
+    assert len(messages) == 2
+    assert messages[0].header.msgsubject == "One"
+    assert messages[1].header.msgsubject == "Two"
+
+def test_text_import_with_bbs_name(tmp_path):
+    text_content = """Conference: General (1)
+BBS: My Cool BBS
+From: Alice
+To: Bob
+Subject: Hello
+Date: 01-23-24 12:34
+
+Body
+"""
+    path = tmp_path / "test_bbs.txt"
+    path.write_text(text_content)
+
+    logger = logging.getLogger("test")
+    messages, board_dict = load_data(str(path), logger)
+
+    assert len(messages) == 1
+    assert messages[0].bbs_name == "My Cool BBS"
+    assert board_dict.bbs_info.name == "My Cool BBS"
+
+def test_text_import_attachments(tmp_path):
+    text_content = """Conference: General (1)
+From: Alice
+To: Bob
+Subject: Hello
+Date: 01-23-24 12:34
+Attachments: file1.zip, file2.jpg
+
+Body
+"""
+    path = tmp_path / "test_attach.txt"
+    path.write_text(text_content)
+
+    logger = logging.getLogger("test")
+    messages, board_dict = load_data(str(path), logger)
+
+    assert len(messages) == 1
+    assert messages[0].attachments == ["file1.zip", "file2.jpg"]

--- a/tests/test_zip_compatibility.py
+++ b/tests/test_zip_compatibility.py
@@ -13,7 +13,7 @@ class TestZipCompatibility(unittest.TestCase):
             # Create a ZIP with an unsupported file
             zip_path = os.path.join(tmpdir, "empty.zip")
             with zipfile.ZipFile(zip_path, 'w') as zf:
-                zf.writestr("readme.txt", "nothing here")
+                zf.writestr("readme.bin", "nothing here")
 
             with self.assertRaises(FileNotFoundError):
                 core.load_data(zip_path, logger)


### PR DESCRIPTION
I have implemented the "missing piece" of functionality for Plain Text support. While `pyqwk` could already export to plain text, it lacked the ability to import from it. This new feature allows users to process message archives that have been saved or exported as text files, which is a common scenario in the BBS community.

The implementation includes:
- A new internal parser `_parse_text_messages` that uses regular expressions to extract conference, BBS, author, recipient, subject, date, and attachment information.
- Support for both standard and verbose (multi-column) header formats.
- Intelligent message splitting using horizontal dash separators or double-newline lookahead.
- Full integration with the library's `load_data` entry point and the CLI/GUI interfaces.
- Comprehensive test coverage with a new test suite and updates to existing tests to ensure no regressions.

This addition follows the "Symmetry" heuristic and provides immediate value by making the tool more versatile in handling legacy and user-generated text archives.

---
*PR created automatically by Jules for task [13024888561819108046](https://jules.google.com/task/13024888561819108046) started by @RainRat*