### PR TITLE
[TEST] Close coverage gap for text import in core

### DIFF
--- a/tests/test_lead_qa_core_text_coverage.py
+++ b/tests/test_lead_qa_core_text_coverage.py
@@ -98,3 +98,14 @@ def test_parse_text_messages_date_std_match_logic(tmp_path):
     assert len(messages) == 1
     assert messages[0].header.msgdate == "01-01-2024"
     assert messages[0].header.msgtime == "12:00"
+
+
+def test_parse_text_messages_leading_empty_lines(tmp_path):
+    content = "------------------------------\n\nFrom: Alice\nTo: Bob\nSubject: Hello\n\nBody content"
+    txt_file = tmp_path / "leading_empty.txt"
+    txt_file.write_text(content)
+
+    messages = _parse_text_messages(str(txt_file))
+    assert len(messages) == 1
+    assert messages[0].header.msgfrom == "Alice"
+    assert messages[0].text == "Body content"


### PR DESCRIPTION
* **Type:** New Coverage
* **What:** Added `test_parse_text_messages_leading_empty_lines` to `tests/test_lead_qa_core_text_coverage.py`.
* **Why:** This test case covers lines 1596-1597 in `pyqwk/core.py`, which handles skipping leading empty lines in a message section during plain text import. This brings `pyqwk/core.py` to 100% statement coverage.

---
*PR created automatically by Jules for task [8395191651550052341](https://jules.google.com/task/8395191651550052341) started by @RainRat*