### PR TITLE
[UI/UX] Pre-fill search with selected text in GUI

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -647,6 +647,15 @@ class QwkGuiApp:
 
     def _focus_search(self, _event: object | None = None) -> None:
         """Focus the search bar and select all text for quick replacement."""
+        try:
+            sel_range = self.detail_text.tag_ranges("sel")
+            if sel_range:
+                selected_text = self.detail_text.get(*sel_range).strip()
+                if selected_text:
+                    self.search_var.set(selected_text)
+        except tk.TclError:
+            pass
+
         self.search_entry.focus_set()
         self.search_entry.selection_range(0, tk.END)
 

--- a/tests/test_gui_ctrl_f_selection.py
+++ b/tests/test_gui_ctrl_f_selection.py
@@ -1,0 +1,69 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+# Mock tkinter before any pyqwk.gui imports
+mock_tk = MagicMock()
+mock_ttk = MagicMock()
+sys.modules["tkinter"] = mock_tk
+sys.modules["tkinter.filedialog"] = MagicMock()
+sys.modules["tkinter.messagebox"] = MagicMock()
+sys.modules["tkinter.simpledialog"] = MagicMock()
+sys.modules["tkinter.font"] = MagicMock()
+sys.modules["tkinter.ttk"] = mock_ttk
+
+import pytest
+from pyqwk.gui import QwkGuiApp
+
+@pytest.fixture
+def app():
+    root = MagicMock()
+    root.after = MagicMock()
+    # Mock search_var as it's initialized with tk.StringVar()
+    with patch("pyqwk.gui.tk.StringVar"), patch("pyqwk.gui.tk.BooleanVar"), patch("pyqwk.gui.font.Font"):
+        app = QwkGuiApp(root)
+        app.search_var = MagicMock()
+        app.detail_text = MagicMock()
+        app.search_entry = MagicMock()
+        return app
+
+def test_focus_search_with_selection(app):
+    """Verify that _focus_search updates search_var when text is selected."""
+    # Simulate a selection
+    app.detail_text.tag_ranges.return_value = ("1.0", "1.4")
+    app.detail_text.get.return_value = "selected"
+
+    app._focus_search()
+
+    app.search_var.set.assert_called_once_with("selected")
+    app.search_entry.focus_set.assert_called_once()
+    # We use "end" as a string instead of tk.END to avoid importing tkinter
+    app.search_entry.selection_range.assert_called_once()
+
+def test_focus_search_without_selection(app):
+    """Verify that _focus_search does not update search_var when no text is selected."""
+    # Simulate no selection
+    app.detail_text.tag_ranges.return_value = ()
+
+    app._focus_search()
+
+    app.search_var.set.assert_not_called()
+    app.search_entry.focus_set.assert_called_once()
+    app.search_entry.selection_range.assert_called_once()
+
+def test_focus_search_tcl_error(app):
+    """Verify that _focus_search handles errors gracefully."""
+    # We mock TclError as well since it's in tkinter
+    import pyqwk.gui
+    app.detail_text.tag_ranges.side_effect = Exception("TclError simulation")
+
+    # Should not raise exception because of the broad except block or specific handling
+    # In my implementation I used 'except tk.TclError'
+    # Since tk is mocked, tk.TclError is also a mock.
+    # To catch it, we need the side_effect to be an instance of that mock.
+
+    with patch("pyqwk.gui.tk.TclError", new=RuntimeError):
+        app.detail_text.tag_ranges.side_effect = RuntimeError("Selection not found")
+        app._focus_search()
+
+    app.search_var.set.assert_not_called()
+    app.search_entry.focus_set.assert_called_once()


### PR DESCRIPTION
### Context
GUI

### Problem
When reading messages, users often want to search for a specific word or phrase they've just encountered. Currently, they have to manually highlight the text, copy it, press `Ctrl+F`, and then paste it into the search bar. This multi-step process adds unnecessary friction.

### Solution
I have updated the `_focus_search` method, which is triggered by the `Ctrl+F` shortcut and the "Find" menu item. The method now checks if there is any text currently selected in the message detail viewer (`detail_text`). If a selection is found, it is automatically set as the new search term in the search bar. This aligns the application's behavior with modern standards seen in web browsers and code editors, providing a more efficient "Invisible Design" improvement.

### Changes
- Updated `pyqwk/gui.py`: Enhanced `_focus_search` to utilize `self.detail_text.tag_ranges("sel")`.
- Added `tests/test_gui_ctrl_f_selection.py`: Verified that `Ctrl+F` correctly populates the search bar when text is selected, handles empty selections, and remains stable if Tcl errors occur.

---
*PR created automatically by Jules for task [148410585787573509](https://jules.google.com/task/148410585787573509) started by @RainRat*