### PR TITLE
[UI/UX] Standardize metadata labels and styling in message detail view

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -1175,6 +1175,9 @@ class QwkGuiApp:
             "header_label", font=("TkDefaultFont", 10, "bold"), foreground="#444444"
         )
         self.detail_text.tag_configure(
+            "header_meta_label", font=("TkDefaultFont", 9, "bold"), foreground="#666666"
+        )
+        self.detail_text.tag_configure(
             "header_meta", font=("TkDefaultFont", 9), foreground="#888888"
         )
         self.detail_text.tag_configure(
@@ -1335,6 +1338,7 @@ class QwkGuiApp:
         self.detail_text.insert(tk.END, "\n\n")
 
         # Information line (Date, Conference, BBS, Msg #)
+        self.detail_text.insert(tk.END, "Date: ", "header_meta_label")
         self.detail_text.insert(
             tk.END, f"{header.msgdate} {header.msgtime}", "header_meta"
         )
@@ -1354,6 +1358,7 @@ class QwkGuiApp:
                 self.detail_text.insert(tk.END, " MINE ", "badge_mine")
 
         self.detail_text.insert(tk.END, "  •  ", "header_meta")
+        self.detail_text.insert(tk.END, "Conf: ", "header_meta_label")
 
         conf_tag = f"conf_link_{id(msg)}"
         self.detail_text.insert(tk.END, conf_name, ("link", "header_meta", conf_tag))
@@ -1365,6 +1370,7 @@ class QwkGuiApp:
 
         if msg.bbs_name:
             self.detail_text.insert(tk.END, "  •  ", "header_meta")
+            self.detail_text.insert(tk.END, "BBS:  ", "header_meta_label")
             bbs_tag = f"bbs_link_{id(msg)}"
             self.detail_text.insert(
                 tk.END, msg.bbs_name, ("link", "header_meta", bbs_tag)
@@ -1377,12 +1383,14 @@ class QwkGuiApp:
 
         if header.msgnum is not None:
             self.detail_text.insert(tk.END, "  •  ", "header_meta")
-            self.detail_text.insert(tk.END, f"Msg #{header.msgnum}", "header_meta")
+            self.detail_text.insert(tk.END, "Msg:  ", "header_meta_label")
+            self.detail_text.insert(tk.END, f"{header.msgnum}", "header_meta")
 
         if msg.refnum:
             self.detail_text.insert(tk.END, "  •  ", "header_meta")
+            self.detail_text.insert(tk.END, "Ref:  ", "header_meta_label")
             ref_tag = f"ref_link_{id(msg)}"
-            self.detail_text.insert(tk.END, f"Ref #{msg.refnum}", ("link", ref_tag))
+            self.detail_text.insert(tk.END, f"{msg.refnum}", ("link", "header_meta", ref_tag))
             self.detail_text.tag_bind(
                 ref_tag,
                 "<Button-1>",
@@ -1394,8 +1402,9 @@ class QwkGuiApp:
         self.detail_text.insert(tk.END, "\n")
 
         if msg.source_file:
+            self.detail_text.insert(tk.END, "Source: ", "header_meta_label")
             self.detail_text.insert(
-                tk.END, f"Source: {msg.source_file}\n", "header_meta"
+                tk.END, f"{msg.source_file}\n", "header_meta"
             )
 
         if msg.attachments:

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -181,21 +181,22 @@ class TestQwkGui:
             texts = [c.kwargs["text"] for c in calls if "text" in c.kwargs]
             assert "Test BBS" in texts[-1]
 
-            # Verify Ref #: was rendered
+            # Verify Ref: was rendered
             app._render_message(0)
-            # Find the call with "Ref #99". The tag should be ('link', 'ref_link_...')
+            # Find the call with "99" (the value). The tag should be ('link', 'header_meta', 'ref_link_...')
             found_ref = False
-            for call in app.detail_text.insert.call_args_list:
-                if len(call.args) >= 2 and call.args[1] == "Ref #99":
-                    tags = call.args[2]
+            for call_obj in app.detail_text.insert.call_args_list:
+                if len(call_obj.args) >= 2 and call_obj.args[1] == "99":
+                    tags = call_obj.args[2]
                     if (
                         isinstance(tags, tuple)
                         and "link" in tags
+                        and "header_meta" in tags
                         and any(t.startswith("ref_link_") for t in tags)
                     ):
                         found_ref = True
                         break
-            assert found_ref, "Ref #99 link with correct tags not found"
+            assert found_ref, "Ref: 99 value with correct tags not found"
 
     def test_load_messages_error(self, mock_gui_deps):
         app = get_app()


### PR DESCRIPTION
This improvement focuses on the visual hierarchy and clarity of the message detail view in the Graphical Reader.

**Problem:**
The metadata line (containing the date, conference, BBS, and message numbers) was previously rendered as a series of values separated by bullets, without explicit labels for most fields. This made the information dense and occasionally ambiguous, especially for new users. Additionally, the styling for the "Ref #" link was inconsistent with the rest of the metadata.

**Solution:**
1.  **Explicit Labels:** Added descriptive labels ("Date: ", "Conf: ", "BBS: ", "Msg: ", "Ref: ", and "Source: ") to all metadata fields.
2.  **Visual Hierarchy:** Defined a new `header_meta_label` tag (9pt, bold, foreground #666666) to distinguish labels from their values (which use the standard `header_meta` tag).
3.  **Improved Alignment:** Applied consistent 6-character alignment for primary labels ("From: ", "To:   ", "Date: ", "Conf: ", "BBS:  ") to facilitate easier vertical scanning.
4.  **Consistency:** Updated the interactive Reference link to use the correct `header_meta` styling, ensuring a uniform look across the entire information line.

These changes adhere to "Invisible Design" principles by polishing the interface without adding unnecessary decoration, resulting in a more professional and readable experience.

---
*PR created automatically by Jules for task [3929904851496037222](https://jules.google.com/task/3929904851496037222) started by @RainRat*