### PR TITLE
[DOCS] Standardize unzip installation instructions for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ pyqwk helps you open these archives and convert them into modern, readable forma
   - **Arch Linux:** `sudo pacman -S tk`
 - **tqdm:** Adds a progress bar. Install with: `python -m pip install tqdm`
 - **unzip:** Helps open older ZIP archives. Install it if `pyqwk` cannot open your file:
-  - **Ubuntu/Debian/Fedora:** `sudo apt install unzip` or `sudo dnf install unzip`
+  - **Ubuntu/Debian:** `sudo apt install unzip`
+  - **Fedora:** `sudo dnf install unzip`
   - **Arch Linux:** `sudo pacman -S unzip`
   - **macOS:** `brew install unzip`
   - **Windows:** `winget install GnuWin32.UnZip`


### PR DESCRIPTION
* **Type:** Documentation
* **What:** Updated the `unzip` installation instructions in the `Prerequisites` section of `README.md`.
* **Why:** To improve clarity and consistency by providing separate commands for Ubuntu/Debian (`apt`) and Fedora (`dnf`), matching the style used for other dependencies in the same section. This makes the instructions easier to follow for users on different Linux distributions.

---
*PR created automatically by Jules for task [7537593431985650066](https://jules.google.com/task/7537593431985650066) started by @RainRat*