### PR TITLE
fix: ensure exact div tag matching in HTML parser

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -1429,7 +1429,7 @@ def _parse_html_messages(path: str) -> list[ParsedMessage]:
     )
 
     # Pre-calculate depths for all message starts in a single pass
-    div_tags = list(re.finditer(r"<(div|/div)([^>]*)>", content, re.IGNORECASE))
+    div_tags = list(re.finditer(r"<(div|/div)\b([^>]*)>", content, re.IGNORECASE))
     msg_depths = {}
     current_depth = 0
     stack = []

--- a/tests/test_html_parser_boundary.py
+++ b/tests/test_html_parser_boundary.py
@@ -1,0 +1,60 @@
+import pytest
+from pyqwk.core import _parse_html_messages
+
+def test_parse_html_messages_div_boundary(tmp_path):
+    """Verify that _parse_html_messages doesn't incorrectly pick up tags like <divisible>."""
+    html_content = """
+    <divisible class="reply">
+        <div class="message">
+            <div class="header">
+                <strong>From:</strong> User1<br>
+                <strong>Date:</strong> 01-01-24 10:00<br>
+                <strong>Number:</strong> 1<br>
+            </div>
+            <pre class="body">Message 1</pre>
+        </div>
+    </divisible>
+    """
+    html_path = tmp_path / "boundary.html"
+    html_path.write_text(html_content, encoding="utf-8")
+
+    messages = _parse_html_messages(str(html_path))
+    assert len(messages) == 1
+    # Depth should be 0 because <divisible class="reply"> should NOT be counted as a nested reply div.
+    # Currently it will likely be 1.
+    assert messages[0].depth == 0
+
+def test_parse_html_messages_slash_div_boundary(tmp_path):
+    """Verify that _parse_html_messages doesn't incorrectly pick up tags like </divisible>."""
+    html_content = """
+    <div class="reply">
+        <div class="message">
+            <div class="header">
+                <strong>From:</strong> User1<br>
+                <strong>Date:</strong> 01-01-24 10:00<br>
+                <strong>Number:</strong> 1<br>
+            </div>
+            <pre class="body">Message 1</pre>
+        </div>
+    </divisible>
+    <div class="message">
+        <div class="header">
+            <strong>From:</strong> User2<br>
+            <strong>Date:</strong> 01-01-24 11:00<br>
+            <strong>Number:</strong> 2<br>
+        </div>
+        <pre class="body">Message 2</pre>
+    </div>
+    """
+    html_path = tmp_path / "slash_boundary.html"
+    html_path.write_text(html_content, encoding="utf-8")
+
+    messages = _parse_html_messages(str(html_path))
+    assert len(messages) == 2
+    assert messages[0].depth == 1
+    # If </divisible> is incorrectly seen as </div>, it might decrement the depth.
+    # Actually, in the current implementation:
+    # </divisible> matches: G1=/div, G2=isible
+    # it pops from stack.
+    # So Message 2 depth would be 0 (incorrectly decremented) instead of 1.
+    assert messages[1].depth == 1


### PR DESCRIPTION
* **What:** Updated the regular expression in `_parse_html_messages` to use word boundaries (`\b`) when identifying `div` and `/div` tags.
* **Why:** The previous regex matched any tag starting with "div" (e.g., `<divisible>`), which led to incorrect message depth calculations and conversation grouping when importing HTML archives containing such tags. This fix improves the robustness of the HTML import logic. No breaking changes were introduced as it strictly narrows the match to valid `div` tags.

---
*PR created automatically by Jules for task [1464137427924546767](https://jules.google.com/task/1464137427924546767) started by @RainRat*