### PR TITLE
[UI/UX] Improve message header hierarchy and alignment in GUI

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -1302,7 +1302,7 @@ class QwkGuiApp:
 
         subject_tag = f"subject_link_{id(msg)}"
         self.detail_text.insert(
-            tk.END, subject + "\n", ("link", "header_subject", subject_tag)
+            tk.END, subject, ("link", "header_subject", subject_tag)
         )
         self.detail_text.tag_bind(
             subject_tag,
@@ -1310,10 +1310,25 @@ class QwkGuiApp:
             lambda e, s=orig_subject: self._pivot_filter(subject=s),
         )
 
+        # Badges inline with subject
+        if header.is_private:
+            self.detail_text.insert(tk.END, "  ")
+            self.detail_text.insert(tk.END, " PRIVATE ", "badge_private")
+
+        bbs_info = getattr(self.board_dict, "bbs_info", None)
+        user_name = self.my_name or (bbs_info.user_name if bbs_info else None)
+        if user_name:
+            is_from_me = user_name.lower() in header.msgfrom.lower()
+            is_to_me = user_name.lower() in header.msgto.lower()
+            if is_from_me or is_to_me:
+                self.detail_text.insert(tk.END, "  ")
+                self.detail_text.insert(tk.END, " MINE ", "badge_mine")
+
+        self.detail_text.insert(tk.END, "\n")
         self.detail_text.insert(tk.END, " \n", "header_hr")
         self.detail_text.insert(tk.END, "\n")
 
-        # Primary fields
+        # Metadata fields (standardized 8-char labels)
         self.detail_text.insert(tk.END, "From:   ", "header_meta_label")
         from_tag = f"from_link_{id(msg)}"
         self.detail_text.insert(tk.END, msg_from, ("link", "header_meta", from_tag))
@@ -1334,29 +1349,12 @@ class QwkGuiApp:
         )
         self.detail_text.insert(tk.END, "\n")
 
-        # Information line (Date, Conference, BBS, Msg #)
         self.detail_text.insert(tk.END, "Date:   ", "header_meta_label")
         self.detail_text.insert(
-            tk.END, f"{header.msgdate} {header.msgtime}", "header_meta"
+            tk.END, f"{header.msgdate} {header.msgtime}\n", "header_meta"
         )
 
-        # Badges
-        if header.is_private:
-            self.detail_text.insert(tk.END, "  ")
-            self.detail_text.insert(tk.END, " PRIVATE ", "badge_private")
-
-        bbs_info = getattr(self.board_dict, "bbs_info", None)
-        user_name = self.my_name or (bbs_info.user_name if bbs_info else None)
-        if user_name:
-            is_from_me = user_name.lower() in header.msgfrom.lower()
-            is_to_me = user_name.lower() in header.msgto.lower()
-            if is_from_me or is_to_me:
-                self.detail_text.insert(tk.END, "  ")
-                self.detail_text.insert(tk.END, " MINE ", "badge_mine")
-
-        self.detail_text.insert(tk.END, "  •  ", "header_meta")
-        self.detail_text.insert(tk.END, "Conf: ", "header_meta_label")
-
+        self.detail_text.insert(tk.END, "Conf:   ", "header_meta_label")
         conf_tag = f"conf_link_{id(msg)}"
         self.detail_text.insert(tk.END, conf_name, ("link", "header_meta", conf_tag))
         self.detail_text.tag_bind(
@@ -1364,13 +1362,13 @@ class QwkGuiApp:
             "<Button-1>",
             lambda e, c=header.confnum: self._pivot_filter(conf_num=c),
         )
+        self.detail_text.insert(tk.END, "\n")
 
         if msg.bbs_name:
-            self.detail_text.insert(tk.END, "  •  ", "header_meta")
-            self.detail_text.insert(tk.END, "BBS: ", "header_meta_label")
+            self.detail_text.insert(tk.END, "BBS:    ", "header_meta_label")
             bbs_tag = f"bbs_link_{id(msg)}"
             self.detail_text.insert(
-                tk.END, msg.bbs_name, ("link", "header_meta", bbs_tag)
+                tk.END, f"{msg.bbs_name}\n", ("link", "header_meta", bbs_tag)
             )
             self.detail_text.tag_bind(
                 bbs_tag,
@@ -1379,15 +1377,13 @@ class QwkGuiApp:
             )
 
         if header.msgnum is not None:
