### PR TITLE
[UI/UX] Standardize and Align Metadata Labels in Graphical Reader

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -1314,7 +1314,7 @@ class QwkGuiApp:
         self.detail_text.insert(tk.END, "\n")
 
         # Primary fields
-        self.detail_text.insert(tk.END, "From:   ", "header_label")
+        self.detail_text.insert(tk.END, "From:   ", "header_meta_label")
         from_tag = f"from_link_{id(msg)}"
         self.detail_text.insert(tk.END, msg_from, ("link", "header_value", from_tag))
         self.detail_text.tag_bind(
@@ -1324,7 +1324,7 @@ class QwkGuiApp:
         )
         self.detail_text.insert(tk.END, "\n")
 
-        self.detail_text.insert(tk.END, "To:     ", "header_label")
+        self.detail_text.insert(tk.END, "To:     ", "header_meta_label")
         to_tag = f"to_link_{id(msg)}"
         self.detail_text.insert(tk.END, msg_to, ("link", "header_value", to_tag))
         self.detail_text.tag_bind(
@@ -1335,7 +1335,7 @@ class QwkGuiApp:
         self.detail_text.insert(tk.END, "\n\n")
 
         # Information line (Date, Conference, BBS, Msg #)
-        self.detail_text.insert(tk.END, "Date: ", "header_meta_label")
+        self.detail_text.insert(tk.END, "Date:   ", "header_meta_label")
         self.detail_text.insert(
             tk.END, f"{header.msgdate} {header.msgtime}", "header_meta"
         )
@@ -1411,7 +1411,7 @@ class QwkGuiApp:
             )
 
         if msg.attachments:
-            self.detail_text.insert(tk.END, "Attachments: ", "header_label")
+            self.detail_text.insert(tk.END, "Attach: ", "header_meta_label")
             for i, filename in enumerate(msg.attachments):
                 tag = f"attach_link_{id(msg)}_{i}"
                 self.detail_text.insert(tk.END, filename, ("link", tag))

--- a/tests/test_gui_attachments_comprehensive.py
+++ b/tests/test_gui_attachments_comprehensive.py
@@ -85,7 +85,7 @@ def test_gui_renders_attachments(mock_gui_deps):
 
     # Check if "Attachments: " label was inserted
     app.detail_text.insert.assert_any_call(
-        mock_gui_deps["tk"].END, "Attachments: ", "header_label"
+        mock_gui_deps["tk"].END, "Attach: ", "header_meta_label"
     )
     # Check if attachment names were inserted as links
     msg_id = id(message)


### PR DESCRIPTION
### **Context:** (GUI)

### **Problem:**
The message detail view in the Graphical Reader utilized inconsistent styling and spacing for metadata labels. 'From' and 'To' used the prominent `header_label` style, while 'Date' and 'Conference' used the more subtle `header_meta_label`. Additionally, the varying character lengths of these labels (e.g., 'From:   ' vs 'Date: ') created a jagged vertical alignment for the message information, making it harder for users to scan the header area quickly.

### **Solution:**
I have standardized the visual hierarchy by applying the `header_meta_label` style (9pt bold, foreground #666666) to all metadata labels. Furthermore, I have aligned all labels that begin a new line in the header ('From', 'To', 'Date', 'Source', and 'Attach') to a uniform 8-character width. This ensures that the message values start at the exact same horizontal position, creating a structured and professional look that adheres to "Invisible Design" principles.

### **Changes:**
- **`pyqwk/gui.py`**:
    - Updated `From:   ` and `To:     ` tags to `header_meta_label`.
    - Adjusted `Date: ` to `Date:   ` (8 characters).
    - Abbreviated and aligned `Attachments: ` to `Attach: ` (8 characters) and updated its style.
- **`tests/test_gui_attachments_comprehensive.py`**:
    - Updated assertions to match the new `Attach: ` label and `header_meta_label` style.

---
*PR created automatically by Jules for task [3457278473410063781](https://jules.google.com/task/3457278473410063781) started by @RainRat*