### PR TITLE
[DOCS] Improve CLI help for input paths

### DIFF
--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -93,7 +93,7 @@ examples:
     )
     parser.add_argument(
         "input_paths",
-        help="Path to message archives, ZIP and TAR archives, or folders. Supports QWK, REP, JSON, JSONL, CSV, XML, RSS, MBOX, EML, SQLite, Markdown, HTML, and Plain Text. ZIP and TAR archives can contain multiple files and formats which will be merged.",
+        help="Path to message archives, ZIP and TAR archives, or folders. Supports QWK, REP, JSON, JSONL, CSV, XML, RSS, mbox, EML, SQLite, Markdown, HTML, Plain Text, and data files (MESSAGES.DAT, REPLY.DAT). ZIP and TAR archives can contain multiple files and formats which the tool merges automatically.",
         nargs="+",
     )
 


### PR DESCRIPTION
* **Type:** Internal Help
* **What:** Updated the `input_paths` argument help string in `pyqwk/cli.py`.
* **Why:** Clarified which files are supported by explicitly mentioning `MESSAGES.DAT` and `REPLY.DAT`, standardized "mbox" casing, and used active voice to describe the merging process for better accessibility and clarity.

---
*PR created automatically by Jules for task [3074719668826361569](https://jules.google.com/task/3074719668826361569) started by @RainRat*