### PR TITLE
Fix missing attachment data in message mapping

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -2696,6 +2696,7 @@ def _get_message_mapping(
     message: ParsedMessage, count: int, redact_pii: bool = False
 ) -> dict[str, Any]:
     """Generate a dictionary of variables representing a message's archive information."""
+    message.discover_attachments()
     header = message.header
     dt = _parse_qwk_date(header.msgdate, header.msgtime)
 

--- a/tests/test_attachment_discovery_mapping.py
+++ b/tests/test_attachment_discovery_mapping.py
@@ -1,0 +1,44 @@
+import pytest
+from pyqwk.core import ParsedMessage, MessageHeader, _get_message_mapping
+
+def test_get_message_mapping_discovers_attachments():
+    """Verify that _get_message_mapping triggers attachment discovery."""
+    header = MessageHeader(
+        status=" ",
+        msgnum=1,
+        msgdate="01-01-23",
+        msgtime="12:00",
+        msgto="To",
+        msgfrom="From",
+        msgsubject="Subject",
+        msgpassword="",
+        refnum=None,
+        numblocks=None,
+        msgflag=" ",
+        confnum=1,
+        lognum=0,
+        nettag=" "
+    )
+
+    # Body contains a UUE attachment
+    body = "Hello\nbegin 644 test.txt\nM(R!A(&9I;&4@(&-O;G1E;G0@;V8@=&5S=\"!F:6QE+@H`\nend\n"
+    msg = ParsedMessage(
+        text=body,
+        msgnum=1,
+        refnum=None,
+        confnum=1,
+        header=header,
+        attachments=None  # Explicitly None to trigger discovery
+    )
+
+    # Initially attachments is None
+    assert msg.attachments is None
+
+    # Getting mapping should trigger discovery
+    mapping = _get_message_mapping(msg, 1)
+
+    # Check that discovery happened and flags/count are correct
+    assert msg.attachments == ["test.txt"]
+    assert mapping["flags"] == "@"
+    assert mapping["attachment_count"] == 1
+    assert mapping["attachments"] == "test.txt"


### PR DESCRIPTION
**PR Title:** Fix missing attachment data in message mapping

**Description:**
* **What:** Modified the `_get_message_mapping` function in `pyqwk/core.py` to explicitly call `message.discover_attachments()` before populating the mapping dictionary. Added a regression test in `tests/test_attachment_discovery_mapping.py`.
* **Why:** Previously, `_get_message_mapping` (which is used by `--oneline-pattern` and individual file exports) would return incomplete data—specifically missing the attachment flag (`@`) and attachment counts—if the message's attachments had not been lazily discovered yet. This change ensures that attachment archive information is always available when generating message mappings, improving the accuracy of terminal summaries and exports. No breaking changes were introduced as `discover_attachments` is idempotent.

---
*PR created automatically by Jules for task [11914872029507522460](https://jules.google.com/task/11914872029507522460) started by @RainRat*