### PR TITLE
[TEST] Add robust branch coverage for HTML date parsing edge cases

### DIFF
--- a/tests/test_lead_qa_branch_closure.py
+++ b/tests/test_lead_qa_branch_closure.py
@@ -1,0 +1,21 @@
+from pyqwk.core import _parse_html_messages
+
+def test_parse_html_whitespace_date(tmp_path):
+    content = '<div class="message"><strong>Date:</strong>   </div>'
+    f = tmp_path / "whitespace_date.html"
+    f.write_text(content, encoding="utf-8")
+
+    msgs = _parse_html_messages(str(f))
+    assert len(msgs) == 1
+    assert msgs[0].header.msgdate == "01-01-70"
+    assert msgs[0].header.msgtime == "00:00"
+
+def test_parse_html_single_part_date(tmp_path):
+    content = '<div class="message"><strong>Date:</strong> 2024-05-20 </div>'
+    f = tmp_path / "single_date.html"
+    f.write_text(content, encoding="utf-8")
+
+    msgs = _parse_html_messages(str(f))
+    assert len(msgs) == 1
+    assert msgs[0].header.msgdate == "2024-05-20"
+    assert msgs[0].header.msgtime == "00:00"


### PR DESCRIPTION
This PR adds targeted branch coverage for HTML message parsing.

Specifically, it addresses coverage gaps in the `_parse_html_messages` function within `pyqwk/core.py` by implementing tests for:
- Whitespace-only date headers (ensuring they fallback to the default Unix epoch).
- Single-part date headers (ensuring they correctly parse the date while defaulting the time).

These additions improve the robustness of the HTML importer when encountering malformed or minimal metadata. All 969 tests in the suite passed.

---
*PR created automatically by Jules for task [17991784268577468113](https://jules.google.com/task/17991784268577468113) started by @RainRat*