### PR TITLE
[UI/UX] Categorize pattern variables in CLI help text

### DIFF
--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -67,9 +67,19 @@ def _parse_cli_date(
 
 
 def main() -> None:
+    pattern_vars = (
+        "Available variables grouped by category:\n"
+        "  Basic Information:   author, to, subject, subject_clean, body, body_clean, snippet, my_name\n"
+        "  Conference:          confname, confnum, confname_or_num\n"
+        "  Dates & Times:       date, time, year, month, day, hour, minute, second, iso_date, iso_time\n"
+        "  BBS & Source:        bbs_name, bbs_id, source_file\n"
+        "  Technical Details:   msgnum, msgid, refnum, status, msgflag, is_private, is_reply, length, size, flags, indent\n"
+        "  Attachments & Links: attachments, attachment_count, url_count, email_count, phone_count"
+    )
+
     parser = argparse.ArgumentParser(
         description="Convert old BBS message packets (like QWK and REP) into modern formats.",
-        formatter_class=argparse.RawDescriptionHelpFormatter,
+        formatter_class=argparse.RawTextHelpFormatter,
         epilog="""
 examples:
   # Show a one-line summary of all messages
@@ -144,7 +154,7 @@ examples:
     )
     io_group.add_argument(
         "--filename-pattern",
-        help="Set a pattern for naming individual files (e.g., '{date}_{author}_{subject}'). Available variables: attachments, attachment_count, author, bbs_id, bbs_name, body, body_clean, confname, confname_or_num, confnum, date, day, email_count, flags, hour, indent, is_private, is_reply, iso_date, iso_time, length, minute, month, msgflag, msgid, msgnum, my_name, phone_count, refnum, second, size, snippet, source_file, status, subject, subject_clean, time, to, url_count, year.",
+        help=f"Set a pattern for naming individual files (e.g., '{{date}}_{{author}}_{{subject}}'). {pattern_vars}",
     )
     io_group.add_argument(
         "-E",
@@ -285,7 +295,7 @@ examples:
     )
     format_group.add_argument(
         "--oneline-pattern",
-        help="Set a custom pattern for one-line summaries (e.g., '[{confnum}] {author}: {subject}'). Available variables: attachments, attachment_count, author, bbs_id, bbs_name, body, body_clean, confname, confname_or_num, confnum, date, day, email_count, flags, hour, indent, is_private, is_reply, iso_date, iso_time, length, minute, month, msgflag, msgid, msgnum, my_name, phone_count, refnum, second, size, snippet, source_file, status, subject, subject_clean, time, to, url_count, year.",
+        help=f"Set a custom pattern for one-line summaries (e.g., '[{{confnum}}] {{author}}: {{subject}}'). {pattern_vars}",
     )
     format_group.add_argument(
         "--toc",


### PR DESCRIPTION
* **Context:** CLI
* **Problem:** The help text for `--filename-pattern` and `--oneline-pattern` listed 40 available variables in a single, unorganized alphabetical block. This "wall of text" made it difficult for users to scan and find specific variables for customization.
* **Solution:** Organized the variables into six logical categories (Basic Information, Conference, Dates & Times, BBS & Source, Technical Details, and Attachments & Links). Switched the ArgumentParser formatter to `RawTextHelpFormatter` to preserve the multi-line layout and indentation, significantly improving visual hierarchy and readability.

---
*PR created automatically by Jules for task [4061683162509101909](https://jules.google.com/task/4061683162509101909) started by @RainRat*