### PR TITLE
Deduplicate and unify field matching logic in `matches_filters`

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -2616,38 +2616,31 @@ def matches_filters(
 
         return any(check_str_match(p, text) for p in pattern_list)
 
+    def matches_any_field(pattern: str) -> bool:
+        return (
+            check_str_match(pattern, message.header.msgfrom)
+            or check_str_match(pattern, message.header.msgto)
+            or check_str_match(pattern, message.header.msgsubject)
+            or check_str_match(pattern, message.text)
+            or (message.confname and check_str_match(pattern, message.confname))
+            or (message.bbs_name and check_str_match(pattern, message.bbs_name))
+            or (message.bbs_id and check_str_match(pattern, message.bbs_id))
+            or (
+                message.source_file and check_str_match(pattern, message.source_file)
+            )
+            or (
+                message.attachments
+                and any(check_str_match(pattern, a) for a in message.attachments)
+            )
+        )
+
     # --- Exclusion Filters (Negative matching) ---
     # If any exclusion matches, the message is rejected immediately.
 
     # 1. Exclude Search
     if settings.exclude_search:
         message.discover_attachments()
-        found_exclude = (
-            check_str_match(settings.exclude_search, message.header.msgfrom)
-            or check_str_match(settings.exclude_search, message.header.msgto)
-            or check_str_match(settings.exclude_search, message.header.msgsubject)
-            or check_str_match(settings.exclude_search, message.text)
-            or (
-                message.confname
-                and check_str_match(settings.exclude_search, message.confname)
-            )
-            or (
-                message.bbs_name
-                and check_str_match(settings.exclude_search, message.bbs_name)
-            )
-            or (
-                message.bbs_id
-                and check_str_match(settings.exclude_search, message.bbs_id)
-            )
-            or (
-                message.attachments
-                and any(
-                    check_str_match(settings.exclude_search, a)
-                    for a in message.attachments
-                )
-            )
-        )
-        if found_exclude:
+        if matches_any_field(settings.exclude_search):
             return False
 
     # 2. Exclude Author
@@ -2727,35 +2720,7 @@ def matches_filters(
     # 7. Full-Text Search
     if settings.search_term:
         message.discover_attachments()
-        found = (
-            check_str_match(settings.search_term, message.header.msgfrom)
-            or check_str_match(settings.search_term, message.header.msgto)
-            or check_str_match(settings.search_term, message.header.msgsubject)
-            or check_str_match(settings.search_term, message.text)
-            or (
-                message.confname
-                and check_str_match(settings.search_term, message.confname)
-            )
-            or (
-                message.bbs_name
-                and check_str_match(settings.search_term, message.bbs_name)
-            )
-            or (
-                message.bbs_id and check_str_match(settings.search_term, message.bbs_id)
-            )
-            or (
-                message.source_file
-                and check_str_match(settings.search_term, message.source_file)
-            )
-            or (
-                message.attachments
-                and any(
-                    check_str_match(settings.search_term, a)
-                    for a in message.attachments
-                )
-            )
-        )
-        if not found:
+        if not matches_any_field(settings.search_term):
             return False
 
     # 7b. Body-Specific Search

--- a/tests/test_advanced_filtering.py
+++ b/tests/test_advanced_filtering.py
@@ -118,3 +118,35 @@ def test_combined_inclusion_exclusion():
     settings.exclude_search = "spam"
     # Matches author Alice, no exclusion.
     assert matches_filters(msg, settings, set()) is True
+
+
+def test_exclude_search_source_file():
+    msg = create_msg(text="Normal message")
+    msg.source_file = "suspicious_file.qwk"
+    settings = ProcessingSettings(
+        verbose=False,
+        private=True,
+        no_header=True,
+        truncate_signatures=False,
+        cut_quoting=False,
+        individual_files=False,
+        threaded=False,
+        binaries_removal=False,
+        redact_pii=False,
+        format="text",
+        separator="none",
+        output_mode="stdout",
+        output_path=None,
+        encoding="cp437",
+        exclude_search="suspicious",
+    )
+    # Should be excluded because source_file matches "suspicious"
+    assert matches_filters(msg, settings, set()) is False
+
+    settings.exclude_search = "normal"
+    # Should be excluded because text matches "normal"
+    assert matches_filters(msg, settings, set()) is False
+
+    settings.exclude_search = "safe"
+    # Should NOT be excluded
+    assert matches_filters(msg, settings, set()) is True


### PR DESCRIPTION
This PR improves code quality by addressing logic duplication in the filtering system.

* **What:** Extracted a nested helper function `matches_any_field` within `matches_filters` in `pyqwk/core.py`. This helper centralizes the logic for checking a search pattern against all relevant message fields (From, To, Subject, Body, Conference, BBS, Source File, and Attachments).
* **Why:** This change removes significant code duplication between the `exclude_search` and `search_term` filters. It also fixes a minor logic bug where the `exclude_search` filter was missing the `source_file` field, ensuring both inclusion and exclusion searches are now consistent across all fields. No breaking changes were introduced as existing behavior was preserved and enhanced for consistency.

Verified with `pytest tests/test_advanced_filtering.py` and other relevant filtering tests.

---
*PR created automatically by Jules for task [15891166796261494529](https://jules.google.com/task/15891166796261494529) started by @RainRat*