### PR TITLE
[UI/UX] Add horizontal scrollbar to message list in GUI

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -996,10 +996,17 @@ class QwkGuiApp:
         scrollbar = ttk.Scrollbar(
             list_frame, orient=tk.VERTICAL, command=self.message_list.yview
         )
-        self.message_list.configure(yscroll=scrollbar.set)
+        h_scrollbar = ttk.Scrollbar(
+            list_frame, orient=tk.HORIZONTAL, command=self.message_list.xview
+        )
+        self.message_list.configure(
+            yscrollcommand=scrollbar.set, xscrollcommand=h_scrollbar.set
+        )
 
         self.message_list.grid(row=0, column=0, sticky="nsew")
         scrollbar.grid(row=0, column=1, sticky="ns")
+        h_scrollbar.grid(row=1, column=0, sticky="ew")
+
         list_frame.grid_columnconfigure(0, weight=1)
         list_frame.grid_rowconfigure(0, weight=1)
 

--- a/tests/test_gui_h_scrollbar.py
+++ b/tests/test_gui_h_scrollbar.py
@@ -1,0 +1,47 @@
+import sys
+from unittest.mock import MagicMock, patch
+import pytest
+
+# We want to avoid global sys.modules mocking here as it's brittle when running the full suite
+# Instead we will patch the components specifically for the test.
+
+def test_gui_horizontal_scrollbar_initialization():
+    # Patch everything in pyqwk.gui to avoid side effects
+    # We must patch where it's USED, which is pyqwk.gui.tk and pyqwk.gui.ttk
+    with patch("pyqwk.gui.tk"), \
+         patch("pyqwk.gui.ttk") as mock_ttk, \
+         patch("pyqwk.gui.font"):
+
+        # Track scrollbar instances and their orients
+        scrollbar_instances = []
+        def scrollbar_side_effect(*args, **kwargs):
+            m = MagicMock()
+            m.orient = kwargs.get('orient')
+            scrollbar_instances.append(m)
+            return m
+        mock_ttk.Scrollbar.side_effect = scrollbar_side_effect
+
+        from pyqwk.gui import QwkGuiApp
+        import pyqwk.gui
+
+        # Mock some constants that might be needed from pyqwk.gui.tk or pyqwk.gui.ttk
+        pyqwk.gui.tk.HORIZONTAL = "horizontal"
+        pyqwk.gui.tk.VERTICAL = "vertical"
+
+        root = MagicMock()
+        app = QwkGuiApp(root)
+
+        # Check for horizontal scrollbars
+        h_scrollbars = [m for m in scrollbar_instances if m.orient == "horizontal"]
+
+        assert len(h_scrollbars) >= 2, f"Expected at least 2 horizontal scrollbars, found {len(h_scrollbars)}"
+
+        # Verify the one gridded at row=1, col=0
+        found_gridded = False
+        for m in h_scrollbars:
+            for call_args in m.grid.call_args_list:
+                if call_args.kwargs.get('row') == 1 and call_args.kwargs.get('column') == 0:
+                    found_gridded = True
+                    assert call_args.kwargs.get('sticky') == "ew"
+
+        assert found_gridded, "Horizontal scrollbar for message list was not gridded at row=1, column=0"


### PR DESCRIPTION
* **Context:** GUI
* **Problem:** The message list in the Graphical Reader contains nine columns with a combined width (~1150px) that often exceeds the default window size. Without a horizontal scrollbar, critical archive information like Date, Conference, and BBS is frequently inaccessible to the user without extreme window resizing.
* **Solution:** Added a themed horizontal scrollbar to the message list's Treeview widget. This ensures all message metadata is reachable regardless of window size or pane layout, improving accessibility and reducing friction. Also modernized the scrollbar configuration to use `yscrollcommand` and `xscrollcommand` for standard `ttk` behavior.

---
*PR created automatically by Jules for task [3873408212823057713](https://jules.google.com/task/3873408212823057713) started by @RainRat*