### PR TITLE
[UI/UX] Standardize message header styling and alignment

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -1316,7 +1316,7 @@ class QwkGuiApp:
         # Primary fields
         self.detail_text.insert(tk.END, "From:   ", "header_meta_label")
         from_tag = f"from_link_{id(msg)}"
-        self.detail_text.insert(tk.END, msg_from, ("link", "header_value", from_tag))
+        self.detail_text.insert(tk.END, msg_from, ("link", "header_meta", from_tag))
         self.detail_text.tag_bind(
             from_tag,
             "<Button-1>",
@@ -1326,13 +1326,13 @@ class QwkGuiApp:
 
         self.detail_text.insert(tk.END, "To:     ", "header_meta_label")
         to_tag = f"to_link_{id(msg)}"
-        self.detail_text.insert(tk.END, msg_to, ("link", "header_value", to_tag))
+        self.detail_text.insert(tk.END, msg_to, ("link", "header_meta", to_tag))
         self.detail_text.tag_bind(
             to_tag,
             "<Button-1>",
             lambda e, a=orig_to: self._pivot_filter(author=a),
         )
-        self.detail_text.insert(tk.END, "\n\n")
+        self.detail_text.insert(tk.END, "\n")
 
         # Information line (Date, Conference, BBS, Msg #)
         self.detail_text.insert(tk.END, "Date:   ", "header_meta_label")
@@ -1414,14 +1414,14 @@ class QwkGuiApp:
             self.detail_text.insert(tk.END, "Attach: ", "header_meta_label")
             for i, filename in enumerate(msg.attachments):
                 tag = f"attach_link_{id(msg)}_{i}"
-                self.detail_text.insert(tk.END, filename, ("link", tag))
+                self.detail_text.insert(tk.END, filename, ("link", "header_meta", tag))
                 self.detail_text.tag_bind(
                     tag,
                     "<Button-1>",
                     lambda e, f=filename, idx=i: self.save_attachment(f, idx),
                 )
                 if i < len(msg.attachments) - 1:
-                    self.detail_text.insert(tk.END, ", ", "header_value")
+                    self.detail_text.insert(tk.END, ", ", "header_meta")
             self.detail_text.insert(tk.END, "\n")
 
         header_end = self.detail_text.index(tk.INSERT)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -807,10 +807,10 @@ class TestQwkGui:
         to_tag = f"to_link_{id(msg)}"
 
         app.detail_text.insert.assert_any_call(
-            mock_gui_deps["tk"].END, "User", ("link", "header_value", from_tag)
+            mock_gui_deps["tk"].END, "User", ("link", "header_meta", from_tag)
         )
         app.detail_text.insert.assert_any_call(
-            mock_gui_deps["tk"].END, "All", ("link", "header_value", to_tag)
+            mock_gui_deps["tk"].END, "All", ("link", "header_meta", to_tag)
         )
 
     def test_initial_path_loading(self, mock_gui_deps):

--- a/tests/test_gui_attachments_comprehensive.py
+++ b/tests/test_gui_attachments_comprehensive.py
@@ -90,10 +90,10 @@ def test_gui_renders_attachments(mock_gui_deps):
     # Check if attachment names were inserted as links
     msg_id = id(message)
     app.detail_text.insert.assert_any_call(
-        mock_gui_deps["tk"].END, "file1.zip", ("link", f"attach_link_{msg_id}_0")
+        mock_gui_deps["tk"].END, "file1.zip", ("link", "header_meta", f"attach_link_{msg_id}_0")
     )
     app.detail_text.insert.assert_any_call(
-        mock_gui_deps["tk"].END, "image.jpg", ("link", f"attach_link_{msg_id}_1")
+        mock_gui_deps["tk"].END, "image.jpg", ("link", "header_meta", f"attach_link_{msg_id}_1")
     )
 
 


### PR DESCRIPTION
This change improves the visual hierarchy and consistency of the message detail view in the PyQWK GUI. By unifying the styling of primary metadata fields (From, To, Attach) with the secondary information line (Date, Conf, BBS), the interface achieves a more polished and professional look. Additionally, reducing vertical whitespace between fields groups related metadata together, improving scannability.

**Changes:**
- In `pyqwk/gui.py`, changed `header_value` (10pt) to `header_meta` (9pt) for sender, recipient, and attachment values.
- Reduced the double newline to a single newline after the 'To' field.
- Updated `tests/test_gui.py` and `tests/test_gui_attachments_comprehensive.py` to reflect the new styling and ensure the test suite passes.

---
*PR created automatically by Jules for task [8790612911761331409](https://jules.google.com/task/8790612911761331409) started by @RainRat*