### PR TITLE
[DOCS] Synchronize supported formats list in Graphical Reader

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -330,7 +330,7 @@ class QwkGuiApp:
         self.detail_text.insert(tk.END, "Use Ctrl+O or the 'Open' button in the toolbar to load a message archive.\n\n", "body")
 
         self.detail_text.insert(tk.END, "Supported Formats:\n", "header_label")
-        formats = "QWK, REP, JSON, JSONL, CSV, SQLite (.db), XML, mbox, EML, Markdown, and MESSAGES.DAT"
+        formats = "QWK, REP, ZIP, TAR, JSON, JSONL, CSV, RSS, SQLite (.db), XML, mbox, EML, Markdown, HTML, Plain Text, and data files (MESSAGES.DAT, REPLY.DAT)"
         self.detail_text.insert(tk.END, f"{formats}\n\n", "body")
 
         self.detail_text.insert(tk.END, "Keyboard Shortcuts:\n", "header_label")
@@ -2087,7 +2087,7 @@ def main() -> None:
     parser.add_argument(
         "paths",
         nargs="*",
-        help="Path to message archives, ZIP files, or folders. Supports QWK, REP, JSON, JSONL, CSV, XML, RSS, MBOX, EML, SQLite, Markdown, and HTML.",
+        help="Path to message archives, ZIP and TAR archives, or folders. Supports QWK, REP, JSON, JSONL, CSV, XML, RSS, MBOX, EML, SQLite, Markdown, HTML, and Plain Text. ZIP and TAR archives can contain multiple files and formats which will be merged.",
     )
     args = parser.parse_args()
 

--- a/tests/test_welcome_screen_formats.py
+++ b/tests/test_welcome_screen_formats.py
@@ -1,0 +1,41 @@
+from unittest.mock import MagicMock, patch
+import tkinter as tk
+
+def test_welcome_screen_supported_formats():
+    """Verify that the welcome screen lists all supported formats accurately."""
+    mock_root = MagicMock()
+
+    with patch("pyqwk.gui.tk") as patched_tk, \
+         patch("pyqwk.gui.ttk"), \
+         patch("pyqwk.gui.font"):
+
+        from pyqwk.gui import QwkGuiApp
+
+        # Setup the Text mock
+        mock_detail_text = MagicMock()
+        patched_tk.Text.return_value = mock_detail_text
+
+        # Also need to mock BooleanVar and StringVar since they are used in __init__
+        patched_tk.BooleanVar.return_value = MagicMock()
+        patched_tk.StringVar.return_value = MagicMock()
+        patched_tk.END = tk.END
+
+        # Create instance
+        app = QwkGuiApp(mock_root)
+        app._render_welcome_screen()
+
+        # Gather all inserted text
+        inserted_text = ""
+        for call in mock_detail_text.insert.call_args_list:
+            args, _ = call
+            if len(args) >= 2:
+                inserted_text += str(args[1])
+
+        # Check for new formats
+        assert "RSS" in inserted_text
+        assert "TAR" in inserted_text
+        assert "ZIP" in inserted_text
+        assert "HTML" in inserted_text
+        assert "Plain Text" in inserted_text
+        assert "REPLY.DAT" in inserted_text
+        assert "MESSAGES.DAT" in inserted_text


### PR DESCRIPTION
Updated `_render_welcome_screen` and the `main()` function's `argparse` help string in `pyqwk/gui.py`. Synchronized the list of supported formats in the Graphical Reader with the core library and main CLI tool, ensuring users are aware of all supported types, including RSS, TAR, HTML, and Plain Text. Added a new test case `tests/test_welcome_screen_formats.py` to verify these strings.

---
*PR created automatically by Jules for task [1998505747436877827](https://jules.google.com/task/1998505747436877827) started by @RainRat*