### PR TITLE
[FEAT] Customizable one-line summary patterns

### DIFF
--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -257,6 +257,10 @@ examples:
         action='store_true',
     )
     format_group.add_argument(
+        '--oneline-pattern',
+        help="Set a custom pattern for one-line summaries (e.g., '[{confnum}] {author}: {subject}'). Available variables: confnum, confname, msgnum, author, to, subject, date, time, year, month, day, hour, minute, second, iso_date, iso_time, bbs_name, bbs_id, length, size, flags, snippet, indent.",
+    )
+    format_group.add_argument(
         '--toc',
         dest='include_toc',
         help='Add a table of contents and archive summary to the output.',
@@ -582,7 +586,8 @@ examples:
         sort=args.sort,
         reverse=args.reverse,
         dry_run=args.dry_run,
-        oneline=args.oneline,
+        oneline=args.oneline or bool(getattr(args, 'oneline_pattern', None)),
+        oneline_pattern=getattr(args, 'oneline_pattern', None),
         has_attachments=args.has_attachments,
         mine=args.mine,
         on_this_day=args.on_this_day,

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -377,6 +377,7 @@ class ProcessingSettings:
     output_path: str | None
     encoding: str
     filename_pattern: str | None = None
+    oneline_pattern: str | None = None
     min_length: int | None = None
     max_length: int | None = None
     regex: bool = False
@@ -2442,6 +2443,57 @@ def format_size(size: int) -> str:
         return f"{size / (1024 * 1024):.1f} MB"
 
 
+def _get_message_mapping(message: ParsedMessage, count: int) -> dict[str, Any]:
+    """Generate a dictionary of variables representing a message's metadata."""
+    header = message.header
+    dt = _parse_qwk_date(header.msgdate, header.msgtime)
+
+    flags = ""
+    if header.is_private:
+        flags += "*"
+    if message.attachments:
+        flags += "@"
+
+    snippet = ""
+    if message.text:
+        # Get first non-empty line
+        for line in message.text.splitlines():
+            clean_line = line.strip()
+            if clean_line:
+                snippet = clean_line[:50]
+                break
+
+    indent = ""
+    if message.depth > 0:
+        indent = "  " * (message.depth - 1) + "└ "
+
+    return {
+        'confnum': header.confnum,
+        'confname': message.confname or "",
+        'msgnum': header.msgnum if header.msgnum is not None else count,
+        'author': header.msgfrom.strip(),
+        'to': header.msgto.strip(),
+        'subject': header.msgsubject.strip(),
+        'date': header.msgdate,
+        'time': header.msgtime,
+        'year': dt.year,
+        'month': f"{dt.month:02d}",
+        'day': f"{dt.day:02d}",
+        'hour': f"{dt.hour:02d}",
+        'minute': f"{dt.minute:02d}",
+        'second': f"{dt.second:02d}",
+        'iso_date': dt.date().isoformat(),
+        'iso_time': dt.time().isoformat(),
+        'bbs_name': message.bbs_name or "",
+        'bbs_id': message.bbs_id or "",
+        'length': len(message.text) if message.text else 0,
+        'size': format_size(len(message.text)) if message.text else "0 B",
+        'flags': flags,
+        'snippet': snippet,
+        'indent': indent,
+    }
+
+
 def _generate_safe_filename(message: ParsedMessage, settings_or_format: ProcessingSettings | str, count: int) -> str:
     """Generate a human-readable filename for an individual message."""
     if isinstance(settings_or_format, ProcessingSettings):
@@ -2455,19 +2507,27 @@ def _generate_safe_filename(message: ParsedMessage, settings_or_format: Processi
 
     if settings and settings.filename_pattern:
         try:
-            mapping = {
-                'date': _slugify(message.header.msgdate, "date"),
-                'time': _slugify(message.header.msgtime, "time"),
-                'author': _slugify(message.header.msgfrom, "author"),
-                'to': _slugify(message.header.msgto, "to"),
-                'subject': _slugify(message.header.msgsubject, "subject"),
-                'msgnum': message.msgnum if message.msgnum is not None else count,
-                'confnum': message.confnum,
-                'confname': _slugify(message.confname or f"conf_{message.confnum}", "conf"),
-                'bbs_name': _slugify(message.bbs_name or "bbs", "bbs"),
-                'bbs_id': _slugify(message.bbs_id or "id", "id"),
-                'length': len(message.text) if message.text else 0,
+            raw_mapping = _get_message_mapping(message, count)
+
+            # Map of variable names to their slugify defaults for filename compatibility
+            defaults = {
+                'confname': 'conf',
+                'bbs_name': 'bbs',
+                'bbs_id': 'id',
             }
+
+            # Slugify all string values for use in a filename
+            mapping = {}
+            for k, v in raw_mapping.items():
+                if isinstance(v, str):
+                    df = defaults.get(k, k)
+                    if k == 'confname' and not v:
+                        mapping[k] = _slugify(f"conf_{message.confnum}", "conf")
+                    else:
+                        mapping[k] = _slugify(v, df)
+                else:
+                    mapping[k] = v
+
             # Use formatting while preserving the pattern's intent
             filename = settings.filename_pattern.format(**mapping)
             # Basic sanitization of the resulting filename (replace any remaining odd chars)
@@ -2635,17 +2695,46 @@ def process_merged_files(
             )
 
         if settings.oneline:
-            processed_buffer = parsed_message.header.format_oneline(
-                board_dict,
-                use_colors=use_colors,
-                highlight_term=settings.search_term,
-                is_regex=settings.regex,
-                verbose=settings.verbose,
-                depth=parsed_message.depth,
-                conf_name=parsed_message.confname,
-                is_private=parsed_message.header.is_private,
-                has_attachments=bool(parsed_message.attachments),
-            )
+            if settings.oneline_pattern:
+                try:
+                    mapping = _get_message_mapping(parsed_message, processed_count)
+                    # Apply fallbacks for oneline display
+                    if not mapping['confname']:
+                        mapping['confname'] = f"Conference {parsed_message.confnum}"
+
+                    processed_buffer = settings.oneline_pattern.format(**mapping) + "\r\n"
+                    # Apply search highlighting to the resulting line
+                    processed_buffer = _highlight_text(
+                        processed_buffer,
+                        settings.search_term,
+                        settings.regex,
+                        use_colors=use_colors
+                    )
+                except (KeyError, ValueError):
+                    # Fallback if pattern is invalid
+                    processed_buffer = parsed_message.header.format_oneline(
+                        board_dict,
+                        use_colors=use_colors,
+                        highlight_term=settings.search_term,
+                        is_regex=settings.regex,
+                        verbose=settings.verbose,
+                        depth=parsed_message.depth,
+                        conf_name=parsed_message.confname,
+                        is_private=parsed_message.header.is_private,
+                        has_attachments=bool(parsed_message.attachments),
+                    )
+            else:
+                processed_buffer = parsed_message.header.format_oneline(
+                    board_dict,
+                    use_colors=use_colors,
+                    highlight_term=settings.search_term,
+                    is_regex=settings.regex,
+                    verbose=settings.verbose,
+                    depth=parsed_message.depth,
+                    conf_name=parsed_message.confname,
+                    is_private=parsed_message.header.is_private,
+                    has_attachments=bool(parsed_message.attachments),
+                )
         else:
             processed_buffer = cleaned_body
 
@@ -3868,7 +3957,7 @@ def _write_text(
         and sys.stdout.isatty()
     )
 
-    if settings and settings.oneline:
+    if settings and settings.oneline and not settings.oneline_pattern:
         msgnum_hdr = f"{'Num':<6} " if settings.verbose else ""
         conf_hdr = f"{'Conference':<12}"
         date_hdr = f"{'Date':<14}"
@@ -3924,20 +4013,49 @@ def _write_text(
             separator_line = f"\x1b[90m{separator_line}\x1b[0m"
         parts.append(separator_line)
 
-    for message in messages:
+    for i, message in enumerate(messages):
         if settings and settings.oneline:
-            # Re-format oneline summary to account for threading depth
-            text = message.header.format_oneline(
-                {},  # board_dict not needed when conf_name is provided
-                use_colors=use_colors,
-                highlight_term=settings.search_term,
-                is_regex=settings.regex,
-                verbose=settings.verbose,
-                depth=message.depth,
-                conf_name=message.confname,
-                is_private=message.header.is_private,
-                has_attachments=bool(message.attachments),
-            )
+            if settings.oneline_pattern:
+                try:
+                    mapping = _get_message_mapping(message, i + 1)
+                    # Apply fallbacks for oneline display
+                    if not mapping['confname']:
+                        mapping['confname'] = f"Conference {message.confnum}"
+
+                    text = settings.oneline_pattern.format(**mapping) + "\r\n"
+                    # Apply search highlighting to the resulting line
+                    text = _highlight_text(
+                        text,
+                        settings.search_term,
+                        settings.regex,
+                        use_colors=use_colors
+                    )
+                except (KeyError, ValueError):
+                    # Fallback if pattern is invalid
+                    text = message.header.format_oneline(
+                        {},
+                        use_colors=use_colors,
+                        highlight_term=settings.search_term,
+                        is_regex=settings.regex,
+                        verbose=settings.verbose,
+                        depth=message.depth,
+                        conf_name=message.confname,
+                        is_private=message.header.is_private,
+                        has_attachments=bool(message.attachments),
+                    )
+            else:
+                # Re-format oneline summary to account for threading depth
+                text = message.header.format_oneline(
+                    {},  # board_dict not needed when conf_name is provided
+                    use_colors=use_colors,
+                    highlight_term=settings.search_term,
+                    is_regex=settings.regex,
+                    verbose=settings.verbose,
+                    depth=message.depth,
+                    conf_name=message.confname,
+                    is_private=message.header.is_private,
+                    has_attachments=bool(message.attachments),
+                )
         else:
             text = message.text
 

--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -870,6 +870,8 @@ class QwkGuiApp:
             has_attachments=self.has_attach_var.get(),
             mine=self.mine_var.get(),
             on_this_day=self.on_this_day_var.get(),
+            oneline=False,
+            oneline_pattern=None,
             has_links=self.has_links_var.get(),
             has_emails=self.has_emails_var.get(),
             has_phones=self.has_phones_var.get(),

--- a/tests/test_oneline_pattern.py
+++ b/tests/test_oneline_pattern.py
@@ -1,0 +1,78 @@
+import pytest
+import io
+from contextlib import redirect_stdout
+from pyqwk.core import ProcessingSettings, process_merged_files, ParsedMessage, MessageHeader
+import logging
+
+def _make_msg(text, author="Alice", subject="Hello", confnum=1, msgnum=101):
+    h = MessageHeader(
+        status=" ", msgnum=msgnum, msgdate="01-23-24", msgtime="12:34",
+        msgto="Bob", msgfrom=author, msgsubject=subject, msgpassword="",
+        refnum=None, numblocks=None, msgflag=" ", confnum=confnum,
+        lognum=0, nettag=""
+    )
+    return ParsedMessage(text=text, msgnum=msgnum, refnum=None, confnum=confnum, header=h)
+
+def test_oneline_pattern(tmp_path, mocker):
+    # Mock load_data to return our test messages
+    msg = _make_msg("This is a snippet.\nSecond line.", author="Alice", subject="Custom Pattern")
+    mocker.patch('pyqwk.core.load_data', return_value=([msg], {1: "General"}))
+
+    settings = ProcessingSettings(
+        verbose=False, private=True, no_header=False, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False, binaries_removal=False,
+        redact_pii=False, format='text', separator='none', output_mode='stdout',
+        output_path=None, encoding='cp437', oneline=True,
+        oneline_pattern="[{confnum}] {author}: {subject} -> {snippet}"
+    )
+
+    logger = logging.getLogger("test")
+    f = io.StringIO()
+    with redirect_stdout(f):
+        process_merged_files(["dummy.qwk"], settings, logger)
+
+    output = f.getvalue()
+    assert "[1] Alice: Custom Pattern -> This is a snippet." in output
+
+def test_oneline_pattern_fallback(tmp_path, mocker):
+    # Invalid pattern should fallback to default oneline
+    msg = _make_msg("Body", author="Alice", subject="Fallback")
+    mocker.patch('pyqwk.core.load_data', return_value=([msg], {1: "General"}))
+
+    settings = ProcessingSettings(
+        verbose=False, private=True, no_header=False, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False, binaries_removal=False,
+        redact_pii=False, format='text', separator='none', output_mode='stdout',
+        output_path=None, encoding='cp437', oneline=True,
+        oneline_pattern="{invalid_variable}"
+    )
+
+    logger = logging.getLogger("test")
+    f = io.StringIO()
+    with redirect_stdout(f):
+        process_merged_files(["dummy.qwk"], settings, logger)
+
+    output = f.getvalue()
+    # Should contain standard oneline elements
+    assert "General" in output
+    assert "Fallback" in output
+
+def test_oneline_pattern_iso_dates(tmp_path, mocker):
+    msg = _make_msg("Body", author="Alice")
+    mocker.patch('pyqwk.core.load_data', return_value=([msg], {1: "General"}))
+
+    settings = ProcessingSettings(
+        verbose=False, private=True, no_header=False, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False, binaries_removal=False,
+        redact_pii=False, format='text', separator='none', output_mode='stdout',
+        output_path=None, encoding='cp437', oneline=True,
+        oneline_pattern="{year}-{month}-{day} {hour}:{minute}"
+    )
+
+    logger = logging.getLogger("test")
+    f = io.StringIO()
+    with redirect_stdout(f):
+        process_merged_files(["dummy.qwk"], settings, logger)
+
+    output = f.getvalue()
+    assert "2024-01-23 12:34" in output


### PR DESCRIPTION
This PR introduces the `--oneline-pattern` feature, allowing users to define custom layouts for message summaries. It leverages a new unified metadata mapping system that also enhances the existing `--filename-pattern` functionality. This feature is particularly useful for users with specific data reporting needs or varying terminal widths.

---
*PR created automatically by Jules for task [13857695226934724308](https://jules.google.com/task/13857695226934724308) started by @RainRat*