### PR TITLE
Remove unused dead code function `_apply_highlighting`

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -5440,60 +5440,6 @@ def _highlight_text(
     )
 
 
-def _apply_highlighting(
-    text: str,
-    term: str | None,
-    is_regex: bool = False,
-    start_tag: str = "",
-    end_tag: str = "",
-    escape_func: Callable[[str], str] | None = None,
-) -> str:
-    """Apply highlighting to matching terms in text, optionally escaping parts.
-
-    Args:
-        text: The input text.
-        term: The search term or pattern.
-        is_regex: Whether the term is a regular expression.
-        start_tag: The string to prepend to matches.
-        end_tag: The string to append to matches.
-        escape_func: Optional function to escape both matching and non-matching parts.
-
-    Returns:
-        The text with highlighting applied.
-    """
-    if not term:
-        return escape_func(text) if escape_func else text
-
-    flags = re.IGNORECASE
-    pattern_str = term if is_regex else re.escape(term)
-    try:
-        pattern = re.compile(pattern_str, flags)
-    except re.error:
-        return escape_func(text) if escape_func else text
-
-    result = []
-    last_end = 0
-    for match in pattern.finditer(text):
-        start, end = match.span()
-        # Non-matching part
-        non_match = text[last_end:start]
-        if non_match:
-            result.append(escape_func(non_match) if escape_func else non_match)
-
-        # Matching part
-        match_text = match.group(0)
-        processed_match = escape_func(match_text) if escape_func else match_text
-        result.append(f"{start_tag}{processed_match}{end_tag}")
-        last_end = end
-
-    # Remaining non-matching part
-    remaining = text[last_end:]
-    if remaining:
-        result.append(escape_func(remaining) if escape_func else remaining)
-
-    return "".join(result)
-
-
 def _render_stats_bar_chart(
     title: str,
     items: list[tuple[Any, int]],

--- a/test_filter_bug.py
+++ b/test_filter_bug.py
@@ -1,0 +1,20 @@
+import logging
+from pyqwk.core import matches_filters, ProcessingSettings, ParsedMessage, MessageHeader
+
+def test_bug():
+    header = MessageHeader(" ", 1, "01-01-70", "00:00", "To", "From", "Sub", "", None, 1, " ", 1, 0, "")
+    msg = ParsedMessage("Body", 1, None, 1, header)
+
+    settings = ProcessingSettings(
+        verbose=False, private=True, no_header=False, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False, binaries_removal=False,
+        redact_pii=False, format="text", separator="none", output_mode="stdout",
+        output_path=None, encoding="utf-8", quiet=True,
+        authors=[]
+    )
+
+    result = matches_filters(msg, settings, set())
+    print(f"Match with authors=[]: {result}")
+
+if __name__ == "__main__":
+    test_bug()

--- a/tests/test_lead_qa_comprehensive_gaps.py
+++ b/tests/test_lead_qa_comprehensive_gaps.py
@@ -3,7 +3,6 @@ import json
 import pytest
 from pyqwk.core import (
     load_data,
-    _apply_highlighting,
     calculate_archive_stats,
     _serialize_rfc822,
     _write_html,
@@ -46,13 +45,6 @@ def test_load_data_jsonl_blank_lines(tmp_path, logger):
 
     messages, _ = load_data(str(jsonl_path), logger)
     assert len(messages) == 2
-
-
-def test_apply_highlighting_start_match():
-    # Match at the very beginning of the string
-    text = "Hello world"
-    result = _apply_highlighting(text, "Hello", start_tag="[", end_tag="]")
-    assert result == "[Hello] world"
 
 
 def test_calculate_archive_stats_limit_zero(tmp_path, logger):

--- a/tests/test_lead_qa_core_linkify_gaps.py
+++ b/tests/test_lead_qa_core_linkify_gaps.py
@@ -1,5 +1,5 @@
 from unittest.mock import patch
-from pyqwk.core import _linkify_text, _apply_highlighting, _parse_html_messages
+from pyqwk.core import _linkify_text, _parse_html_messages
 
 def test_linkify_text_unknown_entity_type():
     # This test demonstrates the bug where unknown entity types cause text deletion.
@@ -48,24 +48,6 @@ def test_linkify_text_overlaps():
     result = _linkify_text(text, "text", search_term="example")
     # Due to sorting and filtering in _discover_entities, it should prefer the longer URL
     assert result == "Visit www.example.com"
-
-def test_apply_highlighting_none_term():
-    assert _apply_highlighting("text", None) == "text"
-    def escape(t): return t.upper()
-    assert _apply_highlighting("text", None, escape_func=escape) == "TEXT"
-
-def test_apply_highlighting_regex_error():
-    # Invalid regex pattern
-    assert _apply_highlighting("text", "[", is_regex=True) == "text"
-
-def test_apply_highlighting_matches():
-    text = "abc def ghi"
-    # Match at start
-    assert _apply_highlighting(text, "abc", start_tag="<", end_tag=">") == "<abc> def ghi"
-    # Match at end
-    assert _apply_highlighting(text, "ghi", start_tag="<", end_tag=">") == "abc def <ghi>"
-    # Match in middle
-    assert _apply_highlighting(text, "def", start_tag="<", end_tag=">") == "abc <def> ghi"
 
 def test_parse_html_messages_stray_div_close(tmp_path):
     # Covers line 1451-1453: if stack is empty


### PR DESCRIPTION
* **What:** Removed the private function `_apply_highlighting` from `pyqwk/core.py` and its corresponding tests in `tests/test_lead_qa_comprehensive_gaps.py` and `tests/test_lead_qa_core_linkify_gaps.py`.
* **Why:** This function was identified as dead code or a premature abstraction; it was not called anywhere within the library. Its functionality has been fully superseded by the integrated `_linkify_text` and `_highlight_text` system. Removing it reduces codebase complexity and maintenance overhead without altering the module's external behavior. All 976 remaining tests passed successfully.

---
*PR created automatically by Jules for task [6944401520348324405](https://jules.google.com/task/6944401520348324405) started by @RainRat*