### PR TITLE
Simplify redundant UUE data pattern check in _is_binary_line

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -311,9 +311,7 @@ def _is_binary_line(
     if in_uue_block:
         if stripped_line in ("end", "`"):
             return True, in_yenc_block, False, in_base64_block
-        if RE_UUE_DATA_PATTERN.match(stripped_line) or RE_UUE_LOOSE_PATTERN.match(
-            stripped_line
-        ):
+        if RE_UUE_LOOSE_PATTERN.match(stripped_line):
             return True, in_yenc_block, True, in_base64_block
         in_uue_block = False
 


### PR DESCRIPTION
This PR simplifies the `_is_binary_line` function in `pyqwk/core.py` by removing a redundant logical condition.

### What:
The `if` condition in `_is_binary_line` (around line 314) that checked for UUE block continuation was simplified from:
```python
if RE_UUE_DATA_PATTERN.match(stripped_line) or RE_UUE_LOOSE_PATTERN.match(stripped_line):
```
to:
```python
if RE_UUE_LOOSE_PATTERN.match(stripped_line):
```

### Why:
The `RE_UUE_LOOSE_PATTERN` regex (`^[\x21-\x4d][\x21-\x60]{1,60}$`) is a more permissive pattern that logically covers all cases matched by `RE_UUE_DATA_PATTERN` (`^M[\x21-\x60]{60}$`). Removing the redundant check improves code readability and slightly reduces execution overhead for each line of a UUE block.

### Verification:
- All 900 tests in the suite passed, including targeted tests for attachment detection and binary line identification (`tests/test_attachments.py` and `tests/test_binary_detection.py`).
- No breaking changes were introduced as the external behavior of the function remains identical.

---
*PR created automatically by Jules for task [1846809305560771770](https://jules.google.com/task/1846809305560771770) started by @RainRat*