### PR TITLE
[FEAT] Advanced Filtering (Exclusion and Body-Specific Search)

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,10 @@ for msg in messages:
 | `-H, --headers-only` | Show only the message headers. |
 | `-E, --encoding` | Set text encoding (default is `cp437`). |
 | `-S, --search` | Search for keywords. |
+| `--body` | Search for keywords specifically in the message body. |
+| `--exclude` | Exclude messages matching a keyword in any field. |
+| `--exclude-from` | Exclude messages from specific authors. |
+| `--exclude-subject` | Exclude messages by subject keywords. |
 | `-1, --oneline` | Show a one-line summary of each message. |
 | `--oneline-pattern` | Set a custom pattern for one-line summaries. |
 | `-I, --info` | Show a summary of the archive and exit. |

--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -363,6 +363,46 @@ examples:
         help="Search for a keyword in author, recipient, subject, body, conference, BBS, and attachments.",
     )
     filter_group.add_argument(
+        "--body",
+        dest="body_search",
+        help="Search for a keyword specifically within the message body text.",
+    )
+    filter_group.add_argument(
+        "--exclude",
+        dest="exclude_search",
+        help="Exclude messages containing this keyword in any field.",
+    )
+    filter_group.add_argument(
+        "--exclude-from",
+        dest="exclude_authors",
+        action="append",
+        help="Exclude messages from this author.",
+    )
+    filter_group.add_argument(
+        "--exclude-to",
+        dest="exclude_recipients",
+        action="append",
+        help="Exclude messages to this recipient.",
+    )
+    filter_group.add_argument(
+        "--exclude-subject",
+        dest="exclude_subjects",
+        action="append",
+        help="Exclude messages with this word in the subject line.",
+    )
+    filter_group.add_argument(
+        "--exclude-conference",
+        dest="exclude_conferences",
+        action="append",
+        help="Exclude messages from this conference (name or number).",
+    )
+    filter_group.add_argument(
+        "--exclude-bbs",
+        dest="exclude_bbs_names",
+        action="append",
+        help="Exclude messages from this BBS.",
+    )
+    filter_group.add_argument(
         "--regex",
         action="store_true",
         help="Use regular expressions (advanced patterns) for searching and filtering.",
@@ -650,6 +690,13 @@ examples:
         has_emails=getattr(args, "has_emails", False),
         has_phones=getattr(args, "has_phones", False),
         has_ansi=getattr(args, "has_ansi", False),
+        body_search=args.body_search,
+        exclude_search=args.exclude_search,
+        exclude_authors=args.exclude_authors,
+        exclude_recipients=args.exclude_recipients,
+        exclude_subjects=args.exclude_subjects,
+        exclude_conferences=args.exclude_conferences,
+        exclude_bbs_names=args.exclude_bbs_names,
         filename_pattern=getattr(args, "filename_pattern", None),
         min_length=getattr(args, "min_length", None),
         max_length=getattr(args, "max_length", None),

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -524,6 +524,13 @@ class ProcessingSettings:
     has_emails: bool = False
     has_phones: bool = False
     has_ansi: bool = False
+    body_search: str | None = None
+    exclude_search: str | None = None
+    exclude_authors: list[str] | None = None
+    exclude_recipients: list[str] | None = None
+    exclude_subjects: list[str] | None = None
+    exclude_conferences: list[str] | None = None
+    exclude_bbs_names: list[str] | None = None
 
 
 @dataclass
@@ -2523,6 +2530,7 @@ def matches_filters(
     settings: ProcessingSettings,
     allowed_conferences: set[int],
     user_name: str | None = None,
+    allowed_exclude_conferences: set[int] | None = None,
 ) -> bool:
     """Check if a message matches all your filters.
 
@@ -2531,6 +2539,7 @@ def matches_filters(
         settings: Settings containing your filter choices.
         allowed_conferences: A set of allowed conference numbers.
         user_name: Your name to use for the "mine" filter.
+        allowed_exclude_conferences: A set of conference numbers to exclude.
 
     Returns:
         True if the message matches all filters, False otherwise.
@@ -2554,6 +2563,71 @@ def matches_filters(
             return True
 
         return any(check_str_match(p, text) for p in pattern_list)
+
+    # --- Exclusion Filters (Negative matching) ---
+    # If any exclusion matches, the message is rejected immediately.
+
+    # 1. Exclude Search
+    if settings.exclude_search:
+        message.discover_attachments()
+        found_exclude = (
+            check_str_match(settings.exclude_search, message.header.msgfrom)
+            or check_str_match(settings.exclude_search, message.header.msgto)
+            or check_str_match(settings.exclude_search, message.header.msgsubject)
+            or check_str_match(settings.exclude_search, message.text)
+            or (
+                message.confname
+                and check_str_match(settings.exclude_search, message.confname)
+            )
+            or (
+                message.bbs_name
+                and check_str_match(settings.exclude_search, message.bbs_name)
+            )
+            or (
+                message.bbs_id
+                and check_str_match(settings.exclude_search, message.bbs_id)
+            )
+            or (
+                message.attachments
+                and any(
+                    check_str_match(settings.exclude_search, a)
+                    for a in message.attachments
+                )
+            )
+        )
+        if found_exclude:
+            return False
+
+    # 2. Exclude Author
+    if settings.exclude_authors and any_match(
+        settings.exclude_authors, message.header.msgfrom
+    ):
+        return False
+
+    # 3. Exclude Recipient
+    if settings.exclude_recipients and any_match(
+        settings.exclude_recipients, message.header.msgto
+    ):
+        return False
+
+    # 4. Exclude Subject
+    if settings.exclude_subjects and any_match(
+        settings.exclude_subjects, message.header.msgsubject
+    ):
+        return False
+
+    # 5. Exclude Conference
+    if allowed_exclude_conferences and message.confnum in allowed_exclude_conferences:
+        return False
+
+    # 6. Exclude BBS
+    if settings.exclude_bbs_names:
+        match_name = any_match(settings.exclude_bbs_names, message.bbs_name or "")
+        match_id = any_match(settings.exclude_bbs_names, message.bbs_id or "")
+        if match_name or match_id:
+            return False
+
+    # --- Inclusion Filters (Positive matching) ---
 
     # 1. Private/Password Check
     if (
@@ -2628,6 +2702,11 @@ def matches_filters(
             )
         )
         if not found:
+            return False
+
+    # 7b. Body-Specific Search
+    if settings.body_search:
+        if not check_str_match(settings.body_search, message.text):
             return False
 
     # 8. Date Filter
@@ -3261,6 +3340,9 @@ def process_merged_files(
         bbs_key = f"{bbs_info.name}|{bbs_info.bbs_id}" if bbs_info else ""
 
         allowed_conferences = get_allowed_conferences(settings.conferences, board_dict)
+        allowed_exclude_conferences = get_allowed_conferences(
+            settings.exclude_conferences, board_dict
+        )
 
         desc = f"Processing {os.path.basename(input_path)}"
 
@@ -3299,7 +3381,11 @@ def process_merged_files(
                     or os.path.basename(input_path),
                 )
                 if not matches_filters(
-                    parsed_message, settings, allowed_conferences, user_name
+                    parsed_message,
+                    settings,
+                    allowed_conferences,
+                    user_name,
+                    allowed_exclude_conferences,
                 ):
                     continue
 
@@ -5459,6 +5545,9 @@ def calculate_archive_stats(
             allowed_conferences = get_allowed_conferences(
                 settings.conferences, board_dict
             )
+            allowed_exclude_conferences = get_allowed_conferences(
+                settings.exclude_conferences, board_dict
+            )
 
             desc = f"Analyzing {os.path.basename(input_path)}"
             is_structured = isinstance(file_data, list)
@@ -5493,7 +5582,11 @@ def calculate_archive_stats(
                     )
 
                     if not matches_filters(
-                        message, settings, allowed_conferences, user_name
+                        message,
+                        settings,
+                        allowed_conferences,
+                        user_name,
+                        allowed_exclude_conferences,
                     ):
                         continue
 

--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -97,6 +97,8 @@ class QwkGuiApp:
 
         self.search_var = tk.StringVar()
         self.search_var.trace_add("write", self._on_search_changed)
+        self.exclude_var = tk.StringVar()
+        self.exclude_var.trace_add("write", self._on_search_changed)
         self._search_timer: str | None = None
 
         # Create custom styles
@@ -164,6 +166,10 @@ class QwkGuiApp:
             label=f"Filter by Author: {author_label}",
             command=lambda a=orig_from: self._pivot_filter(author=a),
         )
+        menu.add_command(
+            label="Exclude Author",
+            command=lambda a=orig_from: self._pivot_filter(exclude_author=a),
+        )
 
         subj_label = (
             (orig_subject[:20] + "...") if len(orig_subject) > 20 else orig_subject
@@ -172,12 +178,20 @@ class QwkGuiApp:
             label=f"Filter by Subject: {subj_label}",
             command=lambda s=orig_subject: self._pivot_filter(subject=s),
         )
+        menu.add_command(
+            label="Exclude Subject",
+            command=lambda s=orig_subject: self._pivot_filter(exclude_subject=s),
+        )
 
         conf_name = self.board_dict.get(msg.confnum, str(msg.confnum))
         conf_label = (conf_name[:20] + "...") if len(conf_name) > 20 else conf_name
         menu.add_command(
             label=f"Filter by Conference: {conf_label}",
             command=lambda c=msg.confnum: self._pivot_filter(conf_num=c),
+        )
+        menu.add_command(
+            label="Exclude Conference",
+            command=lambda c=msg.confnum: self._pivot_filter(exclude_conf_num=c),
         )
 
         bbs_display = msg.bbs_name or msg.bbs_id
@@ -188,6 +202,10 @@ class QwkGuiApp:
             menu.add_command(
                 label=f"Filter by BBS: {bbs_label}",
                 command=lambda b=bbs_display: self._pivot_filter(bbs_name=b),
+            )
+            menu.add_command(
+                label="Exclude BBS",
+                command=lambda b=bbs_display: self._pivot_filter(exclude_bbs_name=b),
             )
 
         menu.post(event.x_root, event.y_root)
@@ -254,6 +272,10 @@ class QwkGuiApp:
                     label=f"Filter by Author: {author_label}",
                     command=lambda a=author_text: self._pivot_filter(author=a),
                 )
+                menu.add_command(
+                    label="Exclude Author",
+                    command=lambda a=author_text: self._pivot_filter(exclude_author=a),
+                )
 
                 subj_text = msg.header.msgsubject.strip()
                 subj_label = (
@@ -263,6 +285,10 @@ class QwkGuiApp:
                     label=f"Filter by Subject: {subj_label}",
                     command=lambda s=subj_text: self._pivot_filter(subject=s),
                 )
+                menu.add_command(
+                    label="Exclude Subject",
+                    command=lambda s=subj_text: self._pivot_filter(exclude_subject=s),
+                )
 
                 conf_name = self.board_dict.get(msg.confnum, str(msg.confnum))
                 conf_label = (
@@ -271,6 +297,10 @@ class QwkGuiApp:
                 menu.add_command(
                     label=f"Filter by Conference: {conf_label}",
                     command=lambda c=msg.confnum: self._pivot_filter(conf_num=c),
+                )
+                menu.add_command(
+                    label="Exclude Conference",
+                    command=lambda c=msg.confnum: self._pivot_filter(exclude_conf_num=c),
                 )
 
                 bbs_display = msg.bbs_name or msg.bbs_id
@@ -283,6 +313,10 @@ class QwkGuiApp:
                     menu.add_command(
                         label=f"Filter by BBS: {bbs_label}",
                         command=lambda b=bbs_display: self._pivot_filter(bbs_name=b),
+                    )
+                    menu.add_command(
+                        label="Exclude BBS",
+                        command=lambda b=bbs_display: self._pivot_filter(exclude_bbs_name=b),
                     )
             except (ValueError, IndexError):
                 pass
@@ -328,6 +362,9 @@ class QwkGuiApp:
     def _is_any_filter_active(self) -> bool:
         """Return True if any visibility filters are currently active."""
         if self.search_var.get().strip():
+            return True
+
+        if self.exclude_var.get().strip():
             return True
 
         bbs_val = self.bbs_combo.get()
@@ -391,6 +428,10 @@ class QwkGuiApp:
         conf_num: int | None = None,
         bbs_name: str | None = None,
         subject: str | None = None,
+        exclude_author: str | None = None,
+        exclude_conf_num: int | None = None,
+        exclude_bbs_name: str | None = None,
+        exclude_subject: str | None = None,
     ) -> None:
         """Update filters based on the selected author, conference, BBS, or subject."""
         if author:
@@ -412,6 +453,18 @@ class QwkGuiApp:
                 if val.startswith(f"{conf_num}:"):
                     self.conf_combo.current(i)
                     break
+
+        if exclude_author:
+            self.exclude_var.set(exclude_author)
+
+        if exclude_subject:
+            self.exclude_var.set(_normalize_subject(exclude_subject))
+
+        if exclude_bbs_name:
+            self.exclude_var.set(exclude_bbs_name)
+
+        if exclude_conf_num is not None:
+            self.exclude_var.set(str(exclude_conf_num))
 
         self.reload_messages()
 
@@ -726,9 +779,10 @@ class QwkGuiApp:
         return None
 
     def clear_search(self, _event: object | None = None) -> None:
-        """Clear the search bar first, and if already empty, reset all filters."""
-        if self.search_var.get():
+        """Clear the search and exclude bars first, and if already empty, reset all filters."""
+        if self.search_var.get() or self.exclude_var.get():
             self.search_var.set("")
+            self.exclude_var.set("")
             self.reload_messages()
             self.message_list.focus_set()
         else:
@@ -751,6 +805,7 @@ class QwkGuiApp:
     def clear_filters(self, _event: object | None = None) -> None:
         """Reset all filters and search to their default state."""
         self.search_var.set("")
+        self.exclude_var.set("")
         try:
             self.bbs_combo.current(0)
         except Exception:
@@ -850,11 +905,22 @@ class QwkGuiApp:
             side=tk.LEFT
         )
         self.search_entry = ttk.Entry(
-            search_frame, textvariable=self.search_var, width=22
+            search_frame, textvariable=self.search_var, width=18
         )
         self.search_entry.pack(side=tk.LEFT, padx=(10, 0))
         ttk.Button(
             search_frame, text="✕", width=2, command=lambda: self.search_var.set("")
+        ).pack(side=tk.LEFT, padx=(0, 5))
+
+        ttk.Label(search_frame, text="Exclude", style="GroupHeader.TLabel").pack(
+            side=tk.LEFT, padx=(5, 5)
+        )
+        self.exclude_entry = ttk.Entry(
+            search_frame, textvariable=self.exclude_var, width=18
+        )
+        self.exclude_entry.pack(side=tk.LEFT, padx=(0, 0))
+        ttk.Button(
+            search_frame, text="✕", width=2, command=lambda: self.exclude_var.set("")
         ).pack(side=tk.LEFT, padx=(0, 2))
 
         self.search_count_label = ttk.Label(
@@ -1112,6 +1178,10 @@ class QwkGuiApp:
         if not search_val:
             search_val = None
 
+        exclude_val = self.exclude_var.get().strip()
+        if not exclude_val:
+            exclude_val = None
+
         selected_bbs_name = self.bbs_combo.get()
         bbs_names = None
         if selected_bbs_name and not selected_bbs_name.startswith("All BBSes"):
@@ -1145,6 +1215,7 @@ class QwkGuiApp:
             regex=self.regex_var.get(),
             quiet=True,
             search_term=search_val if search_val else None,
+            exclude_search=exclude_val if exclude_val else None,
             conferences=conferences,
             bbs_names=bbs_names,
             has_attachments=self.has_attach_var.get(),

--- a/tests/test_advanced_filtering.py
+++ b/tests/test_advanced_filtering.py
@@ -1,0 +1,121 @@
+import pytest
+from pyqwk.core import ParsedMessage, MessageHeader, ProcessingSettings, matches_filters
+
+def create_msg(text="Hello world", author="Alice", to="Bob", subject="Greetings", confnum=1, bbs_name="MyBBS"):
+    header = MessageHeader(
+        status=" ",
+        msgnum=1,
+        msgdate="01-01-23",
+        msgtime="12:00",
+        msgto=to,
+        msgfrom=author,
+        msgsubject=subject,
+        msgpassword="",
+        refnum=None,
+        numblocks=1,
+        msgflag=" ",
+        confnum=confnum,
+        lognum=0,
+        nettag=" ",
+    )
+    return ParsedMessage(
+        text=text,
+        msgnum=1,
+        refnum=None,
+        confnum=confnum,
+        header=header,
+        bbs_name=bbs_name,
+    )
+
+def test_body_search():
+    msg = create_msg(text="The secret code is 12345")
+    settings = ProcessingSettings(
+        verbose=False, private=True, no_header=True, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False,
+        binaries_removal=False, redact_pii=False, format="text",
+        separator="none", output_mode="stdout", output_path=None,
+        encoding="cp437", body_search="secret"
+    )
+    assert matches_filters(msg, settings, set()) is True
+
+    settings.body_search = "missing"
+    assert matches_filters(msg, settings, set()) is False
+
+def test_exclude_search():
+    msg = create_msg(text="Spam message")
+    settings = ProcessingSettings(
+        verbose=False, private=True, no_header=True, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False,
+        binaries_removal=False, redact_pii=False, format="text",
+        separator="none", output_mode="stdout", output_path=None,
+        encoding="cp437", exclude_search="spam"
+    )
+    assert matches_filters(msg, settings, set()) is False
+
+    settings.exclude_search = "ham"
+    assert matches_filters(msg, settings, set()) is True
+
+def test_exclude_author():
+    msg = create_msg(author="Mallory")
+    settings = ProcessingSettings(
+        verbose=False, private=True, no_header=True, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False,
+        binaries_removal=False, redact_pii=False, format="text",
+        separator="none", output_mode="stdout", output_path=None,
+        encoding="cp437", exclude_authors=["Mallory"]
+    )
+    assert matches_filters(msg, settings, set()) is False
+
+    settings.exclude_authors = ["Alice"]
+    assert matches_filters(msg, settings, set()) is True
+
+def test_exclude_subject():
+    msg = create_msg(subject="Annoying Topic")
+    settings = ProcessingSettings(
+        verbose=False, private=True, no_header=True, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False,
+        binaries_removal=False, redact_pii=False, format="text",
+        separator="none", output_mode="stdout", output_path=None,
+        encoding="cp437", exclude_subjects=["annoying"]
+    )
+    assert matches_filters(msg, settings, set()) is False
+
+def test_exclude_conference():
+    msg = create_msg(confnum=10)
+    settings = ProcessingSettings(
+        verbose=False, private=True, no_header=True, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False,
+        binaries_removal=False, redact_pii=False, format="text",
+        separator="none", output_mode="stdout", output_path=None,
+        encoding="cp437"
+    )
+    # Exclude conference 10
+    assert matches_filters(msg, settings, set(), allowed_exclude_conferences={10}) is False
+    assert matches_filters(msg, settings, set(), allowed_exclude_conferences={20}) is True
+
+def test_exclude_bbs():
+    msg = create_msg(bbs_name="LameBBS")
+    settings = ProcessingSettings(
+        verbose=False, private=True, no_header=True, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False,
+        binaries_removal=False, redact_pii=False, format="text",
+        separator="none", output_mode="stdout", output_path=None,
+        encoding="cp437", exclude_bbs_names=["lame"]
+    )
+    assert matches_filters(msg, settings, set()) is False
+
+def test_combined_inclusion_exclusion():
+    msg = create_msg(text="Good content", author="Alice")
+    settings = ProcessingSettings(
+        verbose=False, private=True, no_header=True, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False,
+        binaries_removal=False, redact_pii=False, format="text",
+        separator="none", output_mode="stdout", output_path=None,
+        encoding="cp437", authors=["Alice"], exclude_search="content"
+    )
+    # Matches author Alice (inclusion) BUT matches "content" (exclusion). Exclusion wins.
+    assert matches_filters(msg, settings, set()) is False
+
+    settings.exclude_search = "spam"
+    # Matches author Alice, no exclusion.
+    assert matches_filters(msg, settings, set()) is True

--- a/tests/test_lead_qa_gui_coverage_final.py
+++ b/tests/test_lead_qa_gui_coverage_final.py
@@ -36,6 +36,7 @@ def app():
 def test_is_any_filter_active_private_false(app):
     """Test _is_any_filter_active returns True when private_var is False (line 246)."""
     app.search_var.get.return_value = ""
+    app.exclude_var.get.return_value = ""
     for var in [
         app.has_attach_var,
         app.mine_var,
@@ -60,6 +61,7 @@ def test_is_any_filter_active_private_false(app):
 def test_is_any_filter_active_none(app):
     """Test _is_any_filter_active returns False when no filters are active."""
     app.search_var.get.return_value = ""
+    app.exclude_var.get.return_value = ""
     for var in [
         app.has_attach_var,
         app.mine_var,

--- a/tests/test_qwk.py
+++ b/tests/test_qwk.py
@@ -101,6 +101,13 @@ def _make_settings(**overrides) -> ProcessingSettings:
         on_this_day=False,
         reference_date=None,
         merge_stats=False,
+        body_search=None,
+        exclude_search=None,
+        exclude_authors=None,
+        exclude_recipients=None,
+        exclude_subjects=None,
+        exclude_conferences=None,
+        exclude_bbs_names=None,
     )
     defaults.update(overrides)
     return ProcessingSettings(**defaults)
@@ -155,6 +162,13 @@ def _make_cli_namespace(**overrides: object) -> argparse.Namespace:
         mine=False,
         on_this_day=False,
         merge_stats=False,
+        body_search=None,
+        exclude_search=None,
+        exclude_authors=None,
+        exclude_recipients=None,
+        exclude_subjects=None,
+        exclude_conferences=None,
+        exclude_bbs_names=None,
     )
     base.update(overrides)
     return argparse.Namespace(**base)


### PR DESCRIPTION
This Pull Request introduces "Advanced Filtering" to `pyqwk`, addressing the need for both granular inclusion and powerful noise reduction when browsing large message archives.

### Key Features:
- **Exclusion Filters:** You can now hide messages by keyword (`--exclude`), author (`--exclude-from`), subject (`--exclude-subject`), conference (`--exclude-conference`), or BBS (`--exclude-bbs`).
- **Body-Specific Search:** A new `--body` flag (and internal `body_search` setting) allows you to search specifically within message text, avoiding false positives from archive information like author or subject names.
- **GUI Integration:** The Graphical Reader now features an "Exclude" entry bar next to the search bar. More importantly, the message context menus now include "Exclude Author", "Exclude Subject", and "Exclude Conference" actions, allowing you to instantly "clean" your view while reading.

### Technical Implementation:
- The `matches_filters` function in `core.py` was updated to prioritize exclusion checks using an "OR" logic—if a message matches *any* exclusion criteria, it is immediately rejected before inclusion checks are processed.
- CLI arguments were expanded to map to these new settings.
- The GUI toolbar and context menus were refactored to accommodate the new inputs and actions.
- Comprehensive tests were added in `tests/test_advanced_filtering.py`, and existing test utility helpers were updated to maintain compatibility with the expanded `ProcessingSettings` dataclass.

This feature fulfills the "Symmetry" heuristic by providing a negative counterpart to every existing inclusion filter.

---
*PR created automatically by Jules for task [18361188564127795813](https://jules.google.com/task/18361188564127795813) started by @RainRat*