### PR TITLE
[FEAT] Add custom directory organization via --organize-pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ for msg in messages:
 | `--organize-by-author` | Organize files into folders by author name. |
 | `--organize-by-to` | Organize files into folders by recipient name. |
 | `--organize-by-subject` | Organize files by message subject. |
+| `--organize-pattern` | Set a custom folder structure for individual files. |
 | `--sort` | Sort results by field (date, author, subject, etc.). |
 | `-r, --redact-pii` | Hide personal info like emails and phone numbers. |
 | `-p, --private` | Include private messages. |

--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -174,6 +174,10 @@ examples:
         help=f"Set a pattern for naming individual files (e.g., '{{date}}_{{author}}_{{subject}}').\n{pattern_help}",
     )
     io_group.add_argument(
+        "--organize-pattern",
+        help=f"Set a pattern for organizing individual files into folders (e.g., '{{year}}/{{month}}/{{author}}').\n{pattern_help}",
+    )
+    io_group.add_argument(
         "-E",
         "--encoding",
         help="Set the text encoding (default is 'cp437'). Use this if text looks incorrect.",
@@ -751,6 +755,7 @@ examples:
         exclude_conferences=args.exclude_conferences,
         exclude_bbs_names=args.exclude_bbs_names,
         filename_pattern=getattr(args, "filename_pattern", None),
+        organize_pattern=getattr(args, "organize_pattern", None),
         min_length=getattr(args, "min_length", None),
         max_length=getattr(args, "max_length", None),
     )

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -592,6 +592,7 @@ class ProcessingSettings:
     exclude_subjects: list[str] | None = None
     exclude_conferences: list[str] | None = None
     exclude_bbs_names: list[str] | None = None
+    organize_pattern: str | None = None
 
 
 @dataclass
@@ -2814,6 +2815,30 @@ def _get_organization_subpath(
     message: ParsedMessage, settings: ProcessingSettings
 ) -> str:
     """Determine the relative subfolder path for a message or its attachments."""
+    if settings.organize_pattern:
+        try:
+            raw_mapping = _get_message_mapping(
+                message,
+                0,
+                redact_pii=settings.redact_pii,
+                user_name=settings.my_name,
+            )
+
+            mapping = {}
+            for k, v in raw_mapping.items():
+                if isinstance(v, str):
+                    mapping[k] = _slugify(v, k)
+                else:
+                    mapping[k] = v
+
+            subpath = settings.organize_pattern.format(**mapping)
+            # Support both forward and backward slashes for cross-platform patterns
+            parts = [p for p in subpath.replace("\\", "/").split("/") if p]
+            return os.path.join(*parts) if parts else ""
+        except (KeyError, ValueError, AttributeError):
+            # Fallback to standard organization if pattern fails
+            pass
+
     sub_parts = []
 
     if settings.organize_by_bbs:

