### PR TITLE
[UI/UX] Implement Continuous Reading navigation shortcuts

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -349,6 +349,9 @@ class QwkGuiApp:
             ("Shift+Enter", "Find Previous (Search)"),
             ("J / N", "Next Message"),
             ("K / P", "Previous Message"),
+            ("Space", "Scroll Down / Next"),
+            ("Shift+Space", "Scroll Up / Prev"),
+            ("BackSpace", "Scroll Up / Prev"),
         ]
 
         for key, desc in shortcuts:
@@ -479,6 +482,9 @@ class QwkGuiApp:
         self.root.bind("n", lambda e: self._select_relative_message(1))
         self.root.bind("k", lambda e: self._select_relative_message(-1))
         self.root.bind("p", lambda e: self._select_relative_message(-1))
+        self.root.bind("<space>", self._on_space_pressed)
+        self.root.bind("<Shift-space>", self._on_space_pressed)
+        self.root.bind("<BackSpace>", self._on_space_pressed)
 
     def _get_all_tree_items(self) -> list[str]:
         """Return a flattened list of all item IDs currently visible in the treeview."""
@@ -528,6 +534,33 @@ class QwkGuiApp:
         self.message_list.see(new_item)
         self.message_list.focus(new_item)
         return True
+
+    def _on_space_pressed(self, event: tk.Event) -> str | None:
+        """Handle Space, Shift+Space, and BackSpace for continuous reading."""
+        # If the search entry has focus, let it handle the keys
+        if self.root.focus_get() == self.search_entry:
+            return None
+
+        # Check scroll position: (top, bottom) as fractions of the whole
+        top, bottom = self.detail_text.yview()
+
+        # Space (Forward)
+        if event.keysym == "space" and not (event.state & 0x1):
+            if bottom < 1.0:
+                self.detail_text.yview_scroll(1, "pages")
+            else:
+                self._select_relative_message(1)
+            return "break"
+
+        # Shift+Space or BackSpace (Backward)
+        elif (event.keysym == "space" and (event.state & 0x1)) or event.keysym == "BackSpace":
+            if top > 0.0:
+                self.detail_text.yview_scroll(-1, "pages")
+            else:
+                self._select_relative_message(-1)
+            return "break"
+
+        return None
 
     def clear_search(self, _event: object | None = None) -> None:
         """Clear the search bar first, and if already empty, reset all filters."""

