### PR TITLE
Fix missing attachments in message dictionary serialization

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -3599,6 +3599,7 @@ def process_merged_files(
 
 
 def _message_to_dict(message: ProcessedMessage) -> dict[str, Any]:
+    message.discover_attachments()
     return {
         "header": message.header.as_dict,
         "conference": message.confname,


### PR DESCRIPTION
This PR fixes a logic bug in `pyqwk/core.py` where the `_message_to_dict` function (used for JSON and JSONL exports) failed to include message attachments if they hadn't been explicitly discovered yet.

**What:**
Added a call to `message.discover_attachments()` at the beginning of `_message_to_dict`.

**Why:**
`ParsedMessage` objects use lazy discovery for attachments (scanning the message body for UUE/Base64/yEnc blocks). If this discovery hasn't been triggered by another operation (like filtering or rendering) before `_message_to_dict` is called, the `attachments` field remains `None` (defaulting to `[]` in the dict), even if the message contains binaries. This fix ensures that serialization always includes the complete attachment information.

**Safety:**
This is a non-breaking change that only ensures data completeness during serialization. All existing tests passed successfully.

---
*PR created automatically by Jules for task [8110942714412743134](https://jules.google.com/task/8110942714412743134) started by @RainRat*