### PR TITLE
[UI/UX] Improve CLI one-line summary alignment and hierarchy

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -933,13 +933,16 @@ class MessageHeader:
             to_name = _redact_pii(to_name)
             subject = _redact_pii(subject)
 
-        def prepare_field(text: str, width: int) -> str:
+        def prepare_field(text: str, width: int, dim: bool = False) -> str:
             truncated = text[:width]
             display_len = len(truncated)
             truncated = _highlight_text(truncated, highlight_term, is_regex, use_colors)
-            return truncated + (" " * (width - display_len))
+            res = truncated + (" " * (width - display_len))
+            if use_colors and dim:
+                return f"\x1b[90m{res}\x1b[0m"
+            return res
 
-        conf_part = prepare_field(conf_name, 12)
+        conf_part = prepare_field(conf_name, 12, dim=True)
         from_part = prepare_field(from_name, 15)
         to_part = prepare_field(to_name, 15)
 
@@ -950,24 +953,31 @@ class MessageHeader:
         if has_attachments:
             flags += "@"
 
-        if flags:
-            flags_display = flags.ljust(2)
-            if use_colors:
-                # Dim the flags
-                flags_display = f"\x1b[90m{flags_display}\x1b[0m"
-            subject = f"{flags_display} {subject}"
-
         # Apply conversation indent to subject
         if depth > 0:
             indent = "  " * (depth - 1)
             subject = f"{indent}└ {subject}"
+
+        flags_display = flags.ljust(3)
+        if use_colors:
+            # Dim the flags
+            flags_display = f"\x1b[90m{flags_display}\x1b[0m"
+        subject = f"{flags_display} {subject}"
         subject_part = _highlight_text(subject, highlight_term, is_regex, use_colors)
 
         msgnum_part = ""
         if verbose:
-            msgnum_part = f"{(self.msgnum or ''):<6} "
+            msgnum_val = str(self.msgnum or "")
+            if use_colors:
+                msgnum_part = f"\x1b[90m{msgnum_val:<6}\x1b[0m "
+            else:
+                msgnum_part = f"{msgnum_val:<6} "
 
-        return f"{msgnum_part}{conf_part} {date_str:<14} {from_part} {to_part} {subject_part}\r\n"
+        date_part = date_str.ljust(14)
+        if use_colors:
+            date_part = f"\x1b[90m{date_part}\x1b[0m"
+
+        return f"{msgnum_part}{conf_part} {date_part} {from_part} {to_part} {subject_part}\r\n"
 
 
 class MessagesDatFormatError(Exception):
@@ -4757,7 +4767,8 @@ def _write_text(
         date_hdr = f"{'Date':<14}"
         from_hdr = f"{'From':<15}"
         to_hdr = f"{'To':<15}"
-        subj_hdr = "Subject"
+        # "Flg" header for the new 3-character flags column
+        subj_hdr = "Flg Subject"
 
         if use_colors:
             BOLD = "1"

--- a/tests/test_core_final_coverage.py
+++ b/tests/test_core_final_coverage.py
@@ -444,18 +444,18 @@ def test_format_oneline_flags():
     )
 
     formatted = header.format_oneline({1: "General"}, is_private=True)
-    assert "*  Subject" in formatted
+    assert "*   Subject" in formatted
 
     formatted = header.format_oneline({1: "General"}, has_attachments=True)
-    assert "@  Subject" in formatted
+    assert "@   Subject" in formatted
 
     formatted = header.format_oneline(
         {1: "General"}, is_private=True, has_attachments=True
     )
-    assert "*@ Subject" in formatted
+    assert "*@  Subject" in formatted
 
     formatted = header.format_oneline({1: "General"}, is_private=True, use_colors=True)
-    assert "\x1b[90m* \x1b[0m Subject" in formatted
+    assert "\x1b[90m*  \x1b[0m Subject" in formatted
 
 
 def test_parse_html_empty_attachments(tmp_path):

