### PR TITLE
[DOCS] Improve CLI help text readability and field accuracy

### DIFF
--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -68,7 +68,7 @@ def _parse_cli_date(
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Convert old BBS message packets (like QWK and REP) into modern formats.",
+        description="Convert old BBS message packets (like QWK and REP) into modern,\nreadable formats like HTML, Markdown, and SQLite.",
         formatter_class=argparse.RawTextHelpFormatter,
         epilog="""
 examples:
@@ -96,7 +96,7 @@ examples:
         help=(
             "Path to archives, folders, or compressed files (ZIP/TAR).\n"
             "Supports QWK, JSON, SQLite, EML, and many other formats.\n"
-            "Multiple archives are automatically merged."
+            "Multiple archives are automatically merged into one view."
         ),
         nargs="+",
     )
@@ -170,7 +170,7 @@ examples:
     io_group.add_argument(
         "-E",
         "--encoding",
-        help="Set the text encoding of the input files. Default is 'cp437' (standard for older BBSs). Use this if messages show incorrect characters.",
+        help="Set the text encoding for input files. Default is 'cp437' (standard\nfor older BBSs). Use this if messages show incorrect characters.",
         default="cp437",
     )
 
@@ -252,8 +252,8 @@ examples:
         "-F",
         "--format",
         help=(
-            "Set the output format (text, html, json, etc.). "
-            "If omitted, the format is determined by the output file extension."
+            "Set the output format (text, html, json, etc.). If omitted, the\n"
+            "format is determined by the output file extension."
         ),
         default=None,
         choices=[
@@ -393,7 +393,7 @@ examples:
         "-S",
         "--search",
         dest="search_term",
-        help="Search for a keyword in author, recipient, subject, body, conference, BBS, and attachments.",
+        help="Search for a keyword in sender, recipient, subject, body, conference,\nBBS name, BBS ID, source file, and attachments.",
     )
     filter_group.add_argument(
         "--body",
@@ -403,7 +403,7 @@ examples:
     filter_group.add_argument(
         "--exclude",
         dest="exclude_search",
-        help="Exclude messages containing this keyword in any field.",
+        help="Exclude messages matching this keyword in any field (sender,\nrecipient, subject, body, conference, BBS, source file, or attachments).",
     )
     filter_group.add_argument(
         "--exclude-from",


### PR DESCRIPTION
This PR improves the CLI help strings in `pyqwk/cli.py` to make the tool more accessible and accurate for users.

**Changes:**
*   **Terminal Readability:** Added manual line breaks (`\n`) to several help strings, including the main description, `--encoding`, `--format`, `--search`, and `--exclude`. Since the CLI uses `RawTextHelpFormatter`, these manual breaks are necessary to prevent text from overflowing standard 80-character terminal widths.
*   **Accuracy:** Updated the help text for `--search` and `--exclude` to explicitly include all searchable fields: sender, recipient, subject, body, conference, BBS name, BBS ID, source file, and attachments. This now correctly reflects the filtering implementation in `pyqwk/core.py`.
*   **Clarity:** Refined the project description to highlight popular export formats (HTML, Markdown, SQLite) and clarified that multiple archives are merged into a single view.

These improvements ensure that users get clear, properly formatted guidance directly from the command line.

---
*PR created automatically by Jules for task [18149298427259191066](https://jules.google.com/task/18149298427259191066) started by @RainRat*