### PR TITLE
[DOCS] Add docstring to ProcessingSettings dataclass

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -468,6 +468,7 @@ class ProgressBar(Protocol):
 
 @dataclass
 class ProcessingSettings:
+    """A collection of settings for controlling how messages are read, filtered, and saved."""
     verbose: bool
     private: bool
     no_header: bool


### PR DESCRIPTION
This PR adds a concise, Plain English docstring to the `ProcessingSettings` dataclass in `pyqwk/core.py`. 

The docstring ("A collection of settings for controlling how messages are read, filtered, and saved.") follows the project's style guidelines by using active voice, avoiding jargon, and being accessible to a global audience. 

This change improves the codebase's self-documentation and helps developers understand the role of this central dataclass.

---
*PR created automatically by Jules for task [16765914772633563023](https://jules.google.com/task/16765914772633563023) started by @RainRat*