### PR TITLE
[UI/UX] Enable message navigation shortcuts while viewing message details

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -303,7 +303,17 @@ class QwkGuiApp:
         if event.state & 0x4:  # Control mask
             if event.keysym.lower() in ('c', 'a'):
                 return None
-        # Allow navigation keys
+
+        # Handle message navigation shortcuts
+        key = event.keysym.lower()
+        if key in ('j', 'n'):
+            self._select_relative_message(1)
+            return "break"
+        if key in ('k', 'p'):
+            self._select_relative_message(-1)
+            return "break"
+
+        # Allow text navigation keys
         if event.keysym in ('Up', 'Down', 'Left', 'Right', 'Prior', 'Next', 'Home', 'End'):
             return None
         return "break"

--- a/tests/test_gui_navigation_detail_focus.py
+++ b/tests/test_gui_navigation_detail_focus.py
@@ -1,0 +1,84 @@
+import sys
+from unittest.mock import MagicMock, patch
+import pytest
+
+# Mock tkinter before any pyqwk.gui imports
+mock_tk = MagicMock()
+mock_ttk = MagicMock()
+sys.modules["tkinter"] = mock_tk
+sys.modules["tkinter.filedialog"] = MagicMock()
+sys.modules["tkinter.messagebox"] = MagicMock()
+sys.modules["tkinter.ttk"] = mock_ttk
+
+from pyqwk.gui import QwkGuiApp
+
+@pytest.fixture
+def mock_gui_deps():
+    with patch("pyqwk.gui.tk") as mock_tk, \
+         patch("pyqwk.gui.ttk") as mock_ttk:
+
+        # Configure Variable mocks
+        def make_var(value=None):
+            m = MagicMock()
+            m.get.return_value = value
+            return m
+
+        mock_tk.BooleanVar.side_effect = lambda value=False, **kwargs: make_var(value)
+        mock_tk.StringVar.side_effect = lambda value="", **kwargs: make_var(value)
+        mock_tk.IntVar.side_effect = lambda value=0, **kwargs: make_var(value)
+
+        yield {
+            "tk": mock_tk,
+            "ttk": mock_ttk,
+        }
+
+def test_block_text_input_navigation(mock_gui_deps):
+    root = MagicMock()
+    app = QwkGuiApp(root)
+
+    # Mock _select_relative_message
+    app._select_relative_message = MagicMock()
+
+    # Simulate 'j' key press
+    event_j = MagicMock()
+    event_j.keysym = 'j'
+    event_j.state = 0
+
+    result = app._block_text_input(event_j)
+
+    assert result == "break"
+    app._select_relative_message.assert_called_with(1)
+
+    # Simulate 'K' key press (capital)
+    event_k = MagicMock()
+    event_k.keysym = 'K'
+    event_k.state = 0
+
+    result = app._block_text_input(event_k)
+
+    assert result == "break"
+    app._select_relative_message.assert_called_with(-1)
+
+    # Simulate 'Up' key press
+    event_up = MagicMock()
+    event_up.keysym = 'Up'
+    event_up.state = 0
+
+    result = app._block_text_input(event_up)
+    assert result is None
+
+    # Simulate random key 'x'
+    event_x = MagicMock()
+    event_x.keysym = 'x'
+    event_x.state = 0
+
+    result = app._block_text_input(event_x)
+    assert result == "break"
+
+    # Simulate Control+C
+    event_ctrl_c = MagicMock()
+    event_ctrl_c.keysym = 'c'
+    event_ctrl_c.state = 0x4
+
+    result = app._block_text_input(event_ctrl_c)
+    assert result is None


### PR DESCRIPTION
This improvement reduces friction for power users by allowing them to navigate through message archives using keyboard shortcuts ('j', 'k', 'n', 'p') even when they are interacting with the message content (e.g., selecting text or clicking links). Previously, focus would get "stuck" in the text viewer, requiring a mouse click to return to the list before keyboard navigation could resume.

Changes:
- Modified `pyqwk/gui.py`: Updated `_block_text_input` to intercept and handle navigation keys.
- Added `tests/test_gui_navigation_detail_focus.py`: New unit test to verify the fix and ensure no regressions in standard text navigation (arrow keys) or clipboard shortcuts (Ctrl+C).

---
*PR created automatically by Jules for task [18270101138619485499](https://jules.google.com/task/18270101138619485499) started by @RainRat*