### PR TITLE
Enhanced MIME attachment support for EML and mbox formats

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -461,6 +461,33 @@ def extract_binaries(text: str) -> list[tuple[str, bytes]]:
     return binaries
 
 
+def _bytes_to_uue(data: bytes, filename: str) -> str:
+    """Convert binary data into a UUE-encoded text block.
+
+    Args:
+        data: The binary data to encode.
+        filename: The filename to include in the UUE header.
+
+    Returns:
+        A string containing the formatted UUE block.
+    """
+    if not data:
+        return ""
+
+    result = [f"begin 644 {filename}"]
+
+    # Process data in 45-byte chunks as per UUE standard
+    for i in range(0, len(data), 45):
+        chunk = data[i : i + 45]
+        # b2a_uu handles the length prefix and encoding
+        line = binascii.b2a_uu(chunk).decode("ascii").rstrip("\n")
+        result.append(line)
+
+    result.append("`")  # UUE zero-length line indicator
+    result.append("end")
+    return "\n".join(result) + "\n"
+
+
 class ProgressBar(Protocol):
     def update(self, __n: int, /) -> None:
         """Advance the progress by ``__n`` units."""
@@ -1351,19 +1378,33 @@ def _message_from_email(msg_obj: Any) -> ParsedMessage:
         except (ValueError, TypeError):
             pass
 
-    # Message body
+    # Message body and MIME attachments
     body = ""
+    uue_blocks = []
     if msg_obj.is_multipart():
         for part in msg_obj.walk():
-            if part.get_content_type() == "text/plain":
-                payload = part.get_payload(decode=True)
-                if payload:
+            content_type = part.get_content_type()
+            filename = part.get_filename()
+            payload = part.get_payload(decode=True)
+
+            if payload:
+                # Capture the first plain text part as the main body
+                if content_type == "text/plain" and not filename and not body:
                     body = payload.decode("utf-8", errors="replace")
-                break
+                else:
+                    # Convert other MIME parts into UUE blocks appended to the body
+                    # This ensures compatibility with pyqwk's internal attachment pipeline
+                    fname = filename or f"attachment_{len(uue_blocks) + 1}.bin"
+                    uue_blocks.append(_bytes_to_uue(payload, fname))
     else:
         payload = msg_obj.get_payload(decode=True)
         if payload:
             body = payload.decode("utf-8", errors="replace")
