### PR TITLE
[FEAT] Bidirectional MIME Attachment Support for EML and mbox

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -1,3 +1,4 @@
+from email.message import EmailMessage
 import sys
 import zipfile
 import tarfile
@@ -1351,19 +1352,40 @@ def _message_from_email(msg_obj: Any) -> ParsedMessage:
         except (ValueError, TypeError):
             pass
 
-    # Message body
+    # Message body and MIME attachments
     body = ""
+    uue_parts = []
     if msg_obj.is_multipart():
         for part in msg_obj.walk():
-            if part.get_content_type() == "text/plain":
+            content_type = part.get_content_type()
+            filename = part.get_filename()
+            is_attachment = filename is not None or part.get("Content-Disposition", "").startswith("attachment")
+
+            if content_type == "text/plain" and not is_attachment and not body:
                 payload = part.get_payload(decode=True)
                 if payload:
                     body = payload.decode("utf-8", errors="replace")
-                break
+            elif is_attachment or (content_type != "text/plain" and content_type != "multipart/mixed"):
+                # Convert MIME attachment to UUE block for round-trip compatibility
+                payload = part.get_payload(decode=True)
+                if payload:
+                    fname = filename or "attachment.bin"
+                    uue_block = [f"begin 644 {fname}"]
+                    for i in range(0, len(payload), 45):
+                        chunk = payload[i : i + 45]
+                        uue_block.append(binascii.b2a_uu(chunk).decode("ascii").strip("\n"))
+                    uue_block.append("`")
+                    uue_block.append("end")
+                    uue_parts.append("\r\n".join(uue_block))
     else:
         payload = msg_obj.get_payload(decode=True)
         if payload:
             body = payload.decode("utf-8", errors="replace")
