### PR TITLE
[DOCS] Categorize pattern variables in CLI help text

### DIFF
--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -144,7 +144,16 @@ examples:
     )
     io_group.add_argument(
         "--filename-pattern",
-        help="Set a pattern for naming individual files (e.g., '{date}_{author}_{subject}'). Available variables: attachments, attachment_count, author, bbs_id, bbs_name, body, body_clean, confname, confname_or_num, confnum, date, day, email_count, flags, hour, indent, is_private, is_reply, iso_date, iso_time, length, minute, month, msgflag, msgid, msgnum, my_name, phone_count, refnum, second, size, snippet, source_file, status, subject, subject_clean, time, to, url_count, year.",
+        help=(
+            "Set a pattern for naming individual files (e.g., '{date}_{author}_{subject}'). "
+            "Available variables: "
+            "Basic Information (author, body, body_clean, snippet, subject, subject_clean, to); "
+            "Conference (confname, confname_or_num, confnum); "
+            "Dates & Times (date, day, hour, iso_date, iso_time, minute, month, second, time, year); "
+            "BBS & Source (bbs_id, bbs_name, source_file); "
+            "Technical Details (flags, indent, is_private, is_reply, length, msgflag, msgid, msgnum, my_name, refnum, size, status); "
+            "Attachments & Links (attachment_count, attachments, email_count, phone_count, url_count)."
+        ),
     )
     io_group.add_argument(
         "-E",
@@ -285,7 +294,16 @@ examples:
     )
     format_group.add_argument(
         "--oneline-pattern",
-        help="Set a custom pattern for one-line summaries (e.g., '[{confnum}] {author}: {subject}'). Available variables: attachments, attachment_count, author, bbs_id, bbs_name, body, body_clean, confname, confname_or_num, confnum, date, day, email_count, flags, hour, indent, is_private, is_reply, iso_date, iso_time, length, minute, month, msgflag, msgid, msgnum, my_name, phone_count, refnum, second, size, snippet, source_file, status, subject, subject_clean, time, to, url_count, year.",
+        help=(
+            "Set a custom pattern for one-line summaries (e.g., '[{confnum}] {author}: {subject}'). "
+            "Available variables: "
+            "Basic Information (author, body, body_clean, snippet, subject, subject_clean, to); "
+            "Conference (confname, confname_or_num, confnum); "
+            "Dates & Times (date, day, hour, iso_date, iso_time, minute, month, second, time, year); "
+            "BBS & Source (bbs_id, bbs_name, source_file); "
+            "Technical Details (flags, indent, is_private, is_reply, length, msgflag, msgid, msgnum, my_name, refnum, size, status); "
+            "Attachments & Links (attachment_count, attachments, email_count, phone_count, url_count)."
+        ),
     )
     format_group.add_argument(
         "--toc",


### PR DESCRIPTION
### Description
* **Type:** Internal Help
* **What:** The help text for the `--filename-pattern` and `--oneline-pattern` arguments in `pyqwk/cli.py`.
* **Why:** Previously, these flags displayed a long, alphabetical "wall of text" containing 40 different variables. Organizing these variables into logical categories (e.g., "Basic Information", "Dates & Times", "Technical Details") makes it much easier for users to find and use the specific placeholders they need for custom output formatting.

### Changes
- Refactored the `help` strings for `--filename-pattern` and `--oneline-pattern` in `pyqwk/cli.py` to use categorized lists of variables.
- Verified that all 40 variables supported by `_get_message_mapping` are included.
- Verified output with `qwk --help`.
- Verified no regressions with full test suite (980 tests passed).

---
*PR created automatically by Jules for task [1719579270466916885](https://jules.google.com/task/1719579270466916885) started by @RainRat*