### PR TITLE
[FEAT] Graphical Conference Navigation and Keyboard Shortcuts

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -561,6 +561,7 @@ class QwkGuiApp:
                     ("Shift+Space", "Scroll Up / Prev"),
                     ("BackSpace", "Scroll Up / Prev"),
                     ("Ctrl + G", "Go to Message Number"),
+                    ("[ / ]", "Prev / Next Conference"),
                 ],
             ),
         ]
@@ -705,6 +706,8 @@ class QwkGuiApp:
         self.root.bind("<space>", self._on_space_pressed)
         self.root.bind("<Shift-space>", self._on_space_pressed)
         self.root.bind("<BackSpace>", self._on_space_pressed)
+        self.root.bind("[", lambda e: self._navigate_conference(-1))
+        self.root.bind("]", lambda e: self._navigate_conference(1))
 
     def _get_all_tree_items(self) -> list[str]:
         """Return a flattened list of all item IDs currently visible in the treeview."""
@@ -754,6 +757,27 @@ class QwkGuiApp:
         self.message_list.see(new_item)
         self.message_list.focus(new_item)
         return True
+
+    def _navigate_conference(self, delta: int) -> None:
+        """Change the selected conference in the combobox by a given offset."""
+        if not self.conf_combo["values"]:
+            return
+
+        # Avoid changing conferences while the user is typing in a search or exclude field
+        focused_widget = self.root.focus_get()
+        if focused_widget in (self.search_entry, self.exclude_entry):
+            return
+
+        current_idx = self.conf_combo.current()
+        num_values = len(self.conf_combo["values"])
+
+        if current_idx == -1:
+            new_idx = 0 if delta > 0 else num_values - 1
+        else:
+            new_idx = (current_idx + delta) % num_values
+
+        self.conf_combo.current(new_idx)
+        self.reload_messages()
 
     def _on_space_pressed(self, event: tk.Event) -> str | None:
         """Handle Space, Shift+Space, and BackSpace for continuous reading."""
@@ -969,8 +993,15 @@ class QwkGuiApp:
         ).pack(side=tk.LEFT)
         self.bbs_combo = ttk.Combobox(archives_frame, state="readonly", width=18)
         self.bbs_combo.pack(side=tk.LEFT, padx=2)
+
+        ttk.Button(
+            archives_frame, text="◀", width=2, command=lambda: self._navigate_conference(-1)
+        ).pack(side=tk.LEFT, padx=(5, 0))
         self.conf_combo = ttk.Combobox(archives_frame, state="readonly", width=18)
         self.conf_combo.pack(side=tk.LEFT, padx=2)
+        ttk.Button(
+            archives_frame, text="▶", width=2, command=lambda: self._navigate_conference(1)
+        ).pack(side=tk.LEFT, padx=(0, 2))
 
         ttk.Separator(row2, orient=tk.VERTICAL).pack(side=tk.LEFT, fill=tk.Y, padx=10)
 

