### PR TITLE
[UI/UX] Improve Search & Find toolbar layout and visual hierarchy

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -952,15 +952,10 @@ class QwkGuiApp:
         self.search_entry = ttk.Entry(
             search_frame, textvariable=self.search_var, width=18
         )
-        self.search_entry.pack(side=tk.LEFT, padx=(0, 0))
+        self.search_entry.pack(side=tk.LEFT)
         ttk.Button(
             search_frame, text="✕", width=2, command=lambda: self.search_var.set("")
-        ).pack(side=tk.LEFT, padx=(0, 5))
-
-        self.search_count_label = ttk.Label(
-            search_frame, text="", width=12, anchor=tk.CENTER
-        )
-        self.search_count_label.pack(side=tk.LEFT)
+        ).pack(side=tk.LEFT, padx=(0, 2))
 
         ttk.Button(
             search_frame,
@@ -973,18 +968,29 @@ class QwkGuiApp:
             text="▼",
             width=2,
             command=lambda: self._navigate_search_matches(1),
-        ).pack(side=tk.LEFT, padx=(1, 5))
+        ).pack(side=tk.LEFT, padx=(1, 2))
 
-        ttk.Label(search_frame, text="Exclude: ", padding=(10, 0, 0, 0)).pack(
-            side=tk.LEFT
+        self.search_count_label = ttk.Label(
+            search_frame, text="", width=12, anchor=tk.CENTER
         )
+        self.search_count_label.pack(side=tk.LEFT, padx=(0, 5))
+
+        ttk.Separator(search_frame, orient=tk.VERTICAL).pack(
+            side=tk.LEFT, fill=tk.Y, padx=8
+        )
+
+        ttk.Label(search_frame, text="Exclude: ").pack(side=tk.LEFT)
         self.exclude_entry = ttk.Entry(
             search_frame, textvariable=self.exclude_var, width=18
         )
-        self.exclude_entry.pack(side=tk.LEFT, padx=(0, 0))
+        self.exclude_entry.pack(side=tk.LEFT)
         ttk.Button(
             search_frame, text="✕", width=2, command=lambda: self.exclude_var.set("")
-        ).pack(side=tk.LEFT, padx=(0, 2))
+        ).pack(side=tk.LEFT, padx=(0, 5))
+
+        ttk.Separator(search_frame, orient=tk.VERTICAL).pack(
+            side=tk.LEFT, fill=tk.Y, padx=8
+        )
 
         ttk.Checkbutton(
             search_frame,


### PR DESCRIPTION
### [UI/UX] Improve Search & Find toolbar layout and visual hierarchy

**Context:** GUI

**Problem:** 
The search section in the toolbar was previously a flat list of widgets with inconsistent spacing and grouping. This made it harder for users to quickly distinguish between "Find" actions, "Exclude" filters, and search results/navigation. Manual padding on labels was used for spacing, which is fragile and often leads to misaligned elements.

**Solution:**
Reorganized the `search_frame` in `pyqwk/gui.py` to establish a clear visual hierarchy:
1.  **Logical Reordering:** Reordered widgets into a more intuitive "Find" group: `Label -> Entry -> Clear (✕) -> Prev Match (▲) -> Next Match (▼) -> Match Counter`. This follows the standard flow of "input -> action -> navigation -> feedback".
2.  **Functional Grouping:** Added vertical `ttk.Separator` widgets between the **Find**, **Exclude**, and **Regex** blocks. This creates distinct functional boundaries that reduce cognitive load.
3.  **Standardized Spacing:** Standardized `padx` values across the toolbar and removed manual `padding=(10, 0, 0, 0)` from the "Exclude" label, relying on the separators for consistent spacing.

These changes make the toolbar feel more professional and "stock", adhering to clean design principles without adding unnecessary decoration.

**Verification:**
- Ran `pytest tests/test_gui.py` and `pytest tests/test_ui_toolbar_consolidation.py` (All passed).
- Executed the full test suite (1015 tests) to ensure no system regressions (All passed).
- Confirmed layout changes via code inspection of the `_build_toolbar` method.


---
*PR created automatically by Jules for task [6543028128804889293](https://jules.google.com/task/6543028128804889293) started by @RainRat*