### PR TITLE
[FEAT] Extend metadata variables for custom patterns

### DIFF
--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -139,7 +139,7 @@ examples:
     )
     io_group.add_argument(
         "--filename-pattern",
-        help="Set a pattern for naming individual files (e.g., '{date}_{author}_{subject}'). Available variables: date, time, author, to, subject, msgnum, confnum, confname, bbs_name, bbs_id, length.",
+        help="Set a pattern for naming individual files (e.g., '{date}_{author}_{subject}'). Available variables: date, time, author, to, subject, subject_clean, msgnum, confnum, confname, confname_or_num, bbs_name, bbs_id, length, source_file, refnum, status, msgflag, is_private, is_reply, attachments, attachment_count.",
     )
     io_group.add_argument(
         "-E",
@@ -274,7 +274,7 @@ examples:
     )
     format_group.add_argument(
         "--oneline-pattern",
-        help="Set a custom pattern for one-line summaries (e.g., '[{confnum}] {author}: {subject}'). Available variables: confnum, confname, msgnum, author, to, subject, date, time, year, month, day, hour, minute, second, iso_date, iso_time, bbs_name, bbs_id, length, size, flags, snippet, indent.",
+        help="Set a custom pattern for one-line summaries (e.g., '[{confnum}] {author}: {subject}'). Available variables: confnum, confname, confname_or_num, msgnum, author, to, subject, subject_clean, date, time, year, month, day, hour, minute, second, iso_date, iso_time, bbs_name, bbs_id, source_file, refnum, status, msgflag, is_private, is_reply, attachments, attachment_count, length, size, flags, snippet, indent.",
     )
     format_group.add_argument(
         "--toc",

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -2712,23 +2712,41 @@ def _get_message_mapping(
     author = header.msgfrom.strip()
     to = header.msgto.strip()
     subject = header.msgsubject.strip()
+
+    subject_clean = subject
+    while True:
+        new_subject_clean = RE_SUBJECT_PREFIX_PATTERN.sub("", subject_clean)
+        if new_subject_clean == subject_clean:
+            break
+        subject_clean = new_subject_clean
+
     if redact_pii:
         author = _redact_pii(author)
         to = _redact_pii(to)
         subject = _redact_pii(subject)
+        subject_clean = _redact_pii(subject_clean)
         snippet = _redact_pii(snippet)
 
     indent = ""
     if message.depth > 0:
         indent = "  " * (message.depth - 1) + "└ "
 
+    is_reply = (
+        header.refnum is not None and header.refnum != 0
+    ) or RE_SUBJECT_PREFIX_PATTERN.match(header.msgsubject)
+
+    attachments_list = message.attachments or []
+    attachments_str = ", ".join(attachments_list)
+
     return {
         "confnum": header.confnum,
         "confname": message.confname or "",
+        "confname_or_num": message.confname or str(header.confnum),
         "msgnum": header.msgnum if header.msgnum is not None else count,
         "author": author,
         "to": to,
         "subject": subject,
+        "subject_clean": subject_clean,
         "date": header.msgdate,
         "time": header.msgtime,
         "year": dt.year,
@@ -2741,6 +2759,14 @@ def _get_message_mapping(
         "iso_time": dt.time().isoformat(),
         "bbs_name": message.bbs_name or "",
         "bbs_id": message.bbs_id or "",
+        "source_file": message.source_file or "",
+        "refnum": header.refnum if header.refnum is not None else 0,
+        "status": header.status,
+        "msgflag": header.msgflag,
+        "is_private": "true" if header.is_private else "false",
+        "is_reply": "true" if is_reply else "false",
+        "attachments": attachments_str,
+        "attachment_count": len(attachments_list),
         "length": len(message.text) if message.text else 0,
         "size": format_size(len(message.text)) if message.text else "0 B",
         "flags": flags,

--- a/tests/test_pattern_variables.py
+++ b/tests/test_pattern_variables.py
@@ -1,0 +1,117 @@
+import pytest
+from pyqwk.core import ParsedMessage, MessageHeader, _get_message_mapping
+
+def test_extended_pattern_variables():
+    header = MessageHeader(
+        status="*",
+        msgnum=123,
+        msgdate="10-12-23",
+        msgtime="14:30:00",
+        msgto="Recipient Name",
+        msgfrom="Author Name",
+        msgsubject="Re[123]: Important Subject",
+        msgpassword="",
+        refnum=456,
+        numblocks=2,
+        msgflag=" ",
+        confnum=1,
+        lognum=0,
+        nettag=" "
+    )
+
+    message = ParsedMessage(
+        text="Sample message body",
+        msgnum=123,
+        refnum=456,
+        confnum=1,
+        header=header,
+        confname="General",
+        bbs_name="The BBS",
+        bbs_id="THEBBS",
+        source_file="archive.qwk",
+        attachments=["file1.zip", "image.jpg"]
+    )
+
+    mapping = _get_message_mapping(message, count=1)
+
+    # Existing variables
+    assert mapping["author"] == "Author Name"
+    assert mapping["to"] == "Recipient Name"
+    assert mapping["subject"] == "Re[123]: Important Subject"
+    assert mapping["confnum"] == 1
+    assert mapping["confname"] == "General"
+
+    # New variables
+    assert mapping["subject_clean"] == "Important Subject"
+    assert mapping["confname_or_num"] == "General"
+    assert mapping["source_file"] == "archive.qwk"
+    assert mapping["refnum"] == 456
+    assert mapping["status"] == "*"
+    assert mapping["msgflag"] == " "
+    assert mapping["is_private"] == "true"
+    assert mapping["is_reply"] == "true"
+    assert mapping["attachments"] == "file1.zip, image.jpg"
+    assert mapping["attachment_count"] == 2
+
+def test_extended_variables_redact_pii():
+    header = MessageHeader(
+        status=" ",
+        msgnum=123,
+        msgdate="10-12-23",
+        msgtime="14:30:00",
+        msgto="Recipient Name",
+        msgfrom="Author Name",
+        msgsubject="Re: Contact me at 555-1234",
+        msgpassword="",
+        refnum=0,
+        numblocks=1,
+        msgflag=" ",
+        confnum=1,
+        lognum=0,
+        nettag=" "
+    )
+
+    message = ParsedMessage(
+        text="Sample message body with email@example.com",
+        msgnum=123,
+        refnum=None,
+        confnum=1,
+        header=header
+    )
+
+    mapping = _get_message_mapping(message, count=1, redact_pii=True)
+
+    assert mapping["subject"] == "Re: Contact me at [PHONE]"
+    assert mapping["subject_clean"] == "Contact me at [PHONE]"
+    assert mapping["snippet"] == "Sample message body with [EMAIL]"
+
+def test_confname_or_num_fallback():
+    header = MessageHeader(
+        status=" ",
+        msgnum=123,
+        msgdate="10-12-23",
+        msgtime="14:30:00",
+        msgto="Recipient",
+        msgfrom="Author",
+        msgsubject="Subject",
+        msgpassword="",
+        refnum=None,
+        numblocks=1,
+        msgflag=" ",
+        confnum=42,
+        lognum=0,
+        nettag=" "
+    )
+
+    message = ParsedMessage(
+        text="Text",
+        msgnum=123,
+        refnum=None,
+        confnum=42,
+        header=header,
+        confname=None
+    )
+
+    mapping = _get_message_mapping(message, count=1)
+    assert mapping["confname"] == ""
+    assert mapping["confname_or_num"] == "42"


### PR DESCRIPTION
This PR extends the set of metadata variables available for use in `--oneline-pattern` (for terminal output) and `--filename-pattern` (for individual file export).

### Added Variables:
- `subject_clean`: The subject line with common prefixes like "Re:" and "Fwd:" removed.
- `is_reply`: A boolean flag ("true"/"false") indicating if the message is a reply.
- `is_private`: A boolean flag ("true"/"false") indicating if the message is private.
- `confname_or_num`: A fallback that uses the conference name if available, otherwise the conference number.
- `attachments`: A comma-separated string of attachment filenames.
- `attachment_count`: The number of attachments in the message.
- `source_file`: The name of the archive file where the message was found.
- `refnum`: The reference message number.
- `status` & `msgflag`: Low-level QWK header status and flag characters.

### Why:
Users often need better control over how files are organized and how summaries are displayed. `subject_clean` allows for much cleaner file naming by grouping related messages without "Re:" prefixes. The inclusion of boolean flags and attachment info enables more descriptive summaries and better automation for downstream tools.

### Verification:
- Added `tests/test_pattern_variables.py` covering all new variables and PII redaction.
- Verified that all 884 existing tests pass.
- Updated CLI help text to document the new variables.

---
*PR created automatically by Jules for task [5282866406522605648](https://jules.google.com/task/5282866406522605648) started by @RainRat*