### PR TITLE
Inline redundant EML and mbox parsing wrappers in load_data

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -1443,20 +1443,8 @@ def _message_from_email(msg_obj: Any) -> ParsedMessage:
     )
 
 
-def _parse_mbox_messages(path: str) -> list[ParsedMessage]:
-    """Import messages from an mbox file."""
-    messages = []
-    mbox = mailbox.mbox(path)
-    for msg_obj in mbox:
-        messages.append(_message_from_email(msg_obj))
-    return messages
 
 
-def _parse_eml_messages(path: str) -> list[ParsedMessage]:
-    """Import messages from an EML file."""
-    with open(path, "rb") as f:
-        msg_obj = email.message_from_binary_file(f)
-    return [_message_from_email(msg_obj)]
 
 
 def _parse_html_messages(path: str) -> list[ParsedMessage]:
@@ -2023,7 +2011,11 @@ def load_data(
 
     if input_path.lower().endswith(".mbox"):
         try:
-            messages = _parse_mbox_messages(input_path)
+            messages = []
+            mbox = mailbox.mbox(input_path)
+            for msg_obj in mbox:
+                messages.append(_message_from_email(msg_obj))
+            mbox.close()
         except Exception as e:
             raise ValueError(f"Failed to load mbox archive: {e}")
 
@@ -2041,7 +2033,9 @@ def load_data(
 
     if input_path.lower().endswith(".eml"):
         try:
-            messages = _parse_eml_messages(input_path)
+            with open(input_path, "rb") as f:
+                msg_obj = email.message_from_binary_file(f)
+            messages = [_message_from_email(msg_obj)]
         except Exception as e:
             raise ValueError(f"Failed to load EML file: {e}")
 

--- a/tests/test_coverage_gap_closure.py
+++ b/tests/test_coverage_gap_closure.py
@@ -61,8 +61,8 @@ def _make_settings(**kwargs):
 
 def test_load_data_mbox_error():
     # Lines 1061-1062
-    with patch("pyqwk.core._parse_mbox_messages") as mock_parse:
-        mock_parse.side_effect = Exception("Mock mbox error")
+    with patch("pyqwk.core.mailbox.mbox") as mock_mbox:
+        mock_mbox.side_effect = Exception("Mock mbox error")
         with pytest.raises(
             ValueError, match="Failed to load mbox archive: Mock mbox error"
         ):
@@ -71,10 +71,13 @@ def test_load_data_mbox_error():
 
 def test_load_data_eml_error():
     # Lines 1070-1071
-    with patch("pyqwk.core._parse_eml_messages") as mock_parse:
+    with patch("pyqwk.core.email.message_from_binary_file") as mock_parse:
         mock_parse.side_effect = Exception("Mock eml error")
-        with pytest.raises(ValueError, match="Failed to load EML file: Mock eml error"):
-            load_data("test.eml", MagicMock())
+        with patch("pyqwk.core.open", MagicMock()):
+            with pytest.raises(
+                ValueError, match="Failed to load EML file: Mock eml error"
+            ):
+                load_data("test.eml", MagicMock())
 
 
 def test_write_text_toc_colors():


### PR DESCRIPTION
* **What:** Inlined the private functions `_parse_eml_messages` and `_parse_mbox_messages` into the `load_data` function in `pyqwk/core.py`. Updated associated tests in `tests/test_coverage_gap_closure.py` to mock the underlying library calls (`email.message_from_binary_file` and `mailbox.mbox`) instead of the removed functions. Fixed a minor resource management issue by adding an explicit `mbox.close()` call.
* **Why:** This change addresses "Premature Abstraction" by removing thin, one-off private wrappers, simplifying the call hierarchy and improving code readability. It also ensures better resource management for mbox files. No breaking changes were introduced, and all existing tests continue to pass.

---
*PR created automatically by Jules for task [2465353212571874166](https://jules.google.com/task/2465353212571874166) started by @RainRat*