### PR TITLE
[TEST] Fix message number filter bypass for messages without numbers

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -2695,8 +2695,8 @@ def matches_filters(
             return False
 
     # 3. Message Number Filter
-    if settings.msgnum_filters and message.msgnum is not None:
-        if message.msgnum not in settings.msgnum_filters:
+    if settings.msgnum_filters:
+        if message.msgnum is None or message.msgnum not in settings.msgnum_filters:
             return False
 
     # 4. Author Filter

--- a/tests/test_msgnum_filter.py
+++ b/tests/test_msgnum_filter.py
@@ -89,3 +89,27 @@ def test_msgnum_filtering_none():
     allowed_confs = {1}
     assert matches_filters(message_with_num(10), settings, allowed_confs) is True
     assert matches_filters(message_with_num(100), settings, allowed_confs) is True
+
+
+def test_msgnum_filtering_missing_num():
+    settings = ProcessingSettings(
+        verbose=False,
+        private=True,
+        no_header=False,
+        truncate_signatures=False,
+        cut_quoting=False,
+        individual_files=False,
+        threaded=False,
+        binaries_removal=False,
+        redact_pii=False,
+        format="text",
+        separator="none",
+        output_mode="stdout",
+        output_path=None,
+        encoding="cp437",
+        msgnum_filters={10, 20},
+    )
+
+    allowed_confs = {1}
+    # message_with_num(None) creates a message with msgnum=None
+    assert matches_filters(message_with_num(None), settings, allowed_confs) is False


### PR DESCRIPTION
* **Type:** Bug Fix
* **What:** Updated the `matches_filters` function in `pyqwk/core.py` to ensure that if a message number filter is active, messages with a `None` message number are correctly excluded. Added a corresponding regression test in `tests/test_msgnum_filter.py`.
* **Why:** Previously, the filter logic only checked the message number if it was not `None`, effectively allowing messages without a number to bypass the filter. This ensures consistent filtering behavior across all messages.

---
*PR created automatically by Jules for task [14222397797255983860](https://jules.google.com/task/14222397797255983860) started by @RainRat*