### PR TITLE
[FEAT] Archive Identity & Personalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ for msg in messages:
 | `--sort` | Sort results by field (date, author, subject, etc.). |
 | `-r, --redact-pii` | Hide personal info like emails and phone numbers. |
 | `--mine` | Show messages sent to or from your user name. |
+| `--my-name` | Set your name for the `--mine` filter and QWK exports. |
 | `--has-attachments` | Only show messages that have attachments. |
 | `--has-links` | Only show messages that contain web links. |
 | `--has-emails` | Only show messages that contain email addresses. |
@@ -419,6 +420,7 @@ You can use custom patterns with `--oneline-pattern` (for summaries on the scree
 | `{confname_or_num}` | The conference name, or its number if the name is missing. |
 | `{msgnum}` | The unique message number. |
 | `{snippet}` | The first line of the message body. |
+| `{my_name}` | The user name (either from archive metadata or your override). |
 
 ### Dates & Times
 | Variable | Description |

--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -489,6 +489,12 @@ examples:
         action="store_true",
     )
     filter_group.add_argument(
+        "--my-name",
+        "--user",
+        dest="my_name",
+        help="Set your name for the --mine filter and QWK exports.",
+    )
+    filter_group.add_argument(
         "--on-this-day",
         help="Show messages sent on this same month and day in any year.",
         action="store_true",
@@ -687,6 +693,7 @@ examples:
         on_this_day=args.on_this_day,
         merge_stats=args.merge_stats,
         has_links=getattr(args, "has_links", False),
+        my_name=getattr(args, "my_name", None),
         has_emails=getattr(args, "has_emails", False),
         has_phones=getattr(args, "has_phones", False),
         has_ansi=getattr(args, "has_ansi", False),

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -524,6 +524,7 @@ class ProcessingSettings:
     has_emails: bool = False
     has_phones: bool = False
     has_ansi: bool = False
+    my_name: str | None = None
     body_search: str | None = None
     exclude_search: str | None = None
     exclude_authors: list[str] | None = None
@@ -2775,7 +2776,10 @@ def format_size(size: int) -> str:
 
 
 def _get_message_mapping(
-    message: ParsedMessage, count: int, redact_pii: bool = False
+    message: ParsedMessage,
+    count: int,
+    redact_pii: bool = False,
+    user_name: str | None = None,
 ) -> dict[str, Any]:
     """Generate a dictionary of variables representing a message's archive information."""
     message.discover_attachments()
@@ -2800,6 +2804,15 @@ def _get_message_mapping(
     author = header.msgfrom.strip()
     to = header.msgto.strip()
     subject = header.msgsubject.strip()
+
+    # Determine user name for pattern variable
+    my_name_val = user_name or ""
+    if not my_name_val:
+        bbs_info = getattr(message, "bbs_info", None)
+        if bbs_info:
+            my_name_val = bbs_info.user_name
+        else:
+            my_name_val = author
 
     subject_clean = subject
     while True:
@@ -2855,6 +2868,7 @@ def _get_message_mapping(
         "is_reply": "true" if is_reply else "false",
         "attachments": attachments_str,
         "attachment_count": len(attachments_list),
+        "my_name": my_name_val,
         "length": len(message.text) if message.text else 0,
         "size": format_size(len(message.text)) if message.text else "0 B",
         "flags": flags,
@@ -2879,7 +2893,10 @@ def _generate_safe_filename(
     if settings and settings.filename_pattern:
         try:
             raw_mapping = _get_message_mapping(
-                message, count, redact_pii=settings.redact_pii if settings else False
+                message,
+                count,
+                redact_pii=settings.redact_pii if settings else False,
+                user_name=settings.my_name if settings else None,
             )
 
             # Map of variable names to their slugify defaults for filename compatibility
@@ -3094,7 +3111,10 @@ def process_merged_files(
             if settings.oneline_pattern:
                 try:
                     mapping = _get_message_mapping(
-                        parsed_message, processed_count, redact_pii=settings.redact_pii
+                        parsed_message,
+                        processed_count,
+                        redact_pii=settings.redact_pii,
+                        user_name=user_name,
                     )
                     # Apply fallbacks for oneline display
                     if not mapping["confname"]:
@@ -3332,7 +3352,7 @@ def process_merged_files(
     for input_path in input_paths:
         file_data, board_dict = load_data(input_path, logger, settings.encoding)
         bbs_info = getattr(board_dict, "bbs_info", None)
-        user_name = bbs_info.user_name if bbs_info else None
+        user_name = settings.my_name or (bbs_info.user_name if bbs_info else None)
         if bbs_info and not bbs_info_to_use:
             bbs_info_to_use = bbs_info
         if board_dict and not board_dict_to_use:
@@ -4192,6 +4212,11 @@ def _write_html(
                 html_parts.append(
                     f"<div><strong>Packet Date:</strong> {html.escape(bbs_info.packet_at)}</div>"
                 )
+            user_name_to_show = (settings.my_name if settings else None) or bbs_info.user_name
+            if user_name_to_show:
+                html_parts.append(
+                    f"<div><strong>User Name:</strong> {html.escape(user_name_to_show)}</div>"
+                )
             html_parts.append(
                 f"<div><strong>Total Messages:</strong> {len(messages)}</div>"
             )
@@ -4283,6 +4308,9 @@ def _write_markdown(
                 md_parts.append(f"- **Location:** {bbs_info.location}")
             if bbs_info.packet_at:
                 md_parts.append(f"- **Packet Date:** {bbs_info.packet_at}")
+            user_name_to_show = (settings.my_name if settings else None) or bbs_info.user_name
+            if user_name_to_show:
+                md_parts.append(f"- **User Name:** {user_name_to_show}")
             md_parts.append(f"- **Total Messages:** {len(messages)}")
             md_parts.append("")
 
@@ -4500,6 +4528,7 @@ def _serialize_control_dat(
     bbs_info: BBSInfo | None,
     board_dict: Mapping[int, str] | None,
     encoding: str = "cp437",
+    my_name: str | None = None,
 ) -> list[bytes]:
     """Convert BBS information and conference list into CONTROL.DAT format."""
     lines = [b""] * 11
@@ -4513,7 +4542,8 @@ def _serialize_control_dat(
         lines[4] = id_line.encode(encoding)
 
         lines[5] = bbs_info.packet_at.encode(encoding)
-        lines[6] = bbs_info.user_name.encode(encoding)
+        user_name_val = my_name or bbs_info.user_name
+        lines[6] = user_name_val.encode(encoding)
 
     if board_dict:
         # Line 11 (index 10) is number of conferences - 1
@@ -4599,6 +4629,9 @@ def _write_text(
                 parts.append(f"Location: {bbs_info.location}\r\n")
             if bbs_info.packet_at:
                 parts.append(f"Date:     {bbs_info.packet_at}\r\n")
+            user_name_to_show = (settings.my_name if settings else None) or bbs_info.user_name
+            if user_name_to_show:
+                parts.append(f"User:     {user_name_to_show}\r\n")
         parts.append(f"Messages: {len(messages)}\r\n\r\n")
 
         parts.append("Conferences:\r\n")
@@ -4620,10 +4653,16 @@ def _write_text(
         if settings and settings.oneline:
             if settings.oneline_pattern:
                 try:
+                    user_name_to_pass = (
+                        settings.my_name
+                        if settings
+                        else (bbs_info.user_name if bbs_info else None)
+                    )
                     mapping = _get_message_mapping(
                         message,
                         i + 1,
                         redact_pii=settings.redact_pii if settings else False,
+                        user_name=user_name_to_pass,
                     )
                     # Apply fallbacks for oneline display
                     if not mapping["confname"]:
@@ -4773,7 +4812,12 @@ def _write_qwk(
             zf.writestr(MESSAGES_FILENAME, content)
 
             # CONTROL.DAT
-            control_lines = _serialize_control_dat(bbs_info, board_dict, encoding)
+            control_lines = _serialize_control_dat(
+                bbs_info,
+                board_dict,
+                encoding,
+                my_name=settings.my_name if settings else None,
+            )
             zf.writestr(CONTROL_FILENAME, b"\r\n".join(control_lines) + b"\r\n")
 
 
@@ -5314,6 +5358,9 @@ def show_info(
                         print(f"  {_colorize('BBS ID:', BOLD)}   {bbs_info.bbs_id}")
                     if bbs_info.packet_at:
                         print(f"  {_colorize('Packet At:', BOLD)} {bbs_info.packet_at}")
+                user_name_to_show = settings.my_name or (bbs_info.user_name if bbs_info else None)
+                if user_name_to_show:
+                    print(f"  {_colorize('User Name:', BOLD)} {user_name_to_show}")
 
                 print(f"  {_colorize('Total Messages:', BOLD)} {total_messages}")
                 print(f"  {_colorize('Conferences:', BOLD)}")
@@ -5541,7 +5588,7 @@ def calculate_archive_stats(
                 break
             file_data, board_dict = load_data(input_path, logger, settings.encoding)
             bbs_info = getattr(board_dict, "bbs_info", None)
-            user_name = bbs_info.user_name if bbs_info else None
+            user_name = settings.my_name or (bbs_info.user_name if bbs_info else None)
             allowed_conferences = get_allowed_conferences(
                 settings.conferences, board_dict
             )

--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -49,8 +49,14 @@ class QwkGuiApp:
         else:
             self.current_paths = [value]
 
-    def __init__(self, root: tk.Tk, initial_paths: list[str] | None = None) -> None:
+    def __init__(
+        self,
+        root: tk.Tk,
+        initial_paths: list[str] | None = None,
+        my_name: str | None = None,
+    ) -> None:
         self.root = root
+        self.my_name = my_name
         self.root.title("PyQWK Reader")
         self.root.geometry("1100x650")
 
@@ -1218,6 +1224,7 @@ class QwkGuiApp:
             bbs_names=bbs_names,
             has_attachments=self.has_attach_var.get(),
             mine=self.mine_var.get(),
+            my_name=self.my_name,
             on_this_day=self.on_this_day_var.get(),
             oneline=False,
             oneline_pattern=None,
@@ -1300,7 +1307,7 @@ class QwkGuiApp:
             self.detail_text.insert(tk.END, " PRIVATE ", "badge_private")
 
         bbs_info = getattr(self.board_dict, "bbs_info", None)
-        user_name = bbs_info.user_name if bbs_info else None
+        user_name = self.my_name or (bbs_info.user_name if bbs_info else None)
         if user_name:
             is_from_me = user_name.lower() in header.msgfrom.lower()
             is_to_me = user_name.lower() in header.msgto.lower()
@@ -1757,7 +1764,7 @@ class QwkGuiApp:
                 bbs_info = getattr(board_dict, "bbs_info", None)
                 if not merged_board_dict.bbs_info:
                     merged_board_dict.bbs_info = bbs_info
-                user_name = bbs_info.user_name if bbs_info else None
+                user_name = self.my_name or (bbs_info.user_name if bbs_info else None)
 
                 # Reconstruct/Discovery of conferences
                 try:
@@ -1918,7 +1925,7 @@ class QwkGuiApp:
 
             # Identify the user's name for highlighting "mine" messages
             bbs_info = getattr(self.board_dict, "bbs_info", None)
-            user_name = bbs_info.user_name if bbs_info else None
+            user_name = self.my_name or (bbs_info.user_name if bbs_info else None)
 
             for index, message in enumerate(self.messages):
                 header = message.header
@@ -2704,6 +2711,12 @@ def main() -> None:
         nargs="*",
         help="Path to message archives, ZIP and TAR archives, or folders. Supports QWK, REP, JSON, JSONL, CSV, XML, RSS, mbox, EML, SQLite, Markdown, HTML, Plain Text, and data files (MESSAGES.DAT, REPLY.DAT).",
     )
+    parser.add_argument(
+        "--my-name",
+        "--user",
+        dest="my_name",
+        help="Set your name for highlighting 'mine' messages.",
+    )
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO)
@@ -2711,7 +2724,8 @@ def main() -> None:
     input_paths = expand_paths(args.paths)
 
     root = tk.Tk()
-    QwkGuiApp(root, initial_paths=input_paths)
+    my_name = getattr(args, "my_name", None)
+    QwkGuiApp(root, initial_paths=input_paths, my_name=my_name)
     root.mainloop()
 
 

--- a/tests/test_gui_main.py
+++ b/tests/test_gui_main.py
@@ -29,7 +29,7 @@ def test_gui_main_with_paths():
         mock_tk_class.assert_called_once()
         mock_expand.assert_called_once_with(["test.qwk"])
         mock_app_class.assert_called_once_with(
-            mock_tk_class.return_value, initial_paths=["test.qwk"]
+            mock_tk_class.return_value, initial_paths=["test.qwk"], my_name=None
         )
         mock_tk_class.return_value.mainloop.assert_called_once()
 
@@ -50,6 +50,6 @@ def test_gui_main_without_paths():
         mock_tk_class.assert_called_once()
         mock_expand.assert_called_once_with([])
         mock_app_class.assert_called_once_with(
-            mock_tk_class.return_value, initial_paths=[]
+            mock_tk_class.return_value, initial_paths=[], my_name=None
         )
         mock_tk_class.return_value.mainloop.assert_called_once()

--- a/tests/test_my_name.py
+++ b/tests/test_my_name.py
@@ -1,0 +1,106 @@
+import pytest
+from pyqwk.core import (
+    ProcessingSettings,
+    matches_filters,
+    ParsedMessage,
+    MessageHeader,
+    _get_message_mapping,
+    _serialize_control_dat,
+    BBSInfo,
+    ConferenceMap,
+)
+
+def _make_message(msgfrom="User", msgto="All"):
+    header = MessageHeader(
+        status=" ",
+        msgnum=1,
+        msgdate="01-01-23",
+        msgtime="12:00",
+        msgto=msgto,
+        msgfrom=msgfrom,
+        msgsubject="Test",
+        msgpassword="",
+        refnum=None,
+        numblocks=2,
+        msgflag=" ",
+        confnum=1,
+        lognum=0,
+        nettag=" ",
+    )
+    return ParsedMessage(text="Hello", msgnum=1, refnum=None, confnum=1, header=header)
+
+def test_my_name_filter():
+    """Test that settings.my_name correctly influences the --mine filter."""
+    msg = _make_message(msgfrom="Alice")
+
+    # settings.mine is True, but no user_name provided to matches_filters.
+    # Currently, it returns True because the filter is skipped if user_name is None.
+    settings = ProcessingSettings(
+        verbose=False, private=True, no_header=True, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False,
+        binaries_removal=False, redact_pii=False, format="text",
+        separator="none", output_mode="stdout", output_path=None,
+        encoding="cp437", mine=True, my_name="Alice"
+    )
+
+    # In process_merged_files, user_name is determined from settings.my_name or metadata.
+    # Here we simulate that determination.
+    user_name = settings.my_name
+    assert matches_filters(msg, settings, set(), user_name=user_name)
+
+    # Test mismatch
+    assert not matches_filters(msg, settings, set(), user_name="Bob")
+
+def test_my_name_pattern_variable():
+    """Test that {my_name} is available in message mapping."""
+    msg = _make_message(msgfrom="Bob")
+    mapping = _get_message_mapping(msg, 1)
+    assert mapping["my_name"] == "Bob"
+
+    # Test with custom pattern (implicitly tested via mapping existence)
+    assert "Bob" in "{my_name}".format(**mapping)
+
+def test_my_name_qwk_serialization():
+    """Test that settings.my_name is used in CONTROL.DAT serialization."""
+    bbs_info = BBSInfo(user_name="Original")
+    board_dict = ConferenceMap()
+
+    # Without override
+    lines = _serialize_control_dat(bbs_info, board_dict)
+    assert lines[6] == b"Original"
+
+    # With override
+    lines = _serialize_control_dat(bbs_info, board_dict, my_name="NewName")
+    assert lines[6] == b"NewName"
+
+def test_gui_mine_logic(mocker):
+    """Test that QwkGuiApp uses my_name for its internal logic."""
+    import sys
+    from unittest.mock import MagicMock
+
+    # Mock tkinter components
+    mock_tk = MagicMock()
+    mocker.patch.dict("sys.modules", {
+        "tkinter": mock_tk,
+        "tkinter.font": MagicMock(),
+        "tkinter.ttk": MagicMock(),
+        "tkinter.filedialog": MagicMock(),
+        "tkinter.messagebox": MagicMock(),
+        "tkinter.simpledialog": MagicMock(),
+    })
+
+    # Ensure variables don't crash
+    mock_tk.BooleanVar.return_value = MagicMock()
+    mock_tk.StringVar.return_value = MagicMock()
+    mock_tk.IntVar.return_value = MagicMock()
+
+    from pyqwk.gui import QwkGuiApp
+
+    root = MagicMock()
+    app = QwkGuiApp(root, my_name="Alice")
+
+    assert app.my_name == "Alice"
+
+    # Verify it passes it to settings
+    settings = app._current_settings()
+    assert settings.my_name == "Alice"


### PR DESCRIPTION
### [FEAT] Archive Identity & Personalization

**What:**
Identified and implemented the ability for users to specify their own "Identity" (user name) within the tool. This is exposed via a new `--my-name` (alias `--user`) CLI flag and an equivalent parameter in the Graphical Reader. 

**Why:**
The `--mine` filter previously relied solely on metadata found within the archive (often missing or incorrect in modern/converted formats). By allowing a user to explicitly set their name, the "Happy Path" for identifying one's own messages becomes robust and reliable across all supported formats. Furthermore, it adds "Symmetry" to our export capabilities: if we can read a user name from a QWK packet, we should be able to write a customized one back when creating new packets.

**Changes:**
- **Core:** Added `my_name` to `ProcessingSettings`. Updated `matches_filters` and `_get_message_mapping` to prioritize this setting.
- **CLI:** Added `--my-name` and `--user` flags to the Filtering group.
- **GUI:** Added `my_name` support to the reader, ensuring "Mine" badges and highlighting use the correct identity.
- **Exports:** Updated QWK/REP serialization to use the configured name in the `CONTROL.DAT` user field.
- **Documentation:** Added the new flag and pattern variable to `README.md`.
- **Tests:** Added `tests/test_my_name.py` and updated existing test mocks to account for the new attribute.

---
*PR created automatically by Jules for task [15677693712606150557](https://jules.google.com/task/15677693712606150557) started by @RainRat*