### PR TITLE
Fix logic bug in URI resolution for `www.` links

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -5374,11 +5374,7 @@ def _linkify_text(
             else:
                 result.append(val_esc)
         elif etype == "url":
-            uri = (
-                evalue
-                if "://" in evalue.lower() or evalue.lower().startswith("www.")
-                else f"http://{evalue}"
-            )
+            uri = evalue if "://" in evalue.lower() else f"http://{evalue}"
             if output_format == "html":
                 result.append(f'<a href="{html.escape(uri)}">{val_esc}</a>')
             elif output_format == "markdown":

--- a/tests/test_lead_qa_core_linkify_gaps.py
+++ b/tests/test_lead_qa_core_linkify_gaps.py
@@ -13,16 +13,18 @@ def test_linkify_text_unknown_entity_type():
         assert result == "Hello world!"
 
 def test_linkify_text_html_formats():
-    text = "Check http://example.com and test@example.com and msg #123"
+    text = "Check http://example.com and www.example.com and test@example.com and msg #123"
     result = _linkify_text(text, "html", conf_num=1)
     assert '<a href="http://example.com">http://example.com</a>' in result
+    assert '<a href="http://www.example.com">www.example.com</a>' in result
     assert '<a href="mailto:test@example.com">test@example.com</a>' in result
     assert '<a href="#msg-1-123">msg #123</a>' in result
 
 def test_linkify_text_markdown_formats():
-    text = "Check http://example.com and test@example.com and msg #123"
+    text = "Check http://example.com and www.example.com and test@example.com and msg #123"
     result = _linkify_text(text, "markdown", conf_num=1)
     assert '[http://example.com](http://example.com)' in result
+    assert '[www.example.com](http://www.example.com)' in result
     assert '[test@example.com](mailto:test@example.com)' in result
     assert '[msg #123](#msg-1-123)' in result
 


### PR DESCRIPTION
* **What:** Updated the `_linkify_text` function in `pyqwk/core.py` to ensure that `http://` is prepended to any URL that does not already contain a protocol separator (`://`). This simplifies the logic and correctly handles URLs starting with `www.`.
* **Why:** Previously, URLs starting with `www.` were explicitly excluded from protocol prepending, which resulted in broken relative links in HTML and Markdown exports. This change ensures that such links are generated as absolute URIs (e.g., `http://www.example.com`), which is the standard behavior for linkification. No breaking changes were introduced, and absolute URLs with existing protocols remain unaffected.

---
*PR created automatically by Jules for task [8929504102614036231](https://jules.google.com/task/8929504102614036231) started by @RainRat*