### PR TITLE
Resolve ZeroDivisionError in HTML statistics rendering

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -3894,7 +3894,7 @@ def _render_stats_html(stats: dict[str, Any]) -> list[str]:
         parts.append(f"<h3>{title}</h3>")
         max_count = max(item[count_key] for item in items)
         for item in items[:5]:
-            width = int(item[count_key] * 100 / max_count)
+            width = int(item[count_key] * 100 / max_count) if max_count > 0 else 0
             label = str(item[label_key])
             parts.append('<div class="stats-bar-container">')
             parts.append(


### PR DESCRIPTION
This change resolves a logic bug in `pyqwk/core.py` where rendering statistics in HTML format would fail with a `ZeroDivisionError` if all items in a distribution (such as authors, conferences, or time-based distributions) had zero matching messages.

The fix adds a defensive check `if max_count > 0 else 0` when calculating the percentage width for HTML bar charts. This ensures that the code handles empty or zero-count distributions gracefully instead of crashing.

This was identified as a low-hanging fruit (Logic Bug) and is a non-breaking, atomic improvement. All existing tests (1016) passed successfully after the change.

---
*PR created automatically by Jules for task [9448089492773929303](https://jules.google.com/task/9448089492773929303) started by @RainRat*