### PR TITLE
Refactor "Mine" filter for consistency and regex support

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -2694,8 +2694,8 @@ def matches_filters(
     if settings.mine:
         if not user_name:
             return False
-        is_from_me = user_name.lower() in message.header.msgfrom.lower()
-        is_to_me = user_name.lower() in message.header.msgto.lower()
+        is_from_me = check_str_match(user_name, message.header.msgfrom)
+        is_to_me = check_str_match(user_name, message.header.msgto)
         if not (is_from_me or is_to_me):
             return False
 


### PR DESCRIPTION
This PR resolves an inconsistency in the message filtering logic within `pyqwk/core.py`.

### What:
Refactored the "Mine" filter implementation inside the `matches_filters` function to utilize the `check_str_match` helper function.

### Why:
Previously, the "Mine" filter used a direct `lower() in lower()` comparison. This approach had two drawbacks:
1. It ignored the `regex` flag in `ProcessingSettings`, unlike other filters (Search, Author, Recipient, etc.).
2. It duplicated logic that was already encapsulated in `check_str_match`.

By using the helper, the "Mine" filter now correctly supports regular expressions when enabled and maintains consistent behavior with the rest of the filtering system. This is a non-breaking change that improves code hygiene and fixes a minor logic bug regarding feature parity among filters.

All 984 existing tests passed, and the fix was verified with a targeted reproduction script for regex support in the "Mine" filter.

---
*PR created automatically by Jules for task [8668696083682623669](https://jules.google.com/task/8668696083682623669) started by @RainRat*