### PR TITLE
[DOCS] Replace technical jargon with Plain English in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,7 +420,7 @@ You can use custom patterns with `--oneline-pattern` (for summaries on the scree
 | `{confname_or_num}` | The conference name, or its number if the name is missing. |
 | `{msgnum}` | The unique message number. |
 | `{snippet}` | The first line of the message body. |
-| `{my_name}` | The user name (either from archive metadata or your override). |
+| `{my_name}` | The user name (either from archive information or your override). |
 
 ### Dates & Times
 | Variable | Description |


### PR DESCRIPTION
* **Type:** Documentation
* **What:** Updated the 'Custom Pattern Variables' section in `README.md`.
* **Why:** Replaced the technical term "metadata" with "archive information" to improve accessibility for a global audience, following Plain English standards.

---
*PR created automatically by Jules for task [17645978320491574152](https://jules.google.com/task/17645978320491574152) started by @RainRat*