### PR TITLE
Remove redundant regex searches in _parse_text_messages

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -1461,12 +1461,10 @@ def _parse_text_messages(path: str, encoding: str = 'utf-8') -> list[ParsedMessa
                 msg_time = parts[1]
 
         refnum = None
-        ref_match = re_refnum.search(section)
         if ref_match:
             refnum = int(ref_match.group(1))
 
         attachments = None
-        attach_match = re_attachments.search(section)
         if attach_match:
             attachments = [a.strip() for a in attach_match.group(1).split(',') if a.strip()]
 


### PR DESCRIPTION
This change identifies and removes redundant logic in `pyqwk/core.py`. Specifically, in the `_parse_text_messages` function, `ref_match` and `attach_match` were being re-calculated using the same regex and input string just a few lines after their initial assignment.

**Changes:**
- Deleted redundant assignments of `ref_match` and `attach_match`.
- Ensured subsequent `if` blocks use the existing variables.

**Verification:**
- Ran `pytest` on the entire repository (861 passed).
- Verified with a targeted reproduction script that no `NameError` is raised and data extraction (Reference # and Attachments) remains functional.
- Confirmed the variables are correctly initialized at the start of the loop (formerly lines 1443-1444).

---
*PR created automatically by Jules for task [6650744755942733026](https://jules.google.com/task/6650744755942733026) started by @RainRat*