### PR TITLE
[UI/UX] Refine focus-aware navigation for Exclude filter

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -731,8 +731,8 @@ class QwkGuiApp:
         if not self.messages:
             return False
 
-        # If the search entry has focus, don't hijack keyboard navigation unless forced
-        if not force and self.root.focus_get() == self.search_entry:
+        # If a search or exclude entry has focus, don't hijack keyboard navigation unless forced
+        if not force and self.root.focus_get() in (self.search_entry, self.exclude_entry):
             return False
 
         all_items = self._get_all_tree_items()
@@ -781,8 +781,8 @@ class QwkGuiApp:
 
     def _on_space_pressed(self, event: tk.Event) -> str | None:
         """Handle Space, Shift+Space, and BackSpace for continuous reading."""
-        # If the search entry has focus, let it handle the keys
-        if self.root.focus_get() == self.search_entry:
+        # If a search or exclude entry has focus, let it handle the keys
+        if self.root.focus_get() in (self.search_entry, self.exclude_entry):
             return None
 
         # Check scroll position: (top, bottom) as fractions of the whole

--- a/tests/test_gui_exclude_focus_navigation.py
+++ b/tests/test_gui_exclude_focus_navigation.py
@@ -1,0 +1,61 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+# Mock tkinter and related components before importing pyqwk.gui
+mock_tk = MagicMock()
+mock_ttk = MagicMock()
+mock_font = MagicMock()
+
+# Mock BooleanVar and StringVar to return usable mocks
+def make_var(value=None):
+    m = MagicMock()
+    m.get.return_value = value
+    return m
+
+mock_tk.BooleanVar.side_effect = lambda value=False, **kwargs: make_var(value)
+mock_tk.StringVar.side_effect = lambda value="", **kwargs: make_var(value)
+mock_tk.IntVar.side_effect = lambda value=0, **kwargs: make_var(value)
+
+sys.modules["tkinter"] = mock_tk
+sys.modules["tkinter.ttk"] = mock_ttk
+sys.modules["tkinter.font"] = mock_font
+sys.modules["tkinter.filedialog"] = MagicMock()
+sys.modules["tkinter.messagebox"] = MagicMock()
+sys.modules["tkinter.simpledialog"] = MagicMock()
+
+from pyqwk.gui import QwkGuiApp
+
+def test_select_relative_message_focus_awareness():
+    """Verify that _select_relative_message returns False when exclude_entry has focus."""
+    root = MagicMock()
+    app = QwkGuiApp(root)
+
+    # Setup state
+    app.messages = [MagicMock(), MagicMock()]
+    app.search_entry = MagicMock()
+    app.exclude_entry = MagicMock()
+
+    # Scenario: exclude_entry has focus
+    root.focus_get.return_value = app.exclude_entry
+
+    # Should return False (suppress navigation)
+    assert app._select_relative_message(1) is False
+
+def test_on_space_pressed_focus_awareness():
+    """Verify that _on_space_pressed returns None when exclude_entry has focus."""
+    root = MagicMock()
+    app = QwkGuiApp(root)
+
+    # Setup widgets
+    app.search_entry = MagicMock()
+    app.exclude_entry = MagicMock()
+
+    # Scenario: exclude_entry has focus
+    root.focus_get.return_value = app.exclude_entry
+
+    event = MagicMock()
+    event.keysym = "space"
+    event.state = 0
+
+    # Should return None (let entry handle the key)
+    assert app._on_space_pressed(event) is None


### PR DESCRIPTION
* **Context:** GUI
* **Problem:** Global keyboard navigation shortcuts (like the Space bar for scrolling or 'j'/'k' for moving between messages) would trigger even when the user was typing in the "Exclude" filter field. This resulted in accidental message jumps and interrupted the filtering workflow.
* **Solution:** Updated the keyboard event handlers `_select_relative_message` and `_on_space_pressed` in `pyqwk/gui.py` to check if `self.exclude_entry` has focus. If it does, the global navigation is suppressed, allowing the user to type freely (including spaces) without accidental jumps. This aligns the "Exclude" field behavior with the existing focus-aware logic for the "Search" field.

---
*PR created automatically by Jules for task [673365781234219156](https://jules.google.com/task/673365781234219156) started by @RainRat*