### PR TITLE
[DOCS] Synchronize supported format lists in GUI and docstrings

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -1685,7 +1685,7 @@ def load_data(
     """Load message data and conference mappings from an archive file.
 
     This function handles both older formats (QWK, REP) and modern
-    formats (JSON, SQLite, XML, CSV, mbox, EML).
+    formats (JSON, JSONL, SQLite, XML, RSS, CSV, mbox, EML, Markdown, HTML, Plain Text).
 
     Args:
         input_path: Path to the archive file or an original 'MESSAGES.DAT' file.

--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -330,7 +330,7 @@ class QwkGuiApp:
         self.detail_text.insert(tk.END, "Use Ctrl+O or the 'Open' button in the toolbar to load a message archive.\n\n", "body")
 
         self.detail_text.insert(tk.END, "Supported Formats:\n", "header_label")
-        formats = "QWK, REP, JSON, JSONL, CSV, SQLite (.db), XML, mbox, EML, Markdown, and MESSAGES.DAT"
+        formats = "QWK, REP, ZIP, TAR, JSON, JSONL, CSV, SQLite (.db), XML, RSS, mbox, EML, Markdown, HTML, Plain Text, and data files (MESSAGES.DAT, REPLY.DAT)"
         self.detail_text.insert(tk.END, f"{formats}\n\n", "body")
 
         self.detail_text.insert(tk.END, "Keyboard Shortcuts:\n", "header_label")
@@ -2087,7 +2087,7 @@ def main() -> None:
     parser.add_argument(
         "paths",
         nargs="*",
-        help="Path to message archives, ZIP files, or folders. Supports QWK, REP, JSON, JSONL, CSV, XML, RSS, MBOX, EML, SQLite, Markdown, and HTML.",
+        help="Path to message archives, ZIP and TAR archives, or folders. Supports QWK, REP, JSON, JSONL, CSV, XML, RSS, mbox, EML, SQLite, Markdown, HTML, Plain Text, and data files (MESSAGES.DAT, REPLY.DAT).",
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
* **Type:** Internal Help
* **What:** Synchronized the lists of supported file formats in the Graphical Reader's welcome screen, its CLI help string, and the core library's `load_data` docstring.
* **Why:** The previous documentation was inconsistent and omitted several supported modern and archive formats (ZIP, TAR, JSONL, RSS, HTML, and Plain Text). This change provides users with a clear and comprehensive understanding of the tool's capabilities across all interfaces.

---
*PR created automatically by Jules for task [17017524527083003305](https://jules.google.com/task/17017524527083003305) started by @RainRat*