### PR TITLE
[UI/UX] Implement rapid conference navigation in Graphical Reader

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -560,6 +560,7 @@ class QwkGuiApp:
                     ("Space", "Scroll Down / Next"),
                     ("Shift+Space", "Scroll Up / Prev"),
                     ("BackSpace", "Scroll Up / Prev"),
+                    ("[ / ]", "Prev / Next Conference"),
                     ("Ctrl + G", "Go to Message Number"),
                 ],
             ),
@@ -705,6 +706,8 @@ class QwkGuiApp:
         self.root.bind("<space>", self._on_space_pressed)
         self.root.bind("<Shift-space>", self._on_space_pressed)
         self.root.bind("<BackSpace>", self._on_space_pressed)
+        self.root.bind("[", lambda e: self._navigate_conference(-1))
+        self.root.bind("]", lambda e: self._navigate_conference(1))
 
     def _get_all_tree_items(self) -> list[str]:
         """Return a flattened list of all item IDs currently visible in the treeview."""
@@ -969,8 +972,14 @@ class QwkGuiApp:
         ).pack(side=tk.LEFT)
         self.bbs_combo = ttk.Combobox(archives_frame, state="readonly", width=18)
         self.bbs_combo.pack(side=tk.LEFT, padx=2)
+        ttk.Button(
+            archives_frame, text="◀", width=2, command=lambda: self._navigate_conference(-1)
+        ).pack(side=tk.LEFT, padx=(5, 1))
         self.conf_combo = ttk.Combobox(archives_frame, state="readonly", width=18)
-        self.conf_combo.pack(side=tk.LEFT, padx=2)
+        self.conf_combo.pack(side=tk.LEFT, padx=1)
+        ttk.Button(
+            archives_frame, text="▶", width=2, command=lambda: self._navigate_conference(1)
+        ).pack(side=tk.LEFT, padx=(1, 2))
 
         ttk.Separator(row2, orient=tk.VERTICAL).pack(side=tk.LEFT, fill=tk.Y, padx=10)
 
@@ -1526,6 +1535,21 @@ class QwkGuiApp:
                 self._update_status_bar(message_index)
             else:
                 self.search_count_label.config(text="0 / 0")
+
+    def _navigate_conference(self, delta: int, _event: object | None = None) -> None:
+        """Cycle through available conferences in the selector."""
+        values = self.conf_combo["values"]
+        if not values:
+            return
+
+        current_idx = self.conf_combo.current()
+        if current_idx == -1:
+            new_idx = 0
+        else:
+            new_idx = (current_idx + delta) % len(values)
+
+        self.conf_combo.current(new_idx)
+        self.reload_messages()
 
     def _navigate_search_matches(
         self, delta: int, _event: object | None = None

--- a/tests/test_conference_navigation.py
+++ b/tests/test_conference_navigation.py
@@ -1,0 +1,54 @@
+import pytest
+import tkinter as tk
+from tkinter import ttk
+from unittest.mock import MagicMock, patch
+from pyqwk.gui import QwkGuiApp
+
+@pytest.fixture
+def mock_root():
+    root = tk.Tk()
+    yield root
+    root.destroy()
+
+def test_navigate_conference(mock_root):
+    # Mocking necessary components to avoid full app initialization issues
+    with patch('pyqwk.gui.load_data'), \
+         patch('pyqwk.gui.expand_paths', return_value=[]), \
+         patch('pyqwk.gui.QwkGuiApp._render_welcome_screen'):
+
+        app = QwkGuiApp(mock_root)
+        app.reload_messages = MagicMock()
+
+        # Setup conferences
+        app.conf_combo['values'] = ["0: All", "1: General", "2: Tech"]
+        app.conf_combo.current(1) # Start at General
+
+        # Test forward navigation
+        app._navigate_conference(1)
+        assert app.conf_combo.current() == 2
+        app.reload_messages.assert_called_once()
+
+        # Test backward navigation
+        app.reload_messages.reset_mock()
+        app._navigate_conference(-1)
+        assert app.conf_combo.current() == 1
+        app.reload_messages.assert_called_once()
+
+        # Test wrap around forward
+        app.conf_combo.current(2)
+        app._navigate_conference(1)
+        assert app.conf_combo.current() == 0
+
+        # Test wrap around backward
+        app.conf_combo.current(0)
+        app._navigate_conference(-1)
+        assert app.conf_combo.current() == 2
+
+def test_navigate_conference_no_values(mock_root):
+    with patch('pyqwk.gui.QwkGuiApp._render_welcome_screen'):
+        app = QwkGuiApp(mock_root)
+        app.reload_messages = MagicMock()
+        app.conf_combo['values'] = []
+
+        app._navigate_conference(1)
+        assert app.reload_messages.call_count == 0


### PR DESCRIPTION
### Context
GUI (Graphical Reader)

### Problem
Navigating between conferences currently requires users to open the 'Conference' dropdown menu and manually select a target. This multi-step process introduces significant friction, especially when browsing archives with many active discussion areas.

### Solution
This improvement introduces "rapid navigation" for conferences:
1.  **GUI Buttons:** Added intuitive '◀' and '▶' buttons immediately adjacent to the conference selector in the toolbar.
2.  **Keyboard Shortcuts:** Mapped the '[' (previous) and ']' (next) keys to trigger conference switches.
3.  **Onboarding:** Updated the Welcome Screen's keyboard shortcut list so users can discover the feature immediately.

These changes allow for a seamless "channel-surfing" experience through BBS message archives, maintaining reading flow while reducing the number of necessary clicks and precise mouse movements.

### Changes
- Modified `pyqwk/gui.py` to include the navigation logic, UI elements, and bindings.
- Added `tests/test_conference_navigation.py` to ensure robust behavior including list wrap-around.

---
*PR created automatically by Jules for task [7482859907710872525](https://jules.google.com/task/7482859907710872525) started by @RainRat*