### PR TITLE
Fix Base64 attachment truncation and decoding failures

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -142,7 +142,7 @@ RE_UUE_LOOSE_PATTERN = re.compile(r"^[\x21-\x4d][\x21-\x60]{1,60}$")
 # Identify Base64 blocks by looking for long strings of characters commonly used in Base64 encoding.
 RE_BASE64_PATTERN = re.compile(r"^[A-Za-z0-9+/=]{60,}$")
 RE_YENC_PATTERN = re.compile(r"^=y(begin|part|end)")
-RE_BASE64_LOOSE_PATTERN = re.compile(r"^[A-Za-z0-9+/=]{4,}$")
+RE_BASE64_LOOSE_PATTERN = re.compile(r"^[A-Za-z0-9+/=]{1,}$")
 RE_EMAIL_PATTERN = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
 RE_URL_PATTERN = re.compile(
     r'\b(?:https?|ftp|telnet|gopher)://[^\s<>"]+|www\.[^\s<>"]+', re.IGNORECASE
@@ -366,7 +366,12 @@ def extract_binaries(text: str) -> list[tuple[str, bytes]]:
                     continue
         elif in_base64:
             try:
-                decoded = base64.b64decode("".join(current_data))
+                # Append missing padding to ensure valid Base64 decoding
+                b64_str = "".join(current_data)
+                padding_needed = (4 - (len(b64_str) % 4)) % 4
+                if padding_needed != 3:  # 1 extra char is invalid in Base64
+                    b64_str += "=" * padding_needed
+                decoded = base64.b64decode(b64_str)
             except (binascii.Error, ValueError, TypeError):
                 decoded = b""
         elif in_yenc:

--- a/tests/test_base64_truncation.py
+++ b/tests/test_base64_truncation.py
@@ -1,0 +1,31 @@
+import base64
+from pyqwk.core import extract_binaries
+
+def test_base64_truncation_short_final_line():
+    # 64 chars of Base64
+    line64 = "A" * 64
+    # A final line with 3 characters (unpadded Base64 for 2 bytes)
+    # "AB" in base64 is "QUI="
+    # Unpadded it is "QUI"
+    final_line = "QUI"
+
+    text = f"""
+{line64}
+{final_line}
+"""
+    binaries = extract_binaries(text)
+    # If the bug exists, it might either not find a binary at all (if only one line matches)
+    # or it will find it but truncate it.
+    assert len(binaries) == 1, "Should have found one binary attachment"
+    _, decoded_data = binaries[0]
+
+    full_b64 = line64 + final_line
+    # Add padding to make it valid for base64.b64decode
+    padding_needed = (4 - (len(full_b64) % 4)) % 4
+    if padding_needed == 1:
+        # 1 extra character is impossible in base64, so padding_needed won't be 1 for valid unpadded.
+        pass
+
+    reference_data = base64.b64decode(full_b64 + "=" * padding_needed)
+
+    assert len(decoded_data) == len(reference_data), f"Expected {len(reference_data)} bytes, got {len(decoded_data)}. Final line '{final_line}' was likely truncated."


### PR DESCRIPTION
This change fixes a logic bug in the `extract_binaries` function where Base64-encoded binary attachments would be truncated or fail to decode if the final line of the block was short (less than 4 characters) or lacked proper padding.

Technical changes:
- `RE_BASE64_LOOSE_PATTERN` now allows lines as short as 1 character to be matched as part of a Base64 block.
- `_flush_binary` now calculates the number of padding characters needed and appends them to the Base64 string before calling `base64.b64decode`. It also includes a check to avoid padding strings that are invalid for Base64 (length $4n+1$).
- A new test file `tests/test_base64_truncation.py` provides a reproduction case for the reported issue.

This improvement ensures better compatibility with various unpadded or "lazy" Base64 implementations found in older BBS message archives.

---
*PR created automatically by Jules for task [2207843511124661982](https://jules.google.com/task/2207843511124661982) started by @RainRat*