+
+    if uue_parts:
+        if body and not body.endswith("\r\n"):
+            body += "\r\n"
+        body += "\r\n".join(uue_parts) + "\r\n"
 
     # Construct MessageHeader
     header = MessageHeader(
@@ -4525,91 +4547,101 @@ def _serialize_rfc822(
     and custom X-QWK headers for conference names, message numbers, and statuses.
     """
     header = message.header
+    msg = EmailMessage()
 
-    # Parse date
+    msg["From"] = header.msgfrom
+    msg["To"] = header.msgto
+    msg["Subject"] = header.msgsubject
+
     dt = _parse_qwk_date(header.msgdate, header.msgtime)
+    msg["Date"] = email.utils.format_datetime(dt)
 
-    # Format dates
-    # "From " line uses ctime format: "Day Mon DD HH:MM:SS YYYY"
-    # email.utils.formatdate uses RFC 2822
+    msg_id = (
+        f"<{header.confnum}.{header.msgnum if header.msgnum is not None else 'x'}@qwk>"
+    )
+    msg["Message-ID"] = msg_id
 
-    from_line_date = dt.ctime()
-    rfc_date = email.utils.format_datetime(dt)
+    if message.parent_msgnum is not None:
+        parent_id = f"<{header.confnum}.{message.parent_msgnum}@qwk>"
+        msg["In-Reply-To"] = parent_id
+        msg["References"] = parent_id
+
+    msg["X-QWK-Conference"] = str(header.confnum)
+    if message.confname:
+        msg["X-QWK-Conference-Name"] = message.confname
+    if message.bbs_name:
+        msg["X-QWK-BBS-Name"] = message.bbs_name
+    if message.bbs_id:
+        msg["X-QWK-BBS-ID"] = message.bbs_id
+    if message.source_file:
+        msg["X-QWK-Source-File"] = message.source_file
+    if header.msgnum is not None:
+        msg["X-QWK-Message-Number"] = str(header.msgnum)
+    if header.status.strip():
+        msg["X-QWK-Status"] = header.status
+    if header.msgflag.strip():
+        msg["X-QWK-Flags"] = header.msgflag
+    if header.refnum is not None:
+        msg["X-QWK-Reference"] = str(header.refnum)
+    if message.attachments:
+        msg["X-QWK-Attachments"] = ";".join(message.attachments)
+    if message.depth > 0:
+        msg["X-QWK-Depth"] = str(message.depth)
+    if message.thread_id:
+        msg["X-QWK-Thread-ID"] = message.thread_id
+    if message.parent_msgnum is not None:
+        msg["X-QWK-Parent-Msgnum"] = str(message.parent_msgnum)
+
+    # Attach binaries if any, and remove them from the body for modern email compliance
+    found_binaries = extract_binaries(message.text)
+    clean_body_text = process_message(
+        message.text,
+        truncate_signatures=False,
+        cut_quoting=False,
+        binaries_removal=True,
+        redact_pii=False,
+        strip_ansi=False,
+    )
 
     # Escape "From " lines in body
     body_lines = []
-    for line in message.text.splitlines():
+    for line in clean_body_text.splitlines():
         if line.startswith("From "):
             body_lines.append(">" + line)
         else:
             body_lines.append(line)
     body = "\n".join(body_lines)
 
-    parts = []
+    msg.set_content(body)
+
+    for filename, data in found_binaries:
+        # Simple mime type guessing
+        maintype, subtype = "application", "octet-stream"
+        if filename.lower().endswith((".jpg", ".jpeg")):
+            maintype, subtype = "image", "jpeg"
+        elif filename.lower().endswith(".png"):
+            maintype, subtype = "image", "png"
+        elif filename.lower().endswith(".gif"):
+            maintype, subtype = "image", "gif"
+        elif filename.lower().endswith(".txt"):
+            maintype, subtype = "text", "plain"
+
+        msg.add_attachment(
+            data, maintype=maintype, subtype=subtype, filename=os.path.basename(filename)
+        )
+
+    serialized = msg.as_string()
+
     if include_mbox_header:
         if "@" in header.msgfrom:
             sender_addr = header.msgfrom
         else:
-            # Create a safe address from the name
             safe_name = re.sub(r"[^A-Za-z0-9]", ".", header.msgfrom).strip(".")
             sender_addr = f"{safe_name}@example.com"
-        # Construct mbox entry
-        # From <sender> <date>
-        parts.append(f"From {sender_addr} {from_line_date}")
+        from_line = f"From {sender_addr} {dt.ctime()}\n"
+        return from_line + serialized
 
-    parts.append(f"From: {header.msgfrom}")
-    parts.append(f"To: {header.msgto}")
-    parts.append(f"Subject: {header.msgsubject}")
-    parts.append(f"Date: {rfc_date}")
-
-    # Generate a unique Message-ID
-    # <confnum.msgnum@qwk>
-    msg_id = (
-        f"<{header.confnum}.{header.msgnum if header.msgnum is not None else 'x'}@qwk>"
-    )
-    parts.append(f"Message-ID: {msg_id}")
-
-    # Conversation headers
-    if message.parent_msgnum is not None:
-        parent_id = f"<{header.confnum}.{message.parent_msgnum}@qwk>"
-        parts.append(f"In-Reply-To: {parent_id}")
-        parts.append(f"References: {parent_id}")
-
-    # QWK Information headers
-    parts.append(f"X-QWK-Conference: {header.confnum}")
-    if message.confname:
-        parts.append(f"X-QWK-Conference-Name: {message.confname}")
-    if message.bbs_name:
-        parts.append(f"X-QWK-BBS-Name: {message.bbs_name}")
-    if message.bbs_id:
-        parts.append(f"X-QWK-BBS-ID: {message.bbs_id}")
-    if message.source_file:
-        parts.append(f"X-QWK-Source-File: {message.source_file}")
-    if header.msgnum is not None:
-        parts.append(f"X-QWK-Message-Number: {header.msgnum}")
-    if header.status.strip():
-        parts.append(f"X-QWK-Status: {header.status}")
-    if header.msgflag.strip():
-        parts.append(f"X-QWK-Flags: {header.msgflag}")
-    if header.refnum is not None:
-        parts.append(f"X-QWK-Reference: {header.refnum}")
-    if message.attachments:
-        parts.append(f"X-QWK-Attachments: {';'.join(message.attachments)}")
-    if message.depth > 0:
-        parts.append(f"X-QWK-Depth: {message.depth}")
-    if message.thread_id:
-        parts.append(f"X-QWK-Thread-ID: {message.thread_id}")
-    if message.parent_msgnum is not None:
-        parts.append(f"X-QWK-Parent-Msgnum: {message.parent_msgnum}")
-
-    parts.append("Content-Type: text/plain; charset=utf-8")
-    parts.append("Content-Transfer-Encoding: 8bit")
-
-    parts.append("")  # Separator before body
-    parts.append(body)
-    parts.append("")  # Trailing newline required by mbox/eml
-
-    return "\n".join(parts)
+    return serialized
 
 
 def _write_mbox(

--- a/tests/test_coverage_final_gaps.py
+++ b/tests/test_coverage_final_gaps.py
@@ -190,7 +190,7 @@ def test_eml_serialize_no_from_header_coverage(message_factory):
     result = _serialize_rfc822(msg, include_mbox_header=False)
     # RFC 822 (EML) serialization does not have the mbox "From " separator
     assert not result.startswith("From ")
-    assert "From: " in result
+    assert "From: " in result or "From:\n" in result
     assert "Subject: Test" in result
 
 

--- a/tests/test_eml.py
+++ b/tests/test_eml.py
@@ -69,7 +69,7 @@ def test_eml_export_individual_files(tmp_path: Path, testdata_dir: Path) -> None
     assert "From: GammaO #571 @0*1" in content
     assert "Subject: New User" in content
     assert "X-QWK-Conference: 3" in content
-    assert "Content-Type: text/plain; charset=utf-8" in content
+    assert "Content-Type: text/plain; charset=\"utf-8\"" in content
     # EML should NOT have the mbox "From " separator
     assert not content.startswith("From ")
 

--- a/tests/test_eml_mime_roundtrip.py
+++ b/tests/test_eml_mime_roundtrip.py
@@ -1,0 +1,104 @@
+import email
+import os
+import binascii
+from pyqwk.core import ParsedMessage, MessageHeader, _serialize_rfc822, _message_from_email, extract_binaries
+
+def test_eml_mime_export_with_attachment():
+    """Verify that a message with UUE content is exported as a MIME email with an attachment."""
+    # "Cat" in UUE is #0V%T
+    uue_content = (
+        "begin 644 test.txt\r\n"
+        "#0V%T\r\n"
+        "`\r\n"
+        "end"
+    )
+    header = MessageHeader(
+        status=" ", msgnum=1, msgdate="01-01-23", msgtime="12:00",
+        msgto="Recipient", msgfrom="Author", msgsubject="Test Subject",
+        msgpassword="", refnum=None, numblocks=None, msgflag=" ",
+        confnum=1, lognum=0, nettag=""
+    )
+    msg = ParsedMessage(text="Hello world\r\n" + uue_content, msgnum=1, refnum=None, confnum=1, header=header)
+
+    # Export to EML (no mbox header)
+    eml_str = _serialize_rfc822(msg, include_mbox_header=False)
+
+    # Parse back with standard email library to verify MIME structure
+    eml_obj = email.message_from_string(eml_str)
+    assert eml_obj.is_multipart()
+
+    attachments = []
+    for part in eml_obj.walk():
+        if part.get_filename():
+            attachments.append((part.get_filename(), part.get_payload(decode=True)))
+
+    assert len(attachments) == 1
+    assert attachments[0][0] == "test.txt"
+    assert attachments[0][1] == b"Cat"
+
+def test_eml_mime_import_with_attachment():
+    """Verify that a MIME email with an attachment is imported with the attachment as UUE."""
+    raw_eml = (
+        "From: Author\n"
+        "To: Recipient\n"
+        "Subject: Test Subject\n"
+        "Content-Type: multipart/mixed; boundary=\"bound\"\n"
+        "\n"
+        "--bound\n"
+        "Content-Type: text/plain\n"
+        "\n"
+        "Main body text\n"
+        "--bound\n"
+        "Content-Type: application/octet-stream\n"
+        "Content-Disposition: attachment; filename=\"hello.bin\"\n"
+        "Content-Transfer-Encoding: base64\n"
+        "\n"
+        "SGVsbG8=\n" # "Hello" in base64
+        "--bound--"
+    )
+    msg_obj = email.message_from_string(raw_eml)
+    parsed = _message_from_email(msg_obj)
+
+    assert "Main body text" in parsed.text
+    assert "begin 644 hello.bin" in parsed.text
+    assert "end" in parsed.text
+
+    # Verify extraction works on the imported text
+    binaries = extract_binaries(parsed.text)
+    assert len(binaries) == 1
+    assert binaries[0][0] == "hello.bin"
+    assert binaries[0][1] == b"Hello"
+
+def test_eml_mime_roundtrip():
+    """Verify full roundtrip: ParsedMessage -> EML -> ParsedMessage."""
+    # Use "Cat" (#0V%T) which is reliable
+    original_uue = (
+        "begin 644 data.dat\r\n"
+        "#0V%T\r\n"
+        "`\r\n"
+        "end"
+    )
+    header = MessageHeader(
+        status=" ", msgnum=123, msgdate="05-26-24", msgtime="14:00",
+        msgto="World", msgfrom="Jules", msgsubject="Roundtrip",
+        msgpassword="", refnum=None, numblocks=None, msgflag=" ",
+        confnum=10, lognum=0, nettag=""
+    )
+    original_msg = ParsedMessage(text="Roundtrip test\r\n" + original_uue, msgnum=123, refnum=None, confnum=10, header=header)
+
+    # 1. Export
+    eml_str = _serialize_rfc822(original_msg, include_mbox_header=False)
+
+    # 2. Import
+    msg_obj = email.message_from_string(eml_str)
+    imported_msg = _message_from_email(msg_obj)
+
+    # 3. Verify
+    assert imported_msg.header.msgfrom == "Jules"
+    assert imported_msg.header.msgsubject == "Roundtrip"
+    assert "Roundtrip test" in imported_msg.text
+
+    binaries = extract_binaries(imported_msg.text)
+    assert len(binaries) == 1
+    assert binaries[0][0] == "data.dat"
+    assert binaries[0][1] == b"Cat"

--- a/tests/test_lead_qa_coverage_expansion_v3.py
+++ b/tests/test_lead_qa_coverage_expansion_v3.py
@@ -26,7 +26,7 @@ def test_message_from_email_multipart_no_text_plain():
     msg.add_attachment(b"fake image data", maintype="image", subtype="png")
 
     parsed = _message_from_email(msg)
-    assert parsed.text == ""
+    assert "begin 644 attachment.bin" in parsed.text
 
 
 def test_message_from_email_invalid_date_fallback():

--- a/tests/test_mbox_output.py
+++ b/tests/test_mbox_output.py
@@ -71,7 +71,7 @@ def test_serialize_message_mbox_with_metadata(sample_message):
     assert "X-QWK-Conference-Name: Main Board" in mbox_content
     assert "X-QWK-Message-Number: 123" in mbox_content
     assert "X-QWK-Status: *" in mbox_content
-    assert "Content-Type: text/plain; charset=utf-8" in mbox_content
+    assert "Content-Type: text/plain; charset=\"utf-8\"" in mbox_content
 
 
 def test_serialize_message_mbox_threading(sample_message):


### PR DESCRIPTION
This PR implements true MIME attachment support for EML and mbox formats, providing a seamless bridge between legacy BBS archives and modern email standards.

### Features
- **Modern Export:** QWK messages with embedded UUE or Base64 attachments are now exported as standard multipart MIME emails. The legacy encoding blocks are removed from the message body and placed into formal attachments that modern email clients can display natively.
- **Robust Import:** Emails with standard MIME attachments can now be imported back into the QWK ecosystem. Attachments are automatically converted into UUE blocks and appended to the message body, ensuring compatibility with internal extraction and cleaning tools.
- **Standard-Compliant Headers:** Refactored RFC 822 generation to use Python's `EmailMessage` library, improving compliance and maintainability.

### Technical Details
- Modified `pyqwk/core.py`:
    - Updated `_serialize_rfc822` to handle multipart message construction.
    - Updated `_message_from_email` to walk the MIME tree and encode attachments as UUE.
- Added `tests/test_eml_mime_roundtrip.py` covering export, import, and full round-trip scenarios.
- Updated existing tests in `tests/test_eml.py`, `tests/test_mbox_output.py`, `tests/test_coverage_final_gaps.py`, and `tests/test_lead_qa_coverage_expansion_v3.py` to match the improved output format.

This feature fulfills the **Symmetry** and **Interoperability** heuristics by enabling full data preservation when moving messages between BBS and modern email formats.

---
*PR created automatically by Jules for task [2090301188249441495](https://jules.google.com/task/2090301188249441495) started by @RainRat*