+
+    if uue_blocks:
+        if body and not body.endswith("\n"):
+            body += "\n"
+        body += "\n" + "\n".join(uue_blocks)
 
     # Construct MessageHeader
     header = MessageHeader(
@@ -4523,93 +4564,109 @@ def _serialize_rfc822(
 
     Includes standard email headers for conversations (Message-ID, In-Reply-To, References)
     and custom X-QWK headers for conference names, message numbers, and statuses.
+    Attachments found in the text are converted into proper MIME parts.
     """
+    from email.message import EmailMessage
+
     header = message.header
-
-    # Parse date
     dt = _parse_qwk_date(header.msgdate, header.msgtime)
-
-    # Format dates
-    # "From " line uses ctime format: "Day Mon DD HH:MM:SS YYYY"
-    # email.utils.formatdate uses RFC 2822
-
-    from_line_date = dt.ctime()
     rfc_date = email.utils.format_datetime(dt)
 
-    # Escape "From " lines in body
-    body_lines = []
-    for line in message.text.splitlines():
+    # 1. Identify and extract attachments from the body
+    # We remove them from the text part so the email looks modern
+    found_binaries = extract_binaries(message.text) if message.text else []
+    clean_body = message.text or ""
+    if found_binaries:
+        # Simple removal of lines that look like parts of UUE/Base64/yEnc blocks
+        # This is a bit coarse but effective for the goal of a "clean" MIME email.
+        body_lines = clean_body.splitlines()
+        new_body_lines = []
+        in_y = in_u = in_b = False
+        prev_line = None
+        for line in body_lines:
+            # Re-use the logic from process_message for binaries removal
+            should_skip, in_y, in_u, in_b = _is_binary_line(line, prev_line, in_y, in_u, in_b)
+            if should_skip:
+                prev_line = line
+                continue
+            new_body_lines.append(line)
+            prev_line = line
+        clean_body = "\n".join(new_body_lines)
+
+    # 2. Build the EmailMessage
+    msg = EmailMessage()
+
+    # Escape "From " lines in body for mbox compatibility
+    escaped_body_lines = []
+    for line in clean_body.splitlines():
         if line.startswith("From "):
-            body_lines.append(">" + line)
+            escaped_body_lines.append(">" + line)
         else:
-            body_lines.append(line)
-    body = "\n".join(body_lines)
+            escaped_body_lines.append(line)
+    clean_body = "\n".join(escaped_body_lines)
 
-    parts = []
-    if include_mbox_header:
-        if "@" in header.msgfrom:
-            sender_addr = header.msgfrom
-        else:
-            # Create a safe address from the name
-            safe_name = re.sub(r"[^A-Za-z0-9]", ".", header.msgfrom).strip(".")
-            sender_addr = f"{safe_name}@example.com"
-        # Construct mbox entry
-        # From <sender> <date>
-        parts.append(f"From {sender_addr} {from_line_date}")
+    msg["From"] = header.msgfrom
+    msg["To"] = header.msgto
+    msg["Subject"] = header.msgsubject
+    msg["Date"] = rfc_date
 
-    parts.append(f"From: {header.msgfrom}")
-    parts.append(f"To: {header.msgto}")
-    parts.append(f"Subject: {header.msgsubject}")
-    parts.append(f"Date: {rfc_date}")
+    msg_id = f"<{header.confnum}.{header.msgnum if header.msgnum is not None else 'x'}@qwk>"
+    msg["Message-ID"] = msg_id
 
-    # Generate a unique Message-ID
-    # <confnum.msgnum@qwk>
-    msg_id = (
-        f"<{header.confnum}.{header.msgnum if header.msgnum is not None else 'x'}@qwk>"
-    )
-    parts.append(f"Message-ID: {msg_id}")
-
-    # Conversation headers
     if message.parent_msgnum is not None:
         parent_id = f"<{header.confnum}.{message.parent_msgnum}@qwk>"
-        parts.append(f"In-Reply-To: {parent_id}")
-        parts.append(f"References: {parent_id}")
+        msg["In-Reply-To"] = parent_id
+        msg["References"] = parent_id
 
     # QWK Information headers
-    parts.append(f"X-QWK-Conference: {header.confnum}")
+    msg["X-QWK-Conference"] = str(header.confnum)
     if message.confname:
-        parts.append(f"X-QWK-Conference-Name: {message.confname}")
+        msg["X-QWK-Conference-Name"] = message.confname
     if message.bbs_name:
-        parts.append(f"X-QWK-BBS-Name: {message.bbs_name}")
+        msg["X-QWK-BBS-Name"] = message.bbs_name
     if message.bbs_id:
-        parts.append(f"X-QWK-BBS-ID: {message.bbs_id}")
+        msg["X-QWK-BBS-ID"] = message.bbs_id
     if message.source_file:
-        parts.append(f"X-QWK-Source-File: {message.source_file}")
+        msg["X-QWK-Source-File"] = message.source_file
     if header.msgnum is not None:
-        parts.append(f"X-QWK-Message-Number: {header.msgnum}")
+        msg["X-QWK-Message-Number"] = str(header.msgnum)
     if header.status.strip():
-        parts.append(f"X-QWK-Status: {header.status}")
+        msg["X-QWK-Status"] = header.status
     if header.msgflag.strip():
-        parts.append(f"X-QWK-Flags: {header.msgflag}")
+        msg["X-QWK-Flags"] = header.msgflag
     if header.refnum is not None:
-        parts.append(f"X-QWK-Reference: {header.refnum}")
+        msg["X-QWK-Reference"] = str(header.refnum)
     if message.attachments:
-        parts.append(f"X-QWK-Attachments: {';'.join(message.attachments)}")
+        msg["X-QWK-Attachments"] = ";".join(message.attachments)
     if message.depth > 0:
-        parts.append(f"X-QWK-Depth: {message.depth}")
+        msg["X-QWK-Depth"] = str(message.depth)
     if message.thread_id:
-        parts.append(f"X-QWK-Thread-ID: {message.thread_id}")
+        msg["X-QWK-Thread-ID"] = message.thread_id
     if message.parent_msgnum is not None:
-        parts.append(f"X-QWK-Parent-Msgnum: {message.parent_msgnum}")
+        msg["X-QWK-Parent-Msgnum"] = str(message.parent_msgnum)
 
-    parts.append("Content-Type: text/plain; charset=utf-8")
-    parts.append("Content-Transfer-Encoding: 8bit")
+    msg.set_content(clean_body)
 
-    parts.append("")  # Separator before body
-    parts.append(body)
-    parts.append("")  # Trailing newline required by mbox/eml
+    # 3. Add MIME attachments
+    for filename, data in found_binaries:
+        msg.add_attachment(
+            data,
+            maintype="application",
+            subtype="octet-stream",
+            filename=filename or "attachment.bin",
+        )
 
-    return "\n".join(parts)
+    # 4. Handle mbox "From " line if needed
+    output = msg.as_string()
+    if include_mbox_header:
+        from_line_date = dt.ctime()
+        sender_addr = header.msgfrom
+        if "@" not in sender_addr:
+            safe_name = re.sub(r"[^A-Za-z0-9]", ".", sender_addr).strip(".")
+            sender_addr = f"{safe_name}@example.com"
+        output = f"From {sender_addr} {from_line_date}\n" + output
+
+    return output
 
 
 def _write_mbox(

--- a/tests/test_coverage_final_gaps.py
+++ b/tests/test_coverage_final_gaps.py
@@ -190,7 +190,8 @@ def test_eml_serialize_no_from_header_coverage(message_factory):
     result = _serialize_rfc822(msg, include_mbox_header=False)
     # RFC 822 (EML) serialization does not have the mbox "From " separator
     assert not result.startswith("From ")
-    assert "From: " in result
+    # EmailMessage may omit the space for empty headers in some Python versions
+    assert "From:" in result
     assert "Subject: Test" in result
 
 

--- a/tests/test_eml.py
+++ b/tests/test_eml.py
@@ -69,7 +69,8 @@ def test_eml_export_individual_files(tmp_path: Path, testdata_dir: Path) -> None
     assert "From: GammaO #571 @0*1" in content
     assert "Subject: New User" in content
     assert "X-QWK-Conference: 3" in content
-    assert "Content-Type: text/plain; charset=utf-8" in content
+    # Modern EmailMessage uses quoted charset
+    assert 'Content-Type: text/plain; charset="utf-8"' in content
     # EML should NOT have the mbox "From " separator
     assert not content.startswith("From ")
 

--- a/tests/test_lead_qa_coverage_expansion_v3.py
+++ b/tests/test_lead_qa_coverage_expansion_v3.py
@@ -26,7 +26,8 @@ def test_message_from_email_multipart_no_text_plain():
     msg.add_attachment(b"fake image data", maintype="image", subtype="png")
 
     parsed = _message_from_email(msg)
-    assert parsed.text == ""
+    # The new implementation converts attachments to UUE blocks in the body
+    assert "begin 644 attachment_1.bin" in parsed.text
 
 
 def test_message_from_email_invalid_date_fallback():

--- a/tests/test_mbox_output.py
+++ b/tests/test_mbox_output.py
@@ -71,7 +71,7 @@ def test_serialize_message_mbox_with_metadata(sample_message):
     assert "X-QWK-Conference-Name: Main Board" in mbox_content
     assert "X-QWK-Message-Number: 123" in mbox_content
     assert "X-QWK-Status: *" in mbox_content
-    assert "Content-Type: text/plain; charset=utf-8" in mbox_content
+    assert 'Content-Type: text/plain; charset="utf-8"' in mbox_content
 
 
 def test_serialize_message_mbox_threading(sample_message):

--- a/tests/test_mime_interop.py
+++ b/tests/test_mime_interop.py
@@ -1,0 +1,66 @@
+import email
+import email.message
+import email.policy
+import pytest
+from pyqwk.core import _message_from_email, _serialize_rfc822, ParsedMessage, MessageHeader
+
+def test_eml_import_with_mime_attachments():
+    msg = email.message.EmailMessage()
+    msg['Subject'] = 'Test with attachment'
+    msg['From'] = 'sender@example.com'
+    msg['To'] = 'receiver@example.com'
+    msg.set_content('This is the body.')
+
+    attachment_data = b'binary data'
+    msg.add_attachment(attachment_data, maintype='application', subtype='octet-stream', filename='test.bin')
+
+    parsed = _message_from_email(msg)
+
+    # We expect the attachment to be converted to UUE and appended to the text
+    assert 'begin 644 test.bin' in parsed.text
+    assert 'test.bin' in (parsed.discover_attachments() or [])
+
+def test_eml_export_with_mime_attachments():
+    header = MessageHeader(
+        status=" ",
+        msgnum=1,
+        msgdate="01-01-24",
+        msgtime="12:00",
+        msgto="To",
+        msgfrom="From",
+        msgsubject="Subject",
+        msgpassword="",
+        refnum=None,
+        numblocks=None,
+        msgflag=" ",
+        confnum=1,
+        lognum=0,
+        nettag="",
+    )
+    # Body with UUE attachment for "Cat"
+    uue_body = "This is the body.\r\nbegin 644 cat.txt\n#0V%T\n`\nend\r\n"
+    message = ParsedMessage(
+        text=uue_body,
+        msgnum=1,
+        refnum=None,
+        confnum=1,
+        header=header
+    )
+
+    eml_str = _serialize_rfc822(message, include_mbox_header=False)
+
+    # Use policy.default to ensure EmailMessage objects and proper multipart parsing
+    eml = email.message_from_string(eml_str, policy=email.policy.default)
+
+    # Check that it is a multipart message with a proper attachment
+    assert eml.is_multipart()
+    attachments = list(eml.iter_attachments())
+    assert len(attachments) == 1
+    assert attachments[0].get_filename() == 'cat.txt'
+    assert attachments[0].get_content().strip() == b'Cat'
+
+    # The UUE block should be removed from the main text part in the exported EML
+    body_part = eml.get_body(preferencelist=('plain',))
+    body = body_part.get_content()
+    assert 'begin 644 cat.txt' not in body
+    assert 'This is the body.' in body


### PR DESCRIPTION
This PR implements bidirectional MIME attachment support for EML and mbox formats. 

1. **Import Enhancement**: Incoming multipart MIME messages now have their non-text parts extracted, converted to UUE blocks, and appended to the message text. This ensures that legacy BBS-style attachment discovery remains functional while preserving data from modern sources.

2. **Export Refactor**: The `_serialize_rfc822` function was refactored to use the standard library's `EmailMessage` API. It now automatically detects encoded binary blocks (UUE, Base64, yEnc) within the message text, extracts them as true MIME attachments, and produces a "clean" text body. This results in EML and mbox files that are fully compatible with modern email clients like Thunderbird or Outlook.

3. **Robustness**: The new implementation handles various content types, preserves all `X-QWK-*` metadata headers, and correctly manages mbox "From " separators. Existing tests were updated to reflect the move to the more standards-compliant `EmailMessage` generator (e.g., quoted charsets in headers).

---
*PR created automatically by Jules for task [27752382826454826](https://jules.google.com/task/27752382826454826) started by @RainRat*