### PR TITLE
[FEAT] Rich Export for Archive Statistics and Information

### DIFF
--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -89,6 +89,12 @@ examples:
 
   # Show activity reports and charts
   qwk archive.qwk --stats
+
+  # Save statistics as an HTML report with charts
+  qwk archive.qwk --stats --format html -o stats.html
+
+  # Save archive information as a Markdown report
+  qwk archive.qwk --info --format markdown -o info.md
 """,
     )
     parser.add_argument(
@@ -555,12 +561,12 @@ examples:
         "-I",
         "--info",
         action="store_true",
-        help="Show a summary of the archive and exit. Use --format json for JSON output.",
+        help="Show a summary of the archive and exit. Supports file export via -o and --format (json, html, markdown, text).",
     )
     parser.add_argument(
         "--stats",
         action="store_true",
-        help="Show detailed statistics and exit. Use --format json for JSON output.",
+        help="Show detailed statistics and exit. Supports file export via -o and --format (json, html, markdown, text).",
     )
     parser.add_argument(
         "--merge-stats",

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -5534,14 +5534,151 @@ def _render_stats_bar_chart(
     return parts
 
 
+def render_info_as_text(all_info: list[dict[str, Any]], use_colors: bool = False) -> str:
+    """Render archive information into a human-readable text report."""
+    BOLD = "1"
+    CYAN = "36"
+
+    def c(t, *a):
+        if use_colors:
+            return f"\033[{';'.join(a)}m{t}\033[0m"
+        return t
+
+    parts = []
+    for info in all_info:
+        parts.append(f"File: {c(info['file'], CYAN)}")
+        if info.get("error"):
+            parts.append(f"  {info['error']}")
+            parts.append("")
+            continue
+
+        bbs = info.get("bbs_info")
+        if bbs:
+            if bbs.get("name"):
+                parts.append(f"  {c('BBS Name:', BOLD)} {bbs['name']}")
+            if bbs.get("sysop"):
+                parts.append(f"  {c('SysOp:', BOLD)}    {bbs['sysop']}")
+            if bbs.get("location"):
+                parts.append(f"  {c('Location:', BOLD)} {bbs['location']}")
+            if bbs.get("bbs_id"):
+                parts.append(f"  {c('BBS ID:', BOLD)}   {bbs['bbs_id']}")
+            if bbs.get("packet_at"):
+                parts.append(f"  {c('Packet At:', BOLD)} {bbs['packet_at']}")
+            if bbs.get("user_name"):
+                parts.append(f"  {c('User Name:', BOLD)} {bbs['user_name']}")
+
+        parts.append(f"  {c('Total Messages:', BOLD)} {info['total_messages']}")
+        parts.append(f"  {c('Conferences:', BOLD)}")
+
+        for conf in info["conferences"]:
+            count_str = c(str(conf["message_count"]), BOLD)
+            parts.append(
+                f"    {conf['number']}: {conf['name']} ({count_str} messages)"
+            )
+        parts.append("")
+    return "\n".join(parts)
+
+
+def _render_info_html(all_info: list[dict[str, Any]]) -> list[str]:
+    """Render archive information as an HTML fragment."""
+    parts = []
+    for info in all_info:
+        parts.append('<div class="stats-container">')
+        parts.append(f"<h2>File: {html.escape(info['file'])}</h2>")
+
+        if info.get("error"):
+            parts.append(f"<p>{html.escape(info['error'])}</p>")
+            parts.append("</div>")
+            continue
+
+        bbs = info.get("bbs_info")
+        if bbs:
+            parts.append('<div class="stats-summary-info">')
+            if bbs.get("name"):
+                parts.append(
+                    f"<div><strong>BBS Name:</strong> {html.escape(bbs['name'])}</div>"
+                )
+            if bbs.get("sysop"):
+                parts.append(
+                    f"<div><strong>SysOp:</strong> {html.escape(bbs['sysop'])}</div>"
+                )
+            if bbs.get("location"):
+                parts.append(
+                    f"<div><strong>Location:</strong> {html.escape(bbs['location'])}</div>"
+                )
+            if bbs.get("bbs_id"):
+                parts.append(
+                    f"<div><strong>BBS ID:</strong> {html.escape(bbs['bbs_id'])}</div>"
+                )
+            if bbs.get("packet_at"):
+                parts.append(
+                    f"<div><strong>Packet At:</strong> {html.escape(bbs['packet_at'])}</div>"
+                )
+            if bbs.get("user_name"):
+                parts.append(
+                    f"<div><strong>User Name:</strong> {html.escape(bbs['user_name'])}</div>"
+                )
+            parts.append("</div>")
+
+        parts.append(
+            f"<div><strong>Total Messages:</strong> {info['total_messages']}</div>"
+        )
+
+        if info["conferences"]:
+            parts.append("<h3>Conferences</h3>")
+            parts.append("<ul>")
+            for conf in info["conferences"]:
+                parts.append(
+                    f"<li>{conf['number']}: {html.escape(conf['name'])} ({conf['message_count']} messages)</li>"
+                )
+            parts.append("</ul>")
+        parts.append("</div>")
+    return parts
+
+
+def _render_info_markdown(all_info: list[dict[str, Any]]) -> list[str]:
+    """Render archive information as a Markdown fragment."""
+    parts = []
+    for info in all_info:
+        parts.append(f"## File: {info['file']}\n")
+
+        if info.get("error"):
+            parts.append(f"{info['error']}\n")
+            continue
+
+        bbs = info.get("bbs_info")
+        if bbs:
+            if bbs.get("name"):
+                parts.append(f"- **BBS Name:** {bbs['name']}")
+            if bbs.get("sysop"):
+                parts.append(f"- **SysOp:** {bbs['sysop']}")
+            if bbs.get("location"):
+                parts.append(f"- **Location:** {bbs['location']}")
+            if bbs.get("bbs_id"):
+                parts.append(f"- **BBS ID:** {bbs['bbs_id']}")
+            if bbs.get("packet_at"):
+                parts.append(f"- **Packet At:** {bbs['packet_at']}")
+            if bbs.get("user_name"):
+                parts.append(f"- **User Name:** {bbs['user_name']}")
+
+        parts.append(f"- **Total Messages:** {info['total_messages']}")
+
+        if info["conferences"]:
+            parts.append("\n### Conferences\n")
+            parts.append("| # | Name | Messages |")
+            parts.append("|---|---|---|")
+            for conf in info["conferences"]:
+                parts.append(
+                    f"| {conf['number']} | {conf['name']} | {conf['message_count']} |"
+                )
+            parts.append("")
+    return parts
+
+
 def show_info(
     input_paths: list[str], settings: ProcessingSettings, logger: logging.Logger
 ) -> None:
     """Show a summary of the QWK packet contents."""
-    # ANSI Attribute codes
-    BOLD = "1"
-    CYAN = "36"
-
     all_info = []
 
     for input_path in input_paths:
@@ -5556,15 +5693,15 @@ def show_info(
 
             bbs_info = getattr(board_dict, "bbs_info", None)
             if bbs_info:
+                if settings.my_name:
+                    bbs_info.user_name = settings.my_name
                 info_entry["bbs_info"] = asdict(bbs_info)
 
             if isinstance(file_data, list):
                 messages_to_process = file_data
             else:
                 if len(file_data) < BLOCK_SIZE:
-                    if settings.format != "json":
-                        print(f"File: {_colorize(input_path, CYAN)}")
-                        print("  Invalid or empty file.")
+                    info_entry["error"] = "Invalid or empty file."
                     all_info.append(info_entry)
                     continue
                 messages_to_process = parse_messages(
@@ -5593,40 +5730,38 @@ def show_info(
                     {"number": conf_num, "name": conf_name, "message_count": count}
                 )
 
-            if settings.format != "json":
-                print(f"File: {_colorize(input_path, CYAN)}")
-                if bbs_info:
-                    if bbs_info.name:
-                        print(f"  {_colorize('BBS Name:', BOLD)} {bbs_info.name}")
-                    if bbs_info.sysop:
-                        print(f"  {_colorize('SysOp:', BOLD)}    {bbs_info.sysop}")
-                    if bbs_info.location:
-                        print(f"  {_colorize('Location:', BOLD)} {bbs_info.location}")
-                    if bbs_info.bbs_id:
-                        print(f"  {_colorize('BBS ID:', BOLD)}   {bbs_info.bbs_id}")
-                    if bbs_info.packet_at:
-                        print(f"  {_colorize('Packet At:', BOLD)} {bbs_info.packet_at}")
-                user_name_to_show = settings.my_name or (bbs_info.user_name if bbs_info else None)
-                if user_name_to_show:
-                    print(f"  {_colorize('User Name:', BOLD)} {user_name_to_show}")
-
-                print(f"  {_colorize('Total Messages:', BOLD)} {total_messages}")
-                print(f"  {_colorize('Conferences:', BOLD)}")
-
-                for conf in info_entry["conferences"]:
-                    count_str = _colorize(str(conf["message_count"]), BOLD)
-                    print(
-                        f"    {conf['number']}: {conf['name']} ({count_str} messages)"
-                    )
-                print("")
-
             all_info.append(info_entry)
 
         except PROCESSING_EXCEPTIONS as e:
             logger.error(f"Error reading info for {input_path}: {e}")
 
+    if not all_info:
+        return
+
+    output = ""
     if settings.format == "json":
-        print(json.dumps(all_info, indent=4, ensure_ascii=False))
+        output = json.dumps(all_info, indent=4, ensure_ascii=False)
+    elif settings.format == "html":
+        title = "Archive Information"
+        html_parts = _get_html_header(title)
+        html_parts.append(f"<h1>{title}</h1>")
+        html_parts.extend(_render_info_html(all_info))
+        html_parts.extend(_get_html_footer())
+        output = "\n".join(html_parts)
+    elif settings.format == "markdown":
+        title = "Archive Information"
+        md_parts = [f"# {title}\n"]
+        md_parts.extend(_render_info_markdown(all_info))
+        output = "\n".join(md_parts)
+    else:
+        use_colors = (
+            not settings.output_path
+            and hasattr(sys.stdout, "isatty")
+            and sys.stdout.isatty()
+        )
+        output = render_info_as_text(all_info, use_colors=use_colors)
+
+    _write_text_output(output, settings.output_path, encoding="utf-8")
 
 
 def _compute_stats_from_messages(
@@ -6083,17 +6218,9 @@ def show_stats(
     """Show detailed statistics about the messages in the QWK archives."""
     all_stats = []
 
-    use_colors = (
-        settings.format == "text"
-        and hasattr(sys.stdout, "isatty")
-        and sys.stdout.isatty()
-    )
-
     if settings.merge_stats:
         try:
             stats_entry = calculate_archive_stats(input_paths, settings, logger)
-            if settings.format != "json":
-                print(render_stats_as_text(stats_entry, use_colors=use_colors))
             all_stats.append(stats_entry)
         except PROCESSING_EXCEPTIONS as e:
             logger.error(f"Error calculating merged stats: {e}")
@@ -6101,14 +6228,42 @@ def show_stats(
         for input_path in input_paths:
             try:
                 stats_entry = calculate_archive_stats([input_path], settings, logger)
-                if settings.format != "json":
-                    print(render_stats_as_text(stats_entry, use_colors=use_colors))
                 all_stats.append(stats_entry)
             except PROCESSING_EXCEPTIONS as e:
                 logger.error(f"Error calculating stats for {input_path}: {e}")
 
+    if not all_stats:
+        return
+
+    output = ""
     if settings.format == "json":
-        print(json.dumps(all_stats, indent=4, ensure_ascii=False))
+        output = json.dumps(all_stats, indent=4, ensure_ascii=False)
+    elif settings.format == "html":
+        title = "Archive Statistics"
+        html_parts = _get_html_header(title)
+        html_parts.append(f"<h1>{title}</h1>")
+        for stats in all_stats:
+            html_parts.extend(_render_stats_html(stats))
+        html_parts.extend(_get_html_footer())
+        output = "\n".join(html_parts)
+    elif settings.format == "markdown":
+        title = "Archive Statistics"
+        md_parts = [f"# {title}\n"]
+        for stats in all_stats:
+            md_parts.extend(_render_stats_markdown(stats))
+        output = "\n".join(md_parts)
+    else:
+        use_colors = (
+            not settings.output_path
+            and hasattr(sys.stdout, "isatty")
+            and sys.stdout.isatty()
+        )
+        parts = []
+        for stats in all_stats:
+            parts.append(render_stats_as_text(stats, use_colors=use_colors))
+        output = "\n".join(parts)
+
+    _write_text_output(output, settings.output_path, encoding="utf-8")
 
 
 def process_multiple_files(

--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -2398,9 +2398,49 @@ class QwkGuiApp:
             sb_x = ttk.Scrollbar(main_frame, orient=tk.HORIZONTAL, command=txt.xview)
             txt.configure(yscrollcommand=sb_y.set, xscrollcommand=sb_x.set)
 
-            # Footer for close button
+            # Footer for buttons
             footer = ttk.Frame(stats_win, padding=(10, 5))
             footer.pack(side=tk.BOTTOM, fill=tk.X)
+
+            def save_report():
+                report_filetypes = [
+                    ("HTML files", "*.html"),
+                    ("Markdown files", "*.md"),
+                    ("JSON files", "*.json"),
+                    ("Text files", "*.txt"),
+                    ("All files", "*.*"),
+                ]
+                save_path = filedialog.asksaveasfilename(
+                    title="Save Statistics Report",
+                    filetypes=report_filetypes,
+                    defaultextension=".html",
+                )
+                if not save_path:
+                    return
+
+                try:
+                    # Resolve format from extension
+                    from pyqwk.core import show_stats as core_show_stats
+
+                    report_fmt = resolve_output_format(None, save_path, "file")
+                    report_settings = replace(
+                        settings,
+                        format=report_fmt,
+                        output_mode="file",
+                        output_path=save_path,
+                    )
+                    core_show_stats(self.current_paths, report_settings, self.logger)
+                    messagebox.showinfo(
+                        "Report Saved",
+                        f"Successfully saved statistics report to {os.path.basename(save_path)}",
+                    )
+                except Exception as e:
+                    messagebox.showerror("Save Report Error", str(e))
+
+            ttk.Button(footer, text="Save Report...", command=save_report).pack(
+                side=tk.LEFT, padx=5
+            )
+
             ttk.Button(footer, text="Close", command=stats_win.destroy).pack(
                 side=tk.RIGHT
             )

--- a/tests/test_report_export.py
+++ b/tests/test_report_export.py
@@ -1,0 +1,95 @@
+import os
+import logging
+import pytest
+from pyqwk.core import show_stats, show_info, ProcessingSettings
+
+@pytest.fixture
+def mock_logger():
+    import unittest.mock
+    return unittest.mock.MagicMock(spec=logging.Logger)
+
+@pytest.fixture
+def base_settings():
+    return ProcessingSettings(
+        verbose=False,
+        private=True,
+        no_header=False,
+        truncate_signatures=False,
+        cut_quoting=False,
+        individual_files=False,
+        threaded=False,
+        binaries_removal=False,
+        redact_pii=False,
+        quiet=True,
+        format="text",
+        separator="auto",
+        output_mode="file",
+        output_path=None,
+        encoding="cp437",
+    )
+
+def test_stats_export_html(tmp_path, base_settings, mock_logger):
+    input_path = "testdata/test1_qwk.zip"
+    output_file = tmp_path / "stats.html"
+
+    settings = base_settings
+    settings.format = "html"
+    settings.output_path = str(output_file)
+
+    show_stats([input_path], settings, mock_logger)
+
+    assert output_file.exists()
+    content = output_file.read_text(encoding="utf-8")
+    assert "<!DOCTYPE html>" in content
+    assert "Archive Statistics" in content
+    assert "Top Authors" in content
+    assert "Warren Zatwarni" in content
+
+def test_stats_export_markdown(tmp_path, base_settings, mock_logger):
+    input_path = "testdata/test1_qwk.zip"
+    output_file = tmp_path / "stats.md"
+
+    settings = base_settings
+    settings.format = "markdown"
+    settings.output_path = str(output_file)
+
+    show_stats([input_path], settings, mock_logger)
+
+    assert output_file.exists()
+    content = output_file.read_text(encoding="utf-8")
+    assert "# Archive Statistics" in content
+    assert "### Archive Summary" in content
+    assert "Warren Zatwarni" in content
+
+def test_info_export_html(tmp_path, base_settings, mock_logger):
+    input_path = "testdata/test1_qwk.zip"
+    output_file = tmp_path / "info.html"
+
+    settings = base_settings
+    settings.format = "html"
+    settings.output_path = str(output_file)
+
+    show_info([input_path], settings, mock_logger)
+
+    assert output_file.exists()
+    content = output_file.read_text(encoding="utf-8")
+    assert "<!DOCTYPE html>" in content
+    assert "Archive Information" in content
+    assert "BBS Name:" in content
+    assert "Benden Weyr" in content
+
+def test_info_export_markdown(tmp_path, base_settings, mock_logger):
+    input_path = "testdata/test1_qwk.zip"
+    output_file = tmp_path / "info.md"
+
+    settings = base_settings
+    settings.format = "markdown"
+    settings.output_path = str(output_file)
+
+    show_info([input_path], settings, mock_logger)
+
+    assert output_file.exists()
+    content = output_file.read_text(encoding="utf-8")
+    assert "# Archive Information" in content
+    assert "## File: testdata/test1_qwk.zip" in content
+    assert "**BBS Name:** Benden Weyr" in content


### PR DESCRIPTION
This PR introduces rich report exports for archive statistics and information in both the CLI and GUI.

### What
- Refactored `show_stats` and `show_info` in `pyqwk/core.py` to aggregate results and support file-based export via the `-o/--output` flag.
- Added `_render_info_html` and `_render_info_markdown` helper functions to generate structured Archive Information reports.
- Enhanced the CLI help text in `pyqwk/cli.py` to document report export capabilities and added clear usage examples to the epilog.
- Integrated a "Save Report..." feature into the GUI's statistics window, allowing users to export their current filtered view's statistics directly to HTML, Markdown, JSON, or Text files.
- Added a new test suite `tests/test_report_export.py` to verify the correctness of HTML and Markdown exports for both statistics and archive information.

### Why
The existing statistics and archive information features provided significant value but were largely tethered to the terminal or raw JSON output. By enabling HTML and Markdown exports, users can now easily generate and share polished, readable reports of their historical BBS archives. The addition of a "Save Report" button in the GUI brings this powerful functionality to non-technical users, completing the "missing piece" of the statistics workflow.

---
*PR created automatically by Jules for task [12926108635752265419](https://jules.google.com/task/12926108635752265419) started by @RainRat*