### PR TITLE
Remove redundant _highlight_entities call in handle_output

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -3117,9 +3117,6 @@ def process_merged_files(
                 use_colors=use_colors,
             )
 
-            # Apply highlighting to links and other entities
-            cleaned_body = _highlight_entities(cleaned_body, use_colors)
-
         if settings.oneline:
             if settings.oneline_pattern:
                 try:


### PR DESCRIPTION
In the `handle_output` helper function within `process_merged_files`, the message body was being processed by both `_highlight_text` and `_highlight_entities` sequentially for terminal output. Since `_highlight_text` is a wrapper around `_linkify_text` that handles both search terms and standard entities (URLs, emails, phone numbers, and message links) in a single unified pass, the subsequent call to `_highlight_entities` was unnecessary. Removing this redundant call simplifies the processing pipeline and avoids redundant regex scans over the message text.

---
*PR created automatically by Jules for task [9127328833036414801](https://jules.google.com/task/9127328833036414801) started by @RainRat*