### PR TITLE
Remove redundant validation in _safe_to_int

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -1116,8 +1116,6 @@ def _parse_json_messages(
 
 def _safe_to_int(v: Any) -> int | None:
     """Safely convert a value to an integer, returning None on failure."""
-    if v is None or v == "":
-        return None
     try:
         return int(v)
     except (ValueError, TypeError):


### PR DESCRIPTION
* **What:** Removed the explicit check for `None` and empty strings in the `_safe_to_int` helper function.
* **Why:** The `int()` function already raises `TypeError` for `None` and `ValueError` for empty strings. Since these exceptions are already caught by the existing `try/except` block, the explicit check was redundant. This simplification improves code clarity without changing the function's external behavior.

---
*PR created automatically by Jules for task [12748035140644862738](https://jules.google.com/task/12748035140644862738) started by @RainRat*