-            self.detail_text.insert(tk.END, "  •  ", "header_meta")
-            self.detail_text.insert(tk.END, "Msg: ", "header_meta_label")
-            self.detail_text.insert(tk.END, f"{header.msgnum}", "header_meta")
+            self.detail_text.insert(tk.END, "Msg:    ", "header_meta_label")
+            self.detail_text.insert(tk.END, f"{header.msgnum}\n", "header_meta")
 
         if msg.refnum:
-            self.detail_text.insert(tk.END, "  •  ", "header_meta")
-            self.detail_text.insert(tk.END, "Ref: ", "header_meta_label")
+            self.detail_text.insert(tk.END, "Ref:    ", "header_meta_label")
             ref_tag = f"ref_link_{id(msg)}"
-            self.detail_text.insert(tk.END, f"{msg.refnum}", ("link", "header_meta", ref_tag))
+            self.detail_text.insert(tk.END, f"{msg.refnum}\n", ("link", "header_meta", ref_tag))
             self.detail_text.tag_bind(
                 ref_tag,
                 "<Button-1>",
@@ -1395,8 +1391,6 @@ class QwkGuiApp:
                     c, r
                 ),
             )
-
-        self.detail_text.insert(tk.END, "\n")
 
         if msg.source_file:
             self.detail_text.insert(tk.END, "Source: ", "header_meta_label")
@@ -1428,7 +1422,6 @@ class QwkGuiApp:
         self.detail_text.tag_add("header_area", header_start, header_end)
 
         # Visual separator
-        self.detail_text.insert(tk.END, "\n")
         self.detail_text.insert(tk.END, "\n")
 
         # Insert body with quote highlighting

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -183,10 +183,10 @@ class TestQwkGui:
 
             # Verify Ref: was rendered
             app._render_message(0)
-            # Find the call with "99" (the value). The tag should be ('link', 'header_meta', 'ref_link_...')
+            # Find the call with "99\n" (the value). The tag should be ('link', 'header_meta', 'ref_link_...')
             found_ref = False
             for call_obj in app.detail_text.insert.call_args_list:
-                if len(call_obj.args) >= 2 and call_obj.args[1] == "99":
+                if len(call_obj.args) >= 2 and call_obj.args[1] == "99\n":
                     tags = call_obj.args[2]
                     if (
                         isinstance(tags, tuple)
@@ -797,10 +797,10 @@ class TestQwkGui:
         app._render_message(0)
 
         # Verify that stripped values were inserted as interactive links
-        # Subject is inserted first with a newline as a link
+        # Subject is inserted first as a link
         subject_tag = f"subject_link_{id(msg)}"
         app.detail_text.insert.assert_any_call(
-            mock_gui_deps["tk"].END, "Subject\n", ("link", "header_subject", subject_tag)
+            mock_gui_deps["tk"].END, "Subject", ("link", "header_subject", subject_tag)
         )
         # Then From and To are inserted as interactive links (stripped) with separate newline calls
         from_tag = f"from_link_{id(msg)}"

--- a/tests/test_gui_pivot_enhancements.py
+++ b/tests/test_gui_pivot_enhancements.py
@@ -131,7 +131,7 @@ def test_render_message_links_robustness_pii(mock_gui_deps):
     inserted_texts = [c.args[1] for c in insert_calls]
     # Check for redacted elements
     assert "[EMAIL]" in inserted_texts # From or To
-    assert "Testing [PHONE]\n" in inserted_texts # Subject
+    assert "Testing [PHONE]" in inserted_texts # Subject
 
     # Find tags
     from_tags = [t for t in tag_callbacks if t.startswith("from_link_")]


### PR DESCRIPTION
This PR improves the visual hierarchy and readability of the message detail header in the GUI.

Key changes:
- **Badge Relocation**: 'PRIVATE' and 'MINE' badges are now displayed inline with the Subject title.
- **Label Alignment**: All metadata labels (From, To, Date, Conf, BBS, Msg, Ref, Source, Attach) are standardized to 8 characters wide, ensuring perfect vertical alignment.
- **Structure**: Metadata fields are now listed on individual lines instead of being merged with bullets, improving scannability.
- **Whitespace**: Reduced vertical padding between the header and the message body for a tighter, native feel.

Tests have been updated to reflect these formatting changes.

---
*PR created automatically by Jules for task [13606872585739949588](https://jules.google.com/task/13606872585739949588) started by @RainRat*