### PR TITLE
[FEAT] Organize individual files by subject

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,11 @@ qwk archive.qwk --individual-files --organize-by-author -o output_folder/
 qwk archive.qwk --individual-files --organize-by-to -o output_folder/
 ```
 
+**Organize files by subject:**
+```bash
+qwk archive.qwk --individual-files --organize-by-subject -o output_folder/
+```
+
 **Use custom filenames:**
 ```bash
 qwk archive.qwk --individual-files --filename-pattern "{date}_{author}_{subject}" -o output_folder/
@@ -336,6 +341,7 @@ for msg in messages:
 | `-T`, `--threaded` | Group replies into conversations. |
 | `--clean` | Remove signatures, quotes, and attachments. |
 | `-x, --extract-attachments` | Save attachments to a folder. |
+| `--organize-by-subject` | Organize files by message subject. |
 | `-r, --redact-pii` | Hide emails and phone numbers. |
 | `-E, --encoding` | Set text encoding (default is `cp437`). |
 | `-S, --search` | Search for keywords. |

--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -138,6 +138,11 @@ examples:
         action="store_true",
     )
     io_group.add_argument(
+        "--organize-by-subject",
+        help="Organize individual files into subfolders by message subject.",
+        action="store_true",
+    )
+    io_group.add_argument(
         "--filename-pattern",
         help="Set a pattern for naming individual files (e.g., '{date}_{author}_{subject}'). Available variables: date, time, author, to, subject, subject_clean, msgnum, confnum, confname, confname_or_num, bbs_name, bbs_id, length, source_file, refnum, status, msgflag, is_private, is_reply, attachments, attachment_count.",
     )
@@ -613,6 +618,7 @@ examples:
         organize_by_bbs=args.organize_by_bbs,
         organize_by_author=getattr(args, "organize_by_author", False),
         organize_by_to=getattr(args, "organize_by_to", False),
+        organize_by_subject=getattr(args, "organize_by_subject", False),
         include_toc=args.include_toc,
         extract_attachments=args.extractattachments,
         msgnum_filters=msgnum_filters,

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -497,6 +497,7 @@ class ProcessingSettings:
     organize_by_bbs: bool = False
     organize_by_author: bool = False
     organize_by_to: bool = False
+    organize_by_subject: bool = False
     include_toc: bool = False
     extract_attachments: bool = False
     msgnum_filters: set[int] | None = None
@@ -3117,6 +3118,7 @@ def process_merged_files(
                     settings.organize_by_bbs,
                     settings.organize_by_author,
                     settings.organize_by_to,
+                    settings.organize_by_subject,
                 ]
             ):
                 sub_parts = []
@@ -3131,6 +3133,10 @@ def process_merged_files(
                 if settings.organize_by_to:
                     recipient = parsed_message.header.msgto or "unknown_to"
                     sub_parts.append(_slugify(recipient, "to"))
+
+                if settings.organize_by_subject:
+                    norm_subject = _normalize_subject(parsed_message.header.msgsubject)
+                    sub_parts.append(_slugify(norm_subject or "no_subject", "subject"))
 
                 if settings.organize:
                     conf_name = parsed_message.confname or "unknown"

--- a/tests/test_organize_by_subject.py
+++ b/tests/test_organize_by_subject.py
@@ -1,0 +1,105 @@
+import logging
+from unittest.mock import MagicMock, patch
+from pyqwk.core import (
+    ProcessingSettings,
+    ParsedMessage,
+    MessageHeader,
+    process_merged_files,
+)
+
+def _make_settings(**kwargs):
+    defaults = dict(
+        verbose=False,
+        private=False,
+        no_header=False,
+        truncate_signatures=False,
+        cut_quoting=False,
+        individual_files=True,
+        threaded=False,
+        merge=False,
+        binaries_removal=False,
+        redact_pii=False,
+        strip_ansi=False,
+        format="text",
+        separator="none",
+        output_mode="file",
+        output_path=None,
+        encoding="cp437",
+        organize=False,
+        organize_by_date=False,
+        organize_by_bbs=False,
+        organize_by_author=False,
+        organize_by_to=False,
+        organize_by_subject=False,
+        extract_attachments=False,
+        include_toc=False,
+    )
+    defaults.update(kwargs)
+    return ProcessingSettings(**defaults)
+
+def _make_msg(
+    msgnum=1,
+    confnum=1,
+    msgdate="01-01-23",
+    msgtime="12:00",
+    msgfrom="Author",
+    msgto="Recipient",
+    msgsubject="Subject",
+    text="Body",
+):
+    header = MessageHeader(
+        status=" ",
+        msgnum=msgnum,
+        msgdate=msgdate,
+        msgtime=msgtime,
+        msgto=msgto,
+        msgfrom=msgfrom,
+        msgsubject=msgsubject,
+        msgpassword="",
+        refnum=None,
+        numblocks=1,
+        msgflag="",
+        confnum=confnum,
+        lognum=0,
+        nettag="",
+    )
+    return ParsedMessage(
+        text=text, msgnum=msgnum, refnum=None, confnum=confnum, header=header
+    )
+
+def test_organize_by_subject(tmp_path):
+    output_dir = tmp_path / "output_subject"
+    output_dir.mkdir()
+
+    msg1 = _make_msg(msgnum=1, msgsubject="Greetings")
+    msg2 = _make_msg(msgnum=2, msgsubject="Re: Greetings")
+    msg3 = _make_msg(msgnum=3, msgsubject="Important News")
+
+    settings = _make_settings(output_path=str(output_dir), organize_by_subject=True)
+    logger = MagicMock()
+
+    with (
+        patch("pyqwk.core.load_data", return_value=(bytearray(), {1: "General Chat"})),
+        patch("pyqwk.core.parse_messages", return_value=[msg1, msg2, msg3]),
+    ):
+        process_merged_files(["dummy.qwk"], settings, logger)
+
+    # Both msg1 and msg2 should be in the "greetings" folder because of normalization
+    assert (output_dir / "greetings" / "001-00001-greetings.txt").exists()
+    assert (output_dir / "greetings" / "001-00002-re_greetings.txt").exists()
+    assert (output_dir / "important_news" / "001-00003-important_news.txt").exists()
+
+def test_organize_by_subject_empty(tmp_path):
+    output_dir = tmp_path / "output_subject_empty"
+    output_dir.mkdir()
+
+    msg = _make_msg(msgnum=1, msgsubject="")
+    settings = _make_settings(output_path=str(output_dir), organize_by_subject=True)
+
+    with (
+        patch("pyqwk.core.load_data", return_value=(bytearray(), {1: "General Chat"})),
+        patch("pyqwk.core.parse_messages", return_value=[msg]),
+    ):
+        process_merged_files(["dummy.qwk"], settings, MagicMock())
+
+    assert (output_dir / "no_subject" / "001-00001-message.txt").exists()


### PR DESCRIPTION
A technical description of the new functionality:
Added a new organization mode for individual file exports that groups messages into subfolders by their normalized subjects (stripping "Re:" prefixes).

Why:
I noticed that the tool already supported organization by author, recipient, BBS, and date. Organizing by subject is a logical extension (Symmetry heuristic) that allows users to easily group all messages in a conversation thread into a single directory when exporting to individual files.

---
*PR created automatically by Jules for task [18097059044323575843](https://jules.google.com/task/18097059044323575843) started by @RainRat*