### PR TITLE
[DOCS] Add Plain English docstring to ProcessingSettings class

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -468,6 +468,12 @@ class ProgressBar(Protocol):
 
 @dataclass
 class ProcessingSettings:
+    """A collection of settings used to control how messages are processed.
+
+    This class stores user preferences and configuration for reading,
+    filtering, and saving messages.
+    """
+
     verbose: bool
     private: bool
     no_header: bool


### PR DESCRIPTION
* **Type:** Internal Help
* **What:** The `ProcessingSettings` class in `pyqwk/core.py`.
* **Why:** Added a clear, Plain English description to the `ProcessingSettings` class to explain its role in storing user preferences and configuration. This helps developers understand the purpose of this core data structure without needing to scan all its fields.

---
*PR created automatically by Jules for task [6362534538903214341](https://jules.google.com/task/6362534538903214341) started by @RainRat*