--- a/tests/test_gui_navigation.py
+++ b/tests/test_gui_navigation.py
@@ -1,0 +1,122 @@
+import pytest
+from unittest.mock import MagicMock, patch
+import tkinter as tk
+
+def test_on_space_pressed_scrolling():
+    """Verify that _on_space_pressed scrolls the text widget when not at the bottom."""
+    mock_root = MagicMock()
+    with patch("pyqwk.gui.tk"), \
+         patch("pyqwk.gui.ttk"), \
+         patch("pyqwk.gui.font"):
+        from pyqwk.gui import QwkGuiApp
+        app = QwkGuiApp(mock_root)
+
+        # Mock detail_text
+        app.detail_text = MagicMock()
+        # Mock yview to return (top, bottom) fractions
+        app.detail_text.yview.return_value = (0.0, 0.5)
+
+        # Simulate Space press
+        event = MagicMock()
+        event.keysym = "space"
+        event.state = 0  # No Shift
+
+        result = app._on_space_pressed(event)
+
+        assert result == "break"
+        app.detail_text.yview_scroll.assert_called_with(1, "pages")
+
+def test_on_space_pressed_advance():
+    """Verify that _on_space_pressed advances to the next message when at the bottom."""
+    mock_root = MagicMock()
+    with patch("pyqwk.gui.tk"), \
+         patch("pyqwk.gui.ttk"), \
+         patch("pyqwk.gui.font"):
+        from pyqwk.gui import QwkGuiApp
+        app = QwkGuiApp(mock_root)
+
+        # Mock detail_text at bottom
+        app.detail_text = MagicMock()
+        app.detail_text.yview.return_value = (0.5, 1.0)
+
+        # Mock message advancement
+        app._select_relative_message = MagicMock()
+
+        # Simulate Space press
+        event = MagicMock()
+        event.keysym = "space"
+        event.state = 0
+
+        result = app._on_space_pressed(event)
+
+        assert result == "break"
+        app._select_relative_message.assert_called_with(1)
+
+def test_on_shift_space_scrolling():
+    """Verify that Shift+Space scrolls the text widget up when not at the top."""
+    mock_root = MagicMock()
+    with patch("pyqwk.gui.tk"), \
+         patch("pyqwk.gui.ttk"), \
+         patch("pyqwk.gui.font"):
+        from pyqwk.gui import QwkGuiApp
+        app = QwkGuiApp(mock_root)
+
+        # Mock detail_text not at top
+        app.detail_text = MagicMock()
+        app.detail_text.yview.return_value = (0.5, 1.0)
+
+        # Simulate Shift+Space press
+        event = MagicMock()
+        event.keysym = "space"
+        event.state = 0x1  # Shift mask
+
+        result = app._on_space_pressed(event)
+
+        assert result == "break"
+        app.detail_text.yview_scroll.assert_called_with(-1, "pages")
+
+def test_on_backspace_advance_back():
+    """Verify that BackSpace advances to the previous message when at the top."""
+    mock_root = MagicMock()
+    with patch("pyqwk.gui.tk"), \
+         patch("pyqwk.gui.ttk"), \
+         patch("pyqwk.gui.font"):
+        from pyqwk.gui import QwkGuiApp
+        app = QwkGuiApp(mock_root)
+
+        # Mock detail_text at top
+        app.detail_text = MagicMock()
+        app.detail_text.yview.return_value = (0.0, 0.5)
+
+        # Mock message advancement
+        app._select_relative_message = MagicMock()
+
+        # Simulate BackSpace press
+        event = MagicMock()
+        event.keysym = "BackSpace"
+        event.state = 0
+
+        result = app._on_space_pressed(event)
+
+        assert result == "break"
+        app._select_relative_message.assert_called_with(-1)
+
+def test_space_ignored_when_search_focused():
+    """Verify that Space is ignored when the search entry has focus."""
+    mock_root = MagicMock()
+    with patch("pyqwk.gui.tk"), \
+         patch("pyqwk.gui.ttk"), \
+         patch("pyqwk.gui.font"):
+        from pyqwk.gui import QwkGuiApp
+        app = QwkGuiApp(mock_root)
+
+        app.search_entry = MagicMock()
+        mock_root.focus_get.return_value = app.search_entry
+
+        event = MagicMock()
+        event.keysym = "space"
+        event.state = 0
+
+        result = app._on_space_pressed(event)
+
+        assert result is None


### PR DESCRIPTION
**PR Title:** [UI/UX] Implement Continuous Reading navigation shortcuts

**Description:**
* **Context:** GUI
* **Problem:** Navigating through messages and their content required different sets of keys or mouse usage. Users had to manually advance after finishing a long message, creating a "stop-and-start" friction during reading.
* **Solution:** Implemented "Continuous Reading" logic. The `Space` key now scrolls the message detail view by page; if the viewer is already at the bottom, it advances to the next message. `Shift+Space` and `BackSpace` perform the same action in reverse (scrolling up or moving to the previous message). This intuitive pattern, common in web browsers and email clients, allows for seamless browsing of entire archives using a single primary key.

**Changes:**
Modified `pyqwk/gui.py` to add the `_on_space_pressed` handler, register the root key bindings, and update the welcome screen documentation. Added `tests/test_gui_navigation.py` for verification.

---
*PR created automatically by Jules for task [5821921233337345029](https://jules.google.com/task/5821921233337345029) started by @RainRat*