### PR TITLE
[UI/UX] Add 'Redact PII' toggle to the GUI reader

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -89,6 +89,7 @@ class QwkGuiApp:
         self.has_emails_var = tk.BooleanVar(value=False)
         self.has_phones_var = tk.BooleanVar(value=False)
         self.has_ansi_var = tk.BooleanVar(value=False)
+        self.redact_pii_var = tk.BooleanVar(value=False)
 
         self.search_var = tk.StringVar()
         self.search_var.trace_add("write", self._on_search_changed)
@@ -560,6 +561,7 @@ class QwkGuiApp:
         self.has_emails_var.set(False)
         self.has_phones_var.set(False)
         self.has_ansi_var.set(False)
+        self.redact_pii_var.set(False)
         self.wrap_var.set(True)
         self._update_wrap()
         self.reload_messages()
@@ -680,6 +682,7 @@ class QwkGuiApp:
             ("Clean", self.clean_var, self.reload_messages),
             ("Wrap", self.wrap_var, self._update_wrap),
             ("Remove Colors", self.ansi_var, self.reload_messages),
+            ("Redact PII", self.redact_pii_var, self.reload_messages),
         ]):
             l_padx = (10, 5) if i == 0 else 5
             ttk.Checkbutton(
@@ -855,7 +858,7 @@ class QwkGuiApp:
             individual_files=False,
             threaded=self.threaded_var.get(),
             binaries_removal=clean,
-            redact_pii=False,
+            redact_pii=self.redact_pii_var.get(),
             strip_ansi=clean or self.ansi_var.get(),
             format='text',
             separator='none',

--- a/verify_gui.py
+++ b/verify_gui.py
@@ -1,0 +1,25 @@
+import tkinter as tk
+from pyqwk.gui import QwkGuiApp
+import os
+
+def verify():
+    root = tk.Tk()
+    app = QwkGuiApp(root)
+    # Give it some time to render
+    root.update()
+
+    # Verify the checkbutton exists in the toolbar
+    # We can search through the children of the toolbar
+    found = False
+    for child in root.winfo_children():
+        if isinstance(child, tk.Frame) or 'frame' in str(child).lower():
+            for grandchild in child.winfo_children():
+                 if 'Redact PII' in str(grandchild):
+                     found = True
+                     break
+
+    print(f"Redact PII found: {hasattr(app, 'redact_pii_var')}")
+    root.destroy()
+
+if __name__ == "__main__":
+    verify()


### PR DESCRIPTION
**Context:** GUI
**Problem:** The GUI reader lacked a way to redact personal identifiable information (PII) like emails and phone numbers, a feature already supported by the core engine and CLI.
**Solution:** Added a "Redact PII" toggle to the "View" section of the toolbar. This allows users to easily hide private information for privacy or when taking screenshots. It is integrated into the existing message processing pipeline and respects the "Reset All" action.

---
*PR created automatically by Jules for task [5103251816910791030](https://jules.google.com/task/5103251816910791030) started by @RainRat*