### PR TITLE
Add test coverage for empty message list in GUI random selection

### DIFF
--- a/tests/test_random_feature.py
+++ b/tests/test_random_feature.py
@@ -64,3 +64,17 @@ def test_gui_random_message():
             app.message_list.selection_set.assert_called_once_with("3")
             app.message_list.see.assert_called_once_with("3")
             app.message_list.focus.assert_called_once_with("3")
+
+def test_gui_random_message_empty():
+    # Mocking Tk and root to avoid TclError
+    with patch("tkinter.Tk"), patch("tkinter.ttk.Style"), patch("tkinter.font.Font"):
+        root = MagicMock()
+        # Mocking QwkGuiApp's __init__ to avoid building the whole UI
+        with patch.object(QwkGuiApp, "__init__", return_value=None):
+            app = QwkGuiApp(root)
+            app.message_list = MagicMock()
+            app._get_all_tree_items = MagicMock(return_value=[])
+
+            app._select_random_message()
+
+            app.message_list.selection_set.assert_not_called()


### PR DESCRIPTION
I have added a new test case to `tests/test_random_feature.py` to cover an edge case in the `_select_random_message` method within `pyqwk/gui.py`. Specifically, I targeted line 2334, which handles the scenario where the message list is empty when a user attempts to select a random message.

By mocking an empty message list and asserting that no selection actions are performed, I have ensured this branch is correctly handled and verified. This addition completes the test coverage for `pyqwk/gui.py`, which now stands at 100%. All 994 tests in the suite passed successfully.

---
*PR created automatically by Jules for task [2437723135952706035](https://jules.google.com/task/2437723135952706035) started by @RainRat*