### PR TITLE
[UI/UX] Enhance continuous reading with Page Up/Down support

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -476,6 +476,10 @@ class QwkGuiApp:
 
     def _block_text_input(self, event: tk.Event) -> str | None:
         """Block keyboard input in the detail view while allowing common shortcuts."""
+        # Delegate continuous reading keys (Space, BackSpace, PgDn, PgUp)
+        if event.keysym in ("space", "BackSpace", "Prior", "Next"):
+            return self._on_space_pressed(event)
+
         # Allow Control+C (copy) and Control+A (select all)
         if event.state & 0x4:  # Control mask
             if event.keysym.lower() in ("c", "a"):
@@ -496,8 +500,6 @@ class QwkGuiApp:
             "Down",
             "Left",
             "Right",
-            "Prior",
-            "Next",
             "Home",
             "End",
         ):
@@ -557,8 +559,8 @@ class QwkGuiApp:
                 [
                     ("J / N", "Next Message"),
                     ("K / P", "Previous Message"),
-                    ("Space", "Scroll Down / Next"),
-                    ("Shift+Space", "Scroll Up / Prev"),
+                    ("Space / PgDn", "Scroll Down / Next"),
+                    ("Shift+Spc / PgUp", "Scroll Up / Prev"),
                     ("BackSpace", "Scroll Up / Prev"),
                     ("Ctrl + G", "Go to Message Number"),
                     ("[ / ]", "Prev / Next Conference"),
@@ -706,6 +708,8 @@ class QwkGuiApp:
         self.root.bind("<space>", self._on_space_pressed)
         self.root.bind("<Shift-space>", self._on_space_pressed)
         self.root.bind("<BackSpace>", self._on_space_pressed)
+        self.root.bind("<Prior>", self._on_space_pressed)
+        self.root.bind("<Next>", self._on_space_pressed)
         self.root.bind("[", lambda e: self._navigate_conference(-1))
         self.root.bind("]", lambda e: self._navigate_conference(1))
 
@@ -780,7 +784,7 @@ class QwkGuiApp:
         self.reload_messages()
 
     def _on_space_pressed(self, event: tk.Event) -> str | None:
-        """Handle Space, Shift+Space, and BackSpace for continuous reading."""
+        """Handle Space, PgDn, PgUp, and BackSpace for continuous reading."""
         # If a search or exclude entry has focus, let it handle the keys
         if self.root.focus_get() in (self.search_entry, self.exclude_entry):
             return None
@@ -788,18 +792,18 @@ class QwkGuiApp:
         # Check scroll position: (top, bottom) as fractions of the whole
         top, bottom = self.detail_text.yview()
 
-        # Space (Forward)
-        if event.keysym == "space" and not (event.state & 0x1):
+        # Space / Next (Forward)
+        if event.keysym in ("space", "Next") and not (event.state & 0x1):
             if bottom < 1.0:
                 self.detail_text.yview_scroll(1, "pages")
             else:
                 self._select_relative_message(1)
             return "break"
 
-        # Shift+Space or BackSpace (Backward)
+        # Shift+Space, BackSpace, or Prior (Backward)
         elif (
             event.keysym == "space" and (event.state & 0x1)
-        ) or event.keysym == "BackSpace":
+        ) or event.keysym in ("BackSpace", "Prior"):
             if top > 0.0:
                 self.detail_text.yview_scroll(-1, "pages")
             else:

--- a/tests/test_gui_nav_extension.py
+++ b/tests/test_gui_nav_extension.py
@@ -1,0 +1,115 @@
+import sys
+from unittest.mock import MagicMock, patch, call
+import pytest
+import tkinter as tk
+
+# Mock tkinter before any pyqwk.gui imports
+mock_tk = MagicMock()
+mock_ttk = MagicMock()
+sys.modules["tkinter"] = mock_tk
+sys.modules["tkinter.filedialog"] = MagicMock()
+sys.modules["tkinter.messagebox"] = MagicMock()
+sys.modules["tkinter.ttk"] = mock_ttk
+
+from pyqwk.core import ParsedMessage, MessageHeader
+
+@pytest.fixture
+def mock_app():
+    with (
+        patch("pyqwk.gui.tk") as mock_tk,
+        patch("pyqwk.gui.ttk") as mock_ttk,
+    ):
+        # Configure constants
+        mock_tk.END = "end"
+        mock_tk.HORIZONTAL = "horizontal"
+        mock_tk.VERTICAL = "vertical"
+        mock_tk.BOTH = "both"
+        mock_tk.X = "x"
+        mock_tk.Y = "y"
+        mock_tk.LEFT = "left"
+        mock_tk.RIGHT = "right"
+        mock_tk.TOP = "top"
+        mock_tk.BOTTOM = "bottom"
+        mock_tk.SUNKEN = "sunken"
+        mock_tk.W = "w"
+        mock_tk.E = "e"
+        mock_tk.WORD = "word"
+        mock_tk.NONE = "none"
+        mock_tk.DISABLED = "disabled"
+        mock_tk.NORMAL = "normal"
+        mock_tk.INSERT = "insert"
+
+        from pyqwk.gui import QwkGuiApp
+        root = MagicMock()
+        # Mock focus_get to avoid issues with focused widget checks
+        root.focus_get.return_value = None
+
+        app = QwkGuiApp(root)
+
+        # Setup dummy messages
+        h1 = MessageHeader(" ", 1, "01-01-90", "12:00", "To", "From", "Sub1", "", None, 1, " ", 1, 1, "")
+        h2 = MessageHeader(" ", 2, "01-01-90", "12:05", "To", "From", "Sub2", "", None, 1, " ", 1, 1, "")
+        app.messages = [
+            ParsedMessage("Body 1", 1, None, 1, h1),
+            ParsedMessage("Body 2", 2, None, 1, h2),
+        ]
+
+        yield app
+
+def test_on_space_pressed_next_keysym(mock_app):
+    """Test that 'Next' keysym triggers the same logic as 'space'."""
+    event = MagicMock()
+    event.keysym = "Next"
+    event.state = 0  # No modifiers
+
+    # Mock detail_text.yview to return bottom reached (1.0)
+    mock_app.detail_text.yview.return_value = (0.5, 1.0)
+
+    with patch.object(mock_app, "_select_relative_message") as mock_select:
+        result = mock_app._on_space_pressed(event)
+        assert result == "break"
+        mock_select.assert_called_with(1)
+
+def test_on_space_pressed_prior_keysym(mock_app):
+    """Test that 'Prior' keysym triggers the same logic as 'BackSpace'."""
+    event = MagicMock()
+    event.keysym = "Prior"
+    event.state = 0
+
+    # Mock detail_text.yview to return top reached (0.0)
+    mock_app.detail_text.yview.return_value = (0.0, 0.5)
+
+    with patch.object(mock_app, "_select_relative_message") as mock_select:
+        result = mock_app._on_space_pressed(event)
+        assert result == "break"
+        mock_select.assert_called_with(-1)
+
+def test_block_text_input_delegation(mock_app):
+    """Test that _block_text_input delegates continuous reading keys to _on_space_pressed."""
+    keys_to_test = ["space", "BackSpace", "Prior", "Next"]
+
+    for key in keys_to_test:
+        event = MagicMock()
+        event.keysym = key
+
+        with patch.object(mock_app, "_on_space_pressed", return_value="break") as mock_handler:
+            result = mock_app._block_text_input(event)
+            assert result == "break"
+            mock_handler.assert_called_once_with(event)
+
+def test_block_text_input_remains_blocked_for_others(mock_app):
+    """Test that other keys still return 'break' or None as before."""
+    # A regular character should return "break"
+    event = MagicMock()
+    event.keysym = "x"
+    event.state = 0
+    assert mock_app._block_text_input(event) == "break"
+
+    # An allowed navigation key should return None
+    event.keysym = "Up"
+    assert mock_app._block_text_input(event) is None
+
+    # Prior and Next should now return whatever _on_space_pressed returns (e.g. "break")
+    event.keysym = "Prior"
+    with patch.object(mock_app, "_on_space_pressed", return_value="delegated"):
+        assert mock_app._block_text_input(event) == "delegated"


### PR DESCRIPTION
### Context
GUI (Tkinter)

### Problem
The user experience in the message reader was hindered by a "friction point" where the convenient continuous reading shortcuts (Space/BackSpace) would stop working if the user clicked into the message body (giving it focus). Additionally, Page Up and Page Down keys only performed standard widget scrolling instead of the "intelligent" navigation (which seamlessly advances to the next/previous message at boundaries) provided by the Space bar logic.

### Solution
I have enhanced the keyboard efficiency of the GUI by:
1.  **Integrating PgUp/PgDn:** Standard Page navigation keys are now integrated into the continuous reading pipeline.
2.  **Focus-Aware Delegation:** Modified the input-blocking logic in the detail view to explicitly delegate navigation keys to the global handler. This ensures shortcuts work consistently regardless of which widget has focus.
3.  **UI Feedback:** Updated the Welcome Screen shortcut list to explicitly mention Page Up/Down support.

These changes reduce friction for keyboard-heavy users and improve consistency with standard message reader behaviors.

### Changes
-   **pyqwk/gui.py**:
    -   Added `<Prior>` and `<Next>` bindings to the root window.
    -   Updated `_on_space_pressed` to handle `Prior` and `Next` keysyms.
    -   Updated `_block_text_input` to delegate navigation keys instead of just blocking editing.
    -   Updated `_render_welcome_screen` shortcut labels.
-   **tests/test_gui_nav_extension.py**: New test file verifying delegation and keysym handling.

---
*PR created automatically by Jules for task [3962315490586930216](https://jules.google.com/task/3962315490586930216) started by @RainRat*