--- a/tests/test_organize_pattern.py
+++ b/tests/test_organize_pattern.py
@@ -1,0 +1,100 @@
+import os
+from pyqwk.core import _get_organization_subpath, ParsedMessage, MessageHeader, ProcessingSettings
+
+def test_organize_pattern_basic():
+    header = MessageHeader(
+        status=" ", msgnum=1, msgdate="01-02-23", msgtime="12:34",
+        msgto="All", msgfrom="Author Name", msgsubject="Test Subject",
+        msgpassword="", refnum=0, numblocks=1, msgflag=" ",
+        confnum=1, lognum=0, nettag=" "
+    )
+    msg = ParsedMessage(
+        text="Body", msgnum=1, refnum=0, confnum=1, header=header,
+        confname="General", bbs_name="The BBS"
+    )
+
+    settings = ProcessingSettings(
+        verbose=False, private=True, no_header=True, truncate_signatures=False,
+        cut_quoting=False, individual_files=True, threaded=False,
+        binaries_removal=False, redact_pii=False, format="text",
+        separator="none", output_mode="file", output_path="out",
+        encoding="cp437", organize_pattern="{year}/{month}/{author}"
+    )
+
+    subpath = _get_organization_subpath(msg, settings)
+    # 01-02-23 -> 2023 / 01 / author_name
+    expected = os.path.join("2023", "01", "author_name")
+    assert subpath == expected
+
+def test_organize_pattern_slashes():
+    header = MessageHeader(
+        status=" ", msgnum=1, msgdate="01-02-23", msgtime="12:34",
+        msgto="All", msgfrom="Author", msgsubject="Subject",
+        msgpassword="", refnum=0, numblocks=1, msgflag=" ",
+        confnum=1, lognum=0, nettag=" "
+    )
+    msg = ParsedMessage(
+        text="Body", msgnum=1, refnum=0, confnum=1, header=header,
+        confname="General"
+    )
+
+    # Test both forward and backward slashes in pattern
+    settings = ProcessingSettings(
+        verbose=False, private=True, no_header=True, truncate_signatures=False,
+        cut_quoting=False, individual_files=True, threaded=False,
+        binaries_removal=False, redact_pii=False, format="text",
+        separator="none", output_mode="file", output_path="out",
+        encoding="cp437", organize_pattern="archives\\{confname}/{year}"
+    )
+
+    subpath = _get_organization_subpath(msg, settings)
+    expected = os.path.join("archives", "general", "2023")
+    assert subpath == expected
+
+def test_organize_pattern_invalid_variable():
+    header = MessageHeader(
+        status=" ", msgnum=1, msgdate="01-02-23", msgtime="12:34",
+        msgto="All", msgfrom="Author", msgsubject="Subject",
+        msgpassword="", refnum=0, numblocks=1, msgflag=" ",
+        confnum=1, lognum=0, nettag=" "
+    )
+    msg = ParsedMessage(
+        text="Body", msgnum=1, refnum=0, confnum=1, header=header
+    )
+
+    # Invalid variable {nonexistent} should fall back to standard organization
+    settings = ProcessingSettings(
+        verbose=False, private=True, no_header=True, truncate_signatures=False,
+        cut_quoting=False, individual_files=True, threaded=False,
+        binaries_removal=False, redact_pii=False, format="text",
+        separator="none", output_mode="file", output_path="out",
+        encoding="cp437", organize_pattern="{nonexistent}", organize=True
+    )
+
+    subpath = _get_organization_subpath(msg, settings)
+    # Fallback to organize (by conference): 001-unknown (since confname is None)
+    assert "001-unknown" in subpath
+
+def test_organize_pattern_sanitization():
+    header = MessageHeader(
+        status=" ", msgnum=1, msgdate="01-02-23", msgtime="12:34",
+        msgto="All", msgfrom="Author / Path", msgsubject="Subj",
+        msgpassword="", refnum=0, numblocks=1, msgflag=" ",
+        confnum=1, lognum=0, nettag=" "
+    )
+    msg = ParsedMessage(
+        text="Body", msgnum=1, refnum=0, confnum=1, header=header
+    )
+
+    settings = ProcessingSettings(
+        verbose=False, private=True, no_header=True, truncate_signatures=False,
+        cut_quoting=False, individual_files=True, threaded=False,
+        binaries_removal=False, redact_pii=False, format="text",
+        separator="none", output_mode="file", output_path="out",
+        encoding="cp437", organize_pattern="users/{author}"
+    )
+
+    subpath = _get_organization_subpath(msg, settings)
+    # "Author / Path" should be slugified to "author_path"
+    expected = os.path.join("users", "author_path")
+    assert subpath == expected


### PR DESCRIPTION
Implemented a new `--organize-pattern` feature for the `pyqwk` tool, enabling users to define custom directory structures for individual file exports using template variables (e.g., `{year}/{month}/{author}`). This extension provides symmetry with the existing `--filename-pattern` flag and significantly improves file management flexibility for large message archives.

The implementation includes:
- **Core Logic:** Enhanced `_get_organization_subpath` in `pyqwk/core.py` to handle pattern substitution. It leverages `_get_message_mapping` for variable access and applies `_slugify` to each path component for filesystem safety and cross-platform compatibility.
- **CLI Integration:** Added the `--organize-pattern` flag to `pyqwk/cli.py` within the "Input & Output" argument group, including detailed help text.
- **Documentation:** Updated `README.md` to document the new flag.
- **Testing:** Added `tests/test_organize_pattern.py` with test cases for basic usage, sanitization, and robust fallback behavior. Verified that the full test suite (1000+ tests) passes.
- **Quality:** Addressed code review feedback by ensuring repository hygiene and maintaining consistent variable handling.

---
*PR created automatically by Jules for task [5559133867550343110](https://jules.google.com/task/5559133867550343110) started by @RainRat*