### PR TITLE
[DOCS] Add missing CLI options to README common options table

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,11 +347,16 @@ for msg in messages:
 | `-o`, `--output` | Save results to a file or folder. |
 | `-i`, `--individual-files` | Save each message as a separate file. |
 | `-F, --format` | Set output format (html, json, markdown, etc.). |
+| `-m, --merge` | Combine multiple archives into one file. |
+| `-u, --unique` | Remove duplicate messages during a merge. |
 | `-T`, `--threaded` | Group replies into conversations. |
 | `--clean` | Remove signatures, quotes, and attachments. |
 | `-x, --extract-attachments` | Save attachments to a folder. |
+| `--organize` | Organize individual files into subfolders by conference. |
 | `--organize-by-subject` | Organize files by message subject. |
+| `--sort` | Sort results by field (date, author, subject, etc.). |
 | `-r, --redact-pii` | Hide emails and phone numbers. |
+| `-H, --headers-only` | Show only the message headers. |
 | `-E, --encoding` | Set text encoding (default is `cp437`). |
 | `-S, --search` | Search for keywords. |
 | `-1, --oneline` | Show a one-line summary of each message. |


### PR DESCRIPTION
**PR Title:** [DOCS] Add missing CLI options to README common options table

**Description:**
* **Type:** Documentation
* **What:** The 'Common Options' table in the `README.md` file.
* **Why:** Clarified the available features by adding missing CLI options (`--merge`, `--unique`, `--organize`, `--sort`, and `--headers-only`) that were previously omitted from the quick reference table despite being core features used in the examples.

---
*PR created automatically by Jules for task [18183350949521942297](https://jules.google.com/task/18183350949521942297) started by @RainRat*