--- a/tests/test_lead_qa_gap_closure_v4.py
+++ b/tests/test_lead_qa_gap_closure_v4.py
@@ -292,7 +292,7 @@ def test_write_text_oneline_no_colors(capsys):
         sys.stdout.isatty = original_isatty
     captured = capsys.readouterr()
     assert (
-        "Num    Conference   Date           From            To              Subject"
+        "Num    Conference   Date           From            To              Flg Subject"
         in captured.out
     )
     assert "\x1b[" not in captured.out

--- a/tests/test_ui_oneline_alignment.py
+++ b/tests/test_ui_oneline_alignment.py
@@ -90,7 +90,7 @@ def test_oneline_alignment_with_highlighting():
     assert "Author Name    " in oneline.replace("\x1b[7m", "").replace("\x1b[0m", "")
 
     # Check the whole line structure
-    plain_line = oneline.replace("\x1b[7m", "").replace("\x1b[0m", "")
+    plain_line = oneline.replace("\x1b[7m", "").replace("\x1b[90m", "").replace("\x1b[0m", "")
     # Conf (12) + space (1) + Date (14) + space (1) + From (15) + space (1) + To (15) + space (1) + Subject
     # "Conference  " (12)
     # "01-01-24 12:00 " (14+1)
@@ -100,7 +100,7 @@ def test_oneline_alignment_with_highlighting():
     # "Subject"
 
     expected_start = (
-        "Conference   01-01-24 12:00 Author Name     Recipient       Subject"
+        "Conference   01-01-24 12:00 Author Name     Recipient           Subject"
     )
     assert plain_line.startswith(expected_start)
 
@@ -131,7 +131,8 @@ def test_threaded_oneline_indentation():
     # 12 (Conf) + 1 + 14 (Date) + 1 + 15 (From) + 1 + 15 (To) + 1 = 60 chars before subject
     prefix_d1 = oneline_d1[:60]
     assert prefix_d1 == "Conference   01-01-24 12:00 Author          Recipient       "
-    assert oneline_d1[60:].startswith("└ Threaded Subject")
+    # New flags column (3 chars) + 1 space = 64 chars before subject indentation
+    assert oneline_d1[64:].startswith("└ Threaded Subject")
 
     # Depth 2: Subject should start with "  └ "
     oneline_d2 = header.format_oneline(board_dict, depth=2)
@@ -139,4 +140,5 @@ def test_threaded_oneline_indentation():
     # Verify metadata alignment remains consistent
     prefix_d2 = oneline_d2[:60]
     assert prefix_d2 == "Conference   01-01-24 12:00 Author          Recipient       "
-    assert oneline_d2[60:].startswith("  └ Threaded Subject")
+    # New flags column (3 chars) + 1 space = 64 chars before subject indentation
+    assert oneline_d2[64:].startswith("  └ Threaded Subject")


### PR DESCRIPTION
This improvement focuses on friction reduction and visual hierarchy in the CLI's one-line summary mode (`--oneline`).

### Problem
Previously, flags for private messages or attachments were prepended directly to the subject string only when they existed. This caused the subject line to shift horizontally between rows, making the list harder to scan. Additionally, the lack of visual contrast between metadata and content made it difficult to quickly identify the primary information.

### Solution
1. **Fixed-Width Flags Column**: Added a 3-character "Flg" column (e.g., `*@ `) that is always present. This guarantees that the subject line starts at the exact same horizontal position for every message, regardless of its status.
2. **Visual Hierarchy**: Applied `DIM` (ANSI 90) color to secondary metadata fields like the Message Number, Conference, Date, and the Flags indicators. This causes the white/bolded Author and Subject fields to "pop," allowing users to scan the list much more efficiently.
3. **Alignment-Safe Indentation**: Threaded conversation markers (`└`) now appear *after* the flags column but *before* the subject text, maintaining logical hierarchy while preserving alignment.

### Verification
- Verified alignment manually with `qwk archive.qwk --oneline` and `qwk archive.qwk --oneline -v`.
- Updated and passed the full test suite (993 tests).

---
*PR created automatically by Jules for task [225819136388638024](https://jules.google.com/task/225819136388638024) started by @RainRat*