### PR TITLE
[DOCS] Simplify Troubleshooting headings in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,9 +484,9 @@ You can use custom patterns with `--oneline-pattern` (for summaries on the scree
 
 ## Troubleshooting
 
-- **Unsupported Compression:** If `pyqwk` cannot open an archive, install `unzip`. If it still fails, unzip the file manually and run `qwk` on the `messages.dat` file inside.
-- **Incorrect Text:** If you see incorrect characters, use the `--encoding` flag (for example, `--encoding cp850`).
-- **Conflicting Options:** Some options cannot be used together, such as `--threaded` and `--individual-files`.
+- **If a file will not open:** If `pyqwk` cannot open an archive, install `unzip`. If it still fails, unzip the file manually and run `qwk` on the `messages.dat` file inside.
+- **If characters look wrong:** If you see incorrect characters, use the `--encoding` flag (for example, `--encoding cp850`).
+- **If options do not work together:** Some options cannot be used together, such as `--threaded` and `--individual-files`.
 
 ## Contributing
 


### PR DESCRIPTION
Improved the accessibility of the `README.md` file by simplifying technical jargon in the Troubleshooting section. The headings were updated to use active, descriptive Plain English phrases, making the instructions easier to follow for an international audience.

**Changes:**
- Replaced "**Unsupported Compression:**" with "**If a file will not open:**"
- Replaced "**Incorrect Text:**" with "**If characters look wrong:**"
- Replaced "**Conflicting Options:**" with "**If options do not work together:**"

---
*PR created automatically by Jules for task [7405580414347125341](https://jules.google.com/task/7405580414347125341) started by @RainRat*