### PR TITLE
[UI/UX] Improve Search & Find toolbar hierarchy and reduce friction

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -954,8 +954,15 @@ class QwkGuiApp:
         )
         self.search_entry.pack(side=tk.LEFT, padx=(0, 0))
         ttk.Button(
-            search_frame, text="✕", width=2, command=lambda: self.search_var.set("")
-        ).pack(side=tk.LEFT, padx=(0, 5))
+            search_frame,
+            text="✕",
+            width=2,
+            command=lambda: [self.search_var.set(""), self.search_entry.focus_set()],
+        ).pack(side=tk.LEFT, padx=(0, 0))
+
+        ttk.Separator(search_frame, orient=tk.VERTICAL).pack(
+            side=tk.LEFT, fill=tk.Y, padx=5
+        )
 
         self.search_count_label = ttk.Label(
             search_frame, text="", width=12, anchor=tk.CENTER
@@ -973,18 +980,27 @@ class QwkGuiApp:
             text="▼",
             width=2,
             command=lambda: self._navigate_search_matches(1),
-        ).pack(side=tk.LEFT, padx=(1, 5))
+        ).pack(side=tk.LEFT, padx=(1, 0))
 
-        ttk.Label(search_frame, text="Exclude: ", padding=(10, 0, 0, 0)).pack(
-            side=tk.LEFT
+        ttk.Separator(search_frame, orient=tk.VERTICAL).pack(
+            side=tk.LEFT, fill=tk.Y, padx=5
         )
+
+        ttk.Label(search_frame, text="Exclude: ").pack(side=tk.LEFT)
         self.exclude_entry = ttk.Entry(
             search_frame, textvariable=self.exclude_var, width=18
         )
         self.exclude_entry.pack(side=tk.LEFT, padx=(0, 0))
         ttk.Button(
-            search_frame, text="✕", width=2, command=lambda: self.exclude_var.set("")
-        ).pack(side=tk.LEFT, padx=(0, 2))
+            search_frame,
+            text="✕",
+            width=2,
+            command=lambda: [self.exclude_var.set(""), self.exclude_entry.focus_set()],
+        ).pack(side=tk.LEFT, padx=(0, 0))
+
+        ttk.Separator(search_frame, orient=tk.VERTICAL).pack(
+            side=tk.LEFT, fill=tk.Y, padx=5
+        )
 
         ttk.Checkbutton(
             search_frame,


### PR DESCRIPTION
* **Context:** GUI
* **Problem:** The 'Search & Find' toolbar lacked a clear visual hierarchy, making it difficult to distinguish between search, navigation, and exclusion controls at a glance. Additionally, clearing the search or exclude fields required an extra click to refocus the input field before typing a new query.
* **Solution:** Introduced vertical separators between functional blocks in the search frame to establish a cleaner visual organization. Updated the 'Clear' buttons to automatically refocus their respective entry fields, streamlining the workflow for power users.

---
*PR created automatically by Jules for task [2161689503338241352](https://jules.google.com/task/2161689503338241352) started by @RainRat*