### PR TITLE
Deduplicate search logic in matches_filters

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -2616,39 +2616,29 @@ def matches_filters(
 
         return any(check_str_match(p, text) for p in pattern_list)
 
+    def matches_any_field(pattern: str) -> bool:
+        message.discover_attachments()
+        return (
+            check_str_match(pattern, message.header.msgfrom)
+            or check_str_match(pattern, message.header.msgto)
+            or check_str_match(pattern, message.header.msgsubject)
+            or check_str_match(pattern, message.text)
+            or (message.confname and check_str_match(pattern, message.confname))
+            or (message.bbs_name and check_str_match(pattern, message.bbs_name))
+            or (message.bbs_id and check_str_match(pattern, message.bbs_id))
+            or (message.source_file and check_str_match(pattern, message.source_file))
+            or (
+                message.attachments
+                and any(check_str_match(pattern, a) for a in message.attachments)
+            )
+        )
+
     # --- Exclusion Filters (Negative matching) ---
     # If any exclusion matches, the message is rejected immediately.
 
     # 1. Exclude Search
-    if settings.exclude_search:
-        message.discover_attachments()
-        found_exclude = (
-            check_str_match(settings.exclude_search, message.header.msgfrom)
-            or check_str_match(settings.exclude_search, message.header.msgto)
-            or check_str_match(settings.exclude_search, message.header.msgsubject)
-            or check_str_match(settings.exclude_search, message.text)
-            or (
-                message.confname
-                and check_str_match(settings.exclude_search, message.confname)
-            )
-            or (
-                message.bbs_name
-                and check_str_match(settings.exclude_search, message.bbs_name)
-            )
-            or (
-                message.bbs_id
-                and check_str_match(settings.exclude_search, message.bbs_id)
-            )
-            or (
-                message.attachments
-                and any(
-                    check_str_match(settings.exclude_search, a)
-                    for a in message.attachments
-                )
-            )
-        )
-        if found_exclude:
-            return False
+    if settings.exclude_search and matches_any_field(settings.exclude_search):
+        return False
 
     # 2. Exclude Author
     if settings.exclude_authors and any_match(
@@ -2725,38 +2715,8 @@ def matches_filters(
         return False
 
     # 7. Full-Text Search
-    if settings.search_term:
-        message.discover_attachments()
-        found = (
-            check_str_match(settings.search_term, message.header.msgfrom)
-            or check_str_match(settings.search_term, message.header.msgto)
-            or check_str_match(settings.search_term, message.header.msgsubject)
-            or check_str_match(settings.search_term, message.text)
-            or (
-                message.confname
-                and check_str_match(settings.search_term, message.confname)
-            )
-            or (
-                message.bbs_name
-                and check_str_match(settings.search_term, message.bbs_name)
-            )
-            or (
-                message.bbs_id and check_str_match(settings.search_term, message.bbs_id)
-            )
-            or (
-                message.source_file
-                and check_str_match(settings.search_term, message.source_file)
-            )
-            or (
-                message.attachments
-                and any(
-                    check_str_match(settings.search_term, a)
-                    for a in message.attachments
-                )
-            )
-        )
-        if not found:
-            return False
+    if settings.search_term and not matches_any_field(settings.search_term):
+        return False
 
     # 7b. Body-Specific Search
     if settings.body_search:

--- a/tests/test_advanced_filtering.py
+++ b/tests/test_advanced_filtering.py
@@ -103,6 +103,21 @@ def test_exclude_bbs():
     )
     assert matches_filters(msg, settings, set()) is False
 
+def test_exclude_search_source_file():
+    msg = create_msg()
+    msg.source_file = "bad_source.qwk"
+    settings = ProcessingSettings(
+        verbose=False, private=True, no_header=True, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False,
+        binaries_removal=False, redact_pii=False, format="text",
+        separator="none", output_mode="stdout", output_path=None,
+        encoding="cp437", exclude_search="bad_source"
+    )
+    assert matches_filters(msg, settings, set()) is False
+
+    settings.exclude_search = "good_source"
+    assert matches_filters(msg, settings, set()) is True
+
 def test_combined_inclusion_exclusion():
     msg = create_msg(text="Good content", author="Alice")
     settings = ProcessingSettings(


### PR DESCRIPTION
* **What:** Extracted duplicated search logic into a nested helper function `matches_any_field(pattern)` within `matches_filters`. This helper checks the pattern against From, To, Subject, Body, Conference, BBS, Source File, and Attachments.
* **Why:** This improves code maintainability and ensures consistent filtering across both inclusion and exclusion search paths. It also fixes a logic bug where the `exclude_search` filter was missing the `source_file` field. No breaking changes were introduced; all 983 tests passed.

---
*PR created automatically by Jules for task [10950020881063238459](https://jules.google.com/task/10950020881063238459) started by @RainRat*