### PR TITLE
Remove redundant `_highlight_entities` wrapper function

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -5334,11 +5334,6 @@ def _linkify_text(
     return "".join(result)
 
 
-def _highlight_entities(text: str, use_colors: bool = False) -> str:
-    """Apply terminal highlighting to URLs, emails, phone numbers, and message links."""
-    return _linkify_text(text, "ansi", use_colors=use_colors)
-
-
 def _highlight_text(
     text: str,
     term: str | None,

--- a/tests/test_cross_references.py
+++ b/tests/test_cross_references.py
@@ -1,5 +1,5 @@
 from unittest.mock import MagicMock, patch
-from pyqwk.core import _highlight_entities, RE_MSG_LINK_PATTERN
+from pyqwk.core import _highlight_text, RE_MSG_LINK_PATTERN
 
 def test_msg_link_pattern():
     """Verify that the message link pattern matches various formats."""
@@ -7,14 +7,14 @@ def test_msg_link_pattern():
     assert matches == ["123", "456", "789"]
 
 def test_highlight_entities_ansi():
-    """Verify that _highlight_entities applies the correct ANSI codes."""
+    """Verify that highlighting applies the correct ANSI codes."""
     text = "Visit http://example.com or email test@example.com or see msg #123"
 
     # No colors
-    assert _highlight_entities(text, use_colors=False) == text
+    assert _highlight_text(text, None, use_colors=False) == text
 
     # With colors
-    highlighted = _highlight_entities(text, use_colors=True)
+    highlighted = _highlight_text(text, None, use_colors=True)
 
     # URL: Underline (4) and Dim (90)
     assert "\x1b[4;90mhttp://example.com\x1b[0m" in highlighted


### PR DESCRIPTION
This PR removes a redundant wrapper function `_highlight_entities` from `pyqwk/core.py`. This function was a thin wrapper around `_linkify_text` with hardcoded arguments. Its purpose is entirely superseded by `_highlight_text`, which handles both search term highlighting and entity discovery in a single pass. 

Associated tests in `tests/test_cross_references.py` have been updated to call `_highlight_text` with a `None` search term, which preserves the existing behavior of highlighting URLs, emails, and message links in terminal output.

---
*PR created automatically by Jules for task [8379762956755900439](https://jules.google.com/task/8379762956755900439) started by @RainRat*