### PR TITLE
[TEST] Achieve 100% coverage for pyqwk/core.py

### DIFF
--- a/tests/test_lead_qa_final_coverage_gap.py
+++ b/tests/test_lead_qa_final_coverage_gap.py
@@ -1,0 +1,23 @@
+from email.mime.text import MIMEText
+from email.mime.multipart import MIMEMultipart
+from pyqwk.core import _bytes_to_uue, _message_from_email
+
+def test_bytes_to_uue_empty():
+    assert _bytes_to_uue(b"", "test.bin") == ""
+
+def test_message_from_email_body_no_newline():
+    msg = MIMEMultipart()
+    msg['Subject'] = 'Test'
+    msg['From'] = 'sender@example.com'
+    msg['To'] = 'receiver@example.com'
+
+    body_part = MIMEText('No newline here')
+    msg.attach(body_part)
+
+    attachment_part = MIMEText('data')
+    attachment_part.add_header('Content-Disposition', 'attachment', filename='test.bin')
+    msg.attach(attachment_part)
+
+    parsed = _message_from_email(msg)
+
+    assert "No newline here\n\nbegin 644 test.bin" in parsed.text


### PR DESCRIPTION
This PR adds a new test file `tests/test_lead_qa_final_coverage_gap.py` to address the final coverage gaps in `pyqwk/core.py`. 

Specifically, it covers:
- `_bytes_to_uue`'s early return for empty data.
- The branch in `_message_from_email` that ensures a body ends with a newline before appending UUE blocks for MIME attachments.

With these additions, `pyqwk/core.py` now reaches 100% test coverage.

---
*PR created automatically by Jules for task [18286815926816929765](https://jules.google.com/task/18286815926816929765) started by @RainRat*