--- a/tests/test_conference_navigation.py
+++ b/tests/test_conference_navigation.py
@@ -1,0 +1,138 @@
+import sys
+from unittest.mock import MagicMock, patch, call, ANY
+import pytest
+
+# Mock tkinter before any pyqwk.gui imports
+mock_tk = MagicMock()
+mock_ttk = MagicMock()
+sys.modules["tkinter"] = mock_tk
+sys.modules["tkinter.filedialog"] = MagicMock()
+sys.modules["tkinter.messagebox"] = MagicMock()
+sys.modules["tkinter.ttk"] = mock_ttk
+
+from pyqwk.core import ParsedMessage, MessageHeader
+
+@pytest.fixture
+def mock_gui_deps():
+    with (
+        patch("pyqwk.gui.tk") as mock_tk,
+        patch("pyqwk.gui.ttk") as mock_ttk,
+        patch("pyqwk.gui.filedialog") as mock_fd,
+        patch("pyqwk.gui.messagebox") as mock_mb,
+    ):
+        # Configure Variable mocks
+        def make_var(value=None):
+            m = MagicMock()
+            m.get.return_value = value
+            return m
+
+        mock_tk.BooleanVar.side_effect = lambda value=False, **kwargs: make_var(value)
+        mock_tk.StringVar.side_effect = lambda value="", **kwargs: make_var(value)
+        mock_tk.IntVar.side_effect = lambda value=0, **kwargs: make_var(value)
+
+        # Tkinter constants
+        mock_tk.END = "end"
+        mock_tk.HORIZONTAL = "horizontal"
+        mock_tk.VERTICAL = "vertical"
+        mock_tk.BOTH = "both"
+        mock_tk.X = "x"
+        mock_tk.Y = "y"
+        mock_tk.LEFT = "left"
+        mock_tk.RIGHT = "right"
+        mock_tk.TOP = "top"
+        mock_tk.BOTTOM = "bottom"
+        mock_tk.SUNKEN = "sunken"
+        mock_tk.W = "w"
+        mock_tk.E = "e"
+        mock_tk.WORD = "word"
+        mock_tk.DISABLED = "disabled"
+        mock_tk.NORMAL = "normal"
+        mock_tk.INSERT = "insert"
+
+        # Mock classes/types
+        class TclError(Exception):
+            pass
+        mock_tk.TclError = TclError
+
+        # Mock Combobox
+        mock_combo = MagicMock()
+        mock_ttk.Combobox.return_value = mock_combo
+
+        yield {
+            "tk": mock_tk,
+            "ttk": mock_ttk,
+            "filedialog": mock_fd,
+            "messagebox": mock_mb,
+            "combo": mock_combo,
+        }
+
+def get_app():
+    from pyqwk.gui import QwkGuiApp
+    root = MagicMock()
+    return QwkGuiApp(root)
+
+class TestConferenceNavigation:
+    def test_navigate_conference_logic(self, mock_gui_deps):
+        app = get_app()
+        # Setup mock conferences
+        mock_gui_deps["combo"].__getitem__.side_effect = lambda key: ["All", "1: General", "2: Tech"] if key == "values" else None
+        mock_gui_deps["combo"].current.return_value = 1  # Current is "1: General"
+
+        with patch.object(app, "reload_messages") as mock_reload:
+            # Navigate forward
+            app._navigate_conference(1)
+            mock_gui_deps["combo"].current.assert_called_with(2)
+            mock_reload.assert_called_once()
+
+            # Navigate backward
+            mock_gui_deps["combo"].current.return_value = 2
+            app._navigate_conference(-1)
+            mock_gui_deps["combo"].current.assert_called_with(1)
+
+            # Wrap around forward
+            mock_gui_deps["combo"].current.return_value = 2
+            app._navigate_conference(1)
+            mock_gui_deps["combo"].current.assert_called_with(0)
+
+            # Wrap around backward
+            mock_gui_deps["combo"].current.return_value = 0
+            app._navigate_conference(-1)
+            mock_gui_deps["combo"].current.assert_called_with(2)
+
+    def test_navigate_conference_empty(self, mock_gui_deps):
+        app = get_app()
+        mock_gui_deps["combo"].__getitem__.side_effect = lambda key: [] if key == "values" else None
+
+        with patch.object(app, "reload_messages") as mock_reload:
+            app._navigate_conference(1)
+            mock_reload.assert_not_called()
+
+    def test_navigation_buttons_existence(self, mock_gui_deps):
+        app = get_app()
+        # Verify that buttons with ◀ and ▶ were created
+        mock_gui_deps["ttk"].Button.assert_any_call(
+            ANY, text="◀", width=2, command=ANY
+        )
+        mock_gui_deps["ttk"].Button.assert_any_call(
+            ANY, text="▶", width=2, command=ANY
+        )
+
+    def test_keyboard_shortcuts_bound(self, mock_gui_deps):
+        app = get_app()
+        # Check that [ and ] are bound
+        calls = app.root.bind.call_args_list
+        bound_keys = [c[0][0] for c in calls]
+        assert "[" in bound_keys
+        assert "]" in bound_keys
+
+    def test_welcome_screen_updates(self, mock_gui_deps):
+        app = get_app()
+        app._render_welcome_screen()
+
+        # Verify that the new shortcut is mentioned in the welcome screen
+        found_shortcut = False
+        for call_args in app.detail_text.insert.call_args_list:
+            if "[ / ]" in str(call_args):
+                found_shortcut = True
+                break
+        assert found_shortcut, "Conference navigation shortcuts not found in welcome screen"


### PR DESCRIPTION
Added interactive conference navigation to the Graphical Reader. This includes '◀' and '▶' buttons in the toolbar and global keyboard shortcuts `[` and `]` for cycling through conferences. The implementation includes focus-aware logic to prevent accidental navigation while typing in search fields and robust wrap-around handling.

This feature improves the browsing workflow for multi-conference archives, providing a more intuitive and efficient user experience consistent with traditional offline mail readers.

---
*PR created automatically by Jules for task [11755638727357783894](https://jules.google.com/task/11755638727357783894) started by @RainRat*