### PR TITLE
[UI/UX] Replace technical jargon with plain English in GUI view options

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -932,7 +932,7 @@ class QwkGuiApp:
                 ("Clean", self.clean_var, self.reload_messages),
                 ("Wrap", self.wrap_var, self._update_wrap),
                 ("Remove Colors", self.ansi_var, self.reload_messages),
-                ("Redact PII", self.redact_pii_var, self.reload_messages),
+                ("Hide Personal Info", self.redact_pii_var, self.reload_messages),
             ]
         ):
             l_padx = (10, 5) if i == 0 else 5


### PR DESCRIPTION
**PR Title:** [UI/UX] Replace technical jargon with plain English in GUI view options 
 
**Description:** 
* **Context:** GUI 
* **Problem:** The "Redact PII" label in the view options uses technical acronyms (Personally Identifiable Information) and jargon ("Redact") that may be unclear to non-technical users or non-native English speakers. 
* **Solution:** Changed "Redact PII" to "Hide Personal Info". This aligns with Plain English standards, improves clarity, and ensures consistency with the terminology used in the CLI help and README. 
 
**Changes:** 
```python
<<<<<<< SEARCH
                ("Remove Colors", self.ansi_var, self.reload_messages),
                ("Redact PII", self.redact_pii_var, self.reload_messages),
            ]
=======
                ("Remove Colors", self.ansi_var, self.reload_messages),
                ("Hide Personal Info", self.redact_pii_var, self.reload_messages),
            ]
>>>>>>> REPLACE
```

---
*PR created automatically by Jules for task [561591816386542178](https://jules.google.com/task/561591816386542178) started by @RainRat*