### PR TITLE
[DOCS] Define 'Conferences' terminology in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ pyqwk converts message archives into modern, readable formats like HTML, Markdow
 
 QWK files were created in the 1980s for Bulletin Board Systems (BBS). Users downloaded their messages in a single "packet," read them offline, and then uploaded their replies in a `.REP` packet.
 
+Inside these packets, messages are organized into **Conferences**. You can think of a Conference as a modern forum, channel, or newsgroup dedicated to a specific topic.
+
 pyqwk helps you open these archives and convert them into modern, readable formats.
 
 ## Features


### PR DESCRIPTION
* **Type:** Documentation
* **What:** The "What are QWK and REP files?" section in `README.md`.
* **Why:** Clarified the domain-specific term "Conferences" by relating it to modern forums and channels, making the project more accessible to users unfamiliar with legacy BBS technology.

---
*PR created automatically by Jules for task [10756293200627320521](https://jules.google.com/task/10756293200627320521) started by @RainRat*