### PR TITLE
[UI/UX] Refine 'Search & Find' toolbar with separators and refocusing logic

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -954,7 +954,10 @@ class QwkGuiApp:
         )
         self.search_entry.pack(side=tk.LEFT, padx=(0, 0))
         ttk.Button(
-            search_frame, text="✕", width=2, command=lambda: self.search_var.set("")
+            search_frame,
+            text="✕",
+            width=2,
+            command=lambda: [self.search_var.set(""), self.search_entry.focus_set()],
         ).pack(side=tk.LEFT, padx=(0, 5))
 
         self.search_count_label = ttk.Label(
@@ -975,16 +978,25 @@ class QwkGuiApp:
             command=lambda: self._navigate_search_matches(1),
         ).pack(side=tk.LEFT, padx=(1, 5))
 
-        ttk.Label(search_frame, text="Exclude: ", padding=(10, 0, 0, 0)).pack(
-            side=tk.LEFT
+        ttk.Separator(search_frame, orient=tk.VERTICAL).pack(
+            side=tk.LEFT, fill=tk.Y, padx=5
         )
+
+        ttk.Label(search_frame, text="Exclude: ").pack(side=tk.LEFT)
         self.exclude_entry = ttk.Entry(
             search_frame, textvariable=self.exclude_var, width=18
         )
         self.exclude_entry.pack(side=tk.LEFT, padx=(0, 0))
         ttk.Button(
-            search_frame, text="✕", width=2, command=lambda: self.exclude_var.set("")
+            search_frame,
+            text="✕",
+            width=2,
+            command=lambda: [self.exclude_var.set(""), self.exclude_entry.focus_set()],
         ).pack(side=tk.LEFT, padx=(0, 2))
+
+        ttk.Separator(search_frame, orient=tk.VERTICAL).pack(
+            side=tk.LEFT, fill=tk.Y, padx=5
+        )
 
         ttk.Checkbutton(
             search_frame,

--- a/tests/test_gui_toolbar_refinement.py
+++ b/tests/test_gui_toolbar_refinement.py
@@ -1,0 +1,73 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+# Mock tkinter before importing QwkGuiApp
+import sys
+mock_tk = MagicMock()
+sys.modules['tkinter'] = mock_tk
+sys.modules['tkinter.filedialog'] = MagicMock()
+sys.modules['tkinter.messagebox'] = MagicMock()
+sys.modules['tkinter.ttk'] = MagicMock()
+sys.modules['tkinter.simpledialog'] = MagicMock()
+
+from pyqwk.gui import QwkGuiApp
+
+@pytest.fixture
+def app():
+    root = MagicMock()
+    # Mocking necessary attributes for initialization
+    with patch('pyqwk.gui.ttk.Style'), \
+         patch('pyqwk.gui.QwkGuiApp._render_welcome_screen'), \
+         patch('pyqwk.gui.QwkGuiApp._build_menu'), \
+         patch('pyqwk.gui.QwkGuiApp._build_toolbar'), \
+         patch('pyqwk.gui.QwkGuiApp._build_status_bar'), \
+         patch('pyqwk.gui.QwkGuiApp._build_layout'):
+        app = QwkGuiApp(root)
+        app.search_entry = MagicMock()
+        app.exclude_entry = MagicMock()
+        app.search_var = MagicMock()
+        app.exclude_var = MagicMock()
+        return app
+
+def test_clear_search_refocus(app):
+    # Retrieve the command for the search clear button
+    # In _build_toolbar, it's the first button with text "✕"
+    # Wait, we need to find how it was called.
+    # Actually, we can just test the lambda logic if we can extract it,
+    # but it's easier to mock what it calls.
+
+    # Since we can't easily extract the lambda from the mock Button call without
+    # capturing it during _build_toolbar, let's re-run _build_toolbar with a mock ttk.
+
+    with patch('pyqwk.gui.ttk') as mock_ttk:
+        # Ensure ttk.Entry returns unique mocks for search and exclude
+        mock_ttk.Entry.side_effect = [MagicMock(name="search_entry"), MagicMock(name="exclude_entry")]
+        app._build_toolbar()
+
+        # Find the search clear button (it's the first '✕' button)
+        search_clear_btn_call = None
+        exclude_clear_btn_call = None
+
+        for call in mock_ttk.Button.call_args_list:
+            if call.kwargs.get('text') == '✕':
+                if search_clear_btn_call is None:
+                    search_clear_btn_call = call
+                else:
+                    exclude_clear_btn_call = call
+                    break
+
+        assert search_clear_btn_call is not None
+        assert exclude_clear_btn_call is not None
+
+        search_clear_cmd = search_clear_btn_call.kwargs['command']
+        exclude_clear_cmd = exclude_clear_btn_call.kwargs['command']
+
+        # Test search clear refocus
+        search_clear_cmd()
+        app.search_var.set.assert_called_with("")
+        app.search_entry.focus_set.assert_called_once()
+
+        # Test exclude clear refocus
+        exclude_clear_cmd()
+        app.exclude_var.set.assert_called_with("")
+        app.exclude_entry.focus_set.assert_called_once()


### PR DESCRIPTION
I have improved the 'Search & Find' toolbar in the GUI by adding vertical separators to better group related controls and by ensuring that clicking the 'Clear' (✕) buttons automatically refocuses the respective search or exclude entry fields. This reduces workflow friction by allowing users to immediately start typing a new search term after clearing the previous one. I also removed manual padding that is now handled by the separators and added a new unit test to verify the refocusing behavior.

---
*PR created automatically by Jules for task [12798279535786868947](https://jules.google.com/task/12798279535786868947) started by @RainRat*