### PR TITLE
[DOCS] Enhance README with missing CLI options and format clarifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ pyqwk helps you open these archives and convert them into modern, readable forma
 
 | Format | Import | Export | Notes |
 | :--- | :---: | :---: | :--- |
-| **QWK / REP** | ✅ | ✅ | Classic BBS packets (.qwk, .rep, .zip, .tar, .tar.gz, .tar.bz2, .tgz, messages.dat) |
+| **QWK / REP** | ✅ | ✅ | Classic BBS packets (.qwk, .rep, .zip, .tar, .tar.gz, .tar.bz2, .tgz, messages.dat, reply.dat) |
 | **JSON / JSONL** | ✅ | ✅ | Modern structured data (.json, .jsonl) |
 | **HTML** | ✅ | ✅ | Browsable files with threading and charts (.html, .htm) |
 | **Markdown** | ✅ | ✅ | Readable text files (.md, .markdown) |
@@ -147,6 +147,15 @@ qwk-gui messages.db
 **Read an archive:**
 ```bash
 qwk archive.qwk
+```
+
+**Show a quick summary:**
+```bash
+# Standard one-line summary
+qwk archive.qwk --oneline
+
+# Custom summary with specific information
+qwk archive.qwk --oneline-pattern "[{confnum}] {author}: {subject}"
 ```
 
 **Save as a text file:**
@@ -339,6 +348,9 @@ for msg in messages:
 | `-r, --redact-pii` | Hide emails and phone numbers. |
 | `-E, --encoding` | Set text encoding (default is `cp437`). |
 | `-S, --search` | Search for keywords. |
+| `-1, --oneline` | Show a one-line summary of each message. |
+| `--oneline-pattern` | Set a custom pattern for one-line summaries. |
+| `-I, --info` | Show a summary of the archive and exit. |
 | `--stats` | Show message statistics and exit. |
 | `--dry-run` | Preview actions without writing files. |
 


### PR DESCRIPTION
This submission improves the project documentation in `README.md` to be more comprehensive and user-friendly for a global audience. 

Key changes:
1.  **Truth First Verification:** Confirmed that `reply.dat` is indeed supported for both import and export, and updated the Supported Formats table to reflect this.
2.  **CLI Option Visibility:** Added documented but missing CLI options (`--info`, `--oneline`, `--oneline-pattern`) to the "Common Options" table, ensuring users can find them easily.
3.  **New Usage Examples:** Added a "Show a quick summary" section in Usage Examples to demonstrate how to use the summary features effectively.
4.  **Style Adherence:** Followed Plain English standards, using active voice and avoiding jargon to make the documentation accessible to non-native speakers.

All 896 existing tests passed successfully.

---
*PR created automatically by Jules for task [5976973111648039775](https://jules.google.com/task/5976973111648039775) started by @RainRat*