### PR TITLE
[FEAT] Enriched metadata variables for custom patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,11 +433,16 @@ You can use custom patterns with `--oneline-pattern` (for summaries on the scree
 | `{to}` | The name of the recipient. |
 | `{subject}` | The original subject line. |
 | `{subject_clean}` | The subject line without "Re:" or "Fwd:" prefixes. |
+| `{body}` | The full text of the message body. |
+| `{body_clean}` | The message body with all whitespace collapsed into single spaces. |
 | `{confname}` | The name of the conference (if known). |
 | `{confnum}` | The number of the conference. |
 | `{confname_or_num}` | The conference name, or its number if the name is missing. |
 | `{msgnum}` | The unique message number. |
 | `{snippet}` | The first line of the message body. |
+| `{url_count}` | The number of web links found in the message. |
+| `{email_count}` | The number of email addresses found in the message. |
+| `{phone_count}` | The number of phone numbers found in the message. |
 | `{my_name}` | The user name (either from archive information or your override). |
 
 ### Dates & Times
@@ -459,6 +464,7 @@ You can use custom patterns with `--oneline-pattern` (for summaries on the scree
 ### Technical Details
 | Variable | Description |
 | :--- | :--- |
+| `{msgid}` | A unique identifier for the message (`conf.msg@bbs`). |
 | `{refnum}` | The message number being replied to. |
 | `{status}` | The status code (e.g., `*` for private). |
 | `{msgflag}` | Technical flags from the message header. |

--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -144,7 +144,7 @@ examples:
     )
     io_group.add_argument(
         "--filename-pattern",
-        help="Set a pattern for naming individual files (e.g., '{date}_{author}_{subject}'). Available variables: attachments, attachment_count, author, bbs_id, bbs_name, confname, confname_or_num, confnum, date, day, flags, hour, indent, is_private, is_reply, iso_date, iso_time, length, minute, month, msgflag, msgnum, my_name, refnum, second, size, snippet, source_file, status, subject, subject_clean, time, to, year.",
+        help="Set a pattern for naming individual files (e.g., '{date}_{author}_{subject}'). Available variables: attachments, attachment_count, author, bbs_id, bbs_name, body, body_clean, confname, confname_or_num, confnum, date, day, email_count, flags, hour, indent, is_private, is_reply, iso_date, iso_time, length, minute, month, msgflag, msgid, msgnum, my_name, phone_count, refnum, second, size, snippet, source_file, status, subject, subject_clean, time, to, url_count, year.",
     )
     io_group.add_argument(
         "-E",
@@ -285,7 +285,7 @@ examples:
     )
     format_group.add_argument(
         "--oneline-pattern",
-        help="Set a custom pattern for one-line summaries (e.g., '[{confnum}] {author}: {subject}'). Available variables: attachments, attachment_count, author, bbs_id, bbs_name, confname, confname_or_num, confnum, date, day, flags, hour, indent, is_private, is_reply, iso_date, iso_time, length, minute, month, msgflag, msgnum, my_name, refnum, second, size, snippet, source_file, status, subject, subject_clean, time, to, year.",
+        help="Set a custom pattern for one-line summaries (e.g., '[{confnum}] {author}: {subject}'). Available variables: attachments, attachment_count, author, bbs_id, bbs_name, body, body_clean, confname, confname_or_num, confnum, date, day, email_count, flags, hour, indent, is_private, is_reply, iso_date, iso_time, length, minute, month, msgflag, msgid, msgnum, my_name, phone_count, refnum, second, size, snippet, source_file, status, subject, subject_clean, time, to, url_count, year.",
     )
     format_group.add_argument(
         "--toc",

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -2888,6 +2888,22 @@ def _get_message_mapping(
     attachments_list = message.attachments or []
     attachments_str = ", ".join(attachments_list)
 
+    body = message.text or ""
+    body_clean = " ".join(body.split())
+
+    if redact_pii:
+        body = _redact_pii(body)
+        body_clean = _redact_pii(body_clean)
+
+    entities = _discover_entities(message.text or "")
+    url_count = sum(1 for e in entities if e[2] == "url")
+    email_count = sum(1 for e in entities if e[2] == "email")
+    phone_count = sum(1 for e in entities if e[2] == "phone")
+
+    msgnum_val = header.msgnum if header.msgnum is not None else 0
+    bbs_id_val = message.bbs_id or ""
+    msgid = f"{header.confnum}.{msgnum_val}@{bbs_id_val}"
+
     return {
         "confnum": header.confnum,
         "confname": message.confname or "",
@@ -2897,6 +2913,8 @@ def _get_message_mapping(
         "to": to,
         "subject": subject,
         "subject_clean": subject_clean,
+        "body": body,
+        "body_clean": body_clean,
         "date": header.msgdate,
         "time": header.msgtime,
         "year": dt.year,
@@ -2909,6 +2927,7 @@ def _get_message_mapping(
         "iso_time": dt.time().isoformat(),
         "bbs_name": message.bbs_name or "",
         "bbs_id": message.bbs_id or "",
+        "msgid": msgid,
         "source_file": message.source_file or "",
         "refnum": header.refnum if header.refnum is not None else 0,
         "status": header.status,
@@ -2917,6 +2936,9 @@ def _get_message_mapping(
         "is_reply": "true" if is_reply else "false",
         "attachments": attachments_str,
         "attachment_count": len(attachments_list),
+        "url_count": url_count,
+        "email_count": email_count,
+        "phone_count": phone_count,
         "my_name": my_name_val,
         "length": len(message.text) if message.text else 0,
         "size": format_size(len(message.text)) if message.text else "0 B",

--- a/tests/test_pattern_vars.py
+++ b/tests/test_pattern_vars.py
@@ -1,0 +1,111 @@
+import pytest
+from pyqwk.core import ParsedMessage, MessageHeader, _get_message_mapping
+
+def test_new_pattern_variables():
+    header = MessageHeader(
+        status=" ",
+        msgnum=123,
+        msgdate="01-01-24",
+        msgtime="12:00",
+        msgto="Recipient",
+        msgfrom="Author",
+        msgsubject="Test Subject",
+        msgpassword="",
+        refnum=None,
+        numblocks=1,
+        msgflag=" ",
+        confnum=1,
+        lognum=0,
+        nettag=" "
+    )
+
+    text = "Hello world! Check out https://example.com and email me at test@example.com or call 555-1212.\nNew line here."
+
+    msg = ParsedMessage(
+        text=text,
+        msgnum=123,
+        refnum=None,
+        confnum=1,
+        header=header,
+        bbs_id="MYBBS"
+    )
+
+    mapping = _get_message_mapping(msg, 1)
+
+    assert mapping["body"] == text
+    assert mapping["body_clean"] == "Hello world! Check out https://example.com and email me at test@example.com or call 555-1212. New line here."
+    assert mapping["msgid"] == "1.123@MYBBS"
+    assert mapping["url_count"] == 1
+    assert mapping["email_count"] == 1
+    assert mapping["phone_count"] == 1
+
+def test_redaction_in_pattern_variables():
+    header = MessageHeader(
+        status=" ",
+        msgnum=123,
+        msgdate="01-01-24",
+        msgtime="12:00",
+        msgto="Recipient",
+        msgfrom="Author",
+        msgsubject="Test Subject",
+        msgpassword="",
+        refnum=None,
+        numblocks=1,
+        msgflag=" ",
+        confnum=1,
+        lognum=0,
+        nettag=" "
+    )
+
+    text = "Email me at test@example.com or call 555-1212."
+
+    msg = ParsedMessage(
+        text=text,
+        msgnum=123,
+        refnum=None,
+        confnum=1,
+        header=header,
+        bbs_id="MYBBS"
+    )
+
+    mapping = _get_message_mapping(msg, 1, redact_pii=True)
+
+    assert "[EMAIL]" in mapping["body"]
+    assert "[PHONE]" in mapping["body"]
+    assert "test@example.com" not in mapping["body"]
+    assert "555-1212" not in mapping["body"]
+
+    assert "[EMAIL]" in mapping["body_clean"]
+    assert "[PHONE]" in mapping["body_clean"]
+
+def test_msgid_fallbacks():
+    header = MessageHeader(
+        status=" ",
+        msgnum=None,
+        msgdate="01-01-24",
+        msgtime="12:00",
+        msgto="Recipient",
+        msgfrom="Author",
+        msgsubject="Test Subject",
+        msgpassword="",
+        refnum=None,
+        numblocks=1,
+        msgflag=" ",
+        confnum=99,
+        lognum=0,
+        nettag=" "
+    )
+
+    msg = ParsedMessage(
+        text="No links here",
+        msgnum=None,
+        refnum=None,
+        confnum=99,
+        header=header,
+        bbs_id=None
+    )
+
+    mapping = _get_message_mapping(msg, 1)
+
+    assert mapping["msgid"] == "99.0@"
+    assert mapping["url_count"] == 0


### PR DESCRIPTION
This PR introduces enriched metadata variables to the `pyqwk` pattern mapping system, significantly expanding the capabilities of custom summaries and individual file naming.

### Key Additions:
- **`{body}`**: The full message text (respects `--redact-pii`).
- **`{body_clean}`**: Message text with all whitespace and newlines collapsed into single spaces (ideal for concise filenames or oneline summaries).
- **`{msgid}`**: A unique identifier in the format `confnum.msgnum@bbsid`.
- **`{url_count}`, `{email_count}`, `{phone_count}`**: Integer counts of discovered entities, leveraging the existing `_discover_entities` engine.

### Rationale:
These additions fill a "missing piece" in the current pattern system by allowing users to automate processing based on message content and entity density. For example, a user can now export messages to filenames that include the link count or a unique identifier, or view the first few characters of the body in a standard list view without using the snippet fallback.

### Verification:
- Added a new test suite `tests/test_pattern_vars.py` covering all new variables and edge cases (redaction, fallbacks, whitespace collapsing).
- Verified that all 974 existing tests pass.
- Updated CLI help strings and the README documentation for discovery and parity.

---
*PR created automatically by Jules for task [8333640451863709586](https://jules.google.com/task/8333640451863709586) started by @RainRat*