### PR TITLE
[UI/UX] Enable global keyboard shortcuts during message reading

### DIFF
--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -477,9 +477,9 @@ class QwkGuiApp:
         if event.keysym in ("space", "BackSpace", "Prior", "Next"):
             return self._on_space_pressed(event)
 
-        # Allow Control+C (copy) and Control+A (select all)
+        # Allow common Control key shortcuts to propagate to root bindings
         if event.state & 0x4:  # Control mask
-            if event.keysym.lower() in ("c", "a"):
+            if event.keysym.lower() in ("c", "a", "f", "g", "o", "s", "i", "q"):
                 return None
 
         # Handle message navigation shortcuts
@@ -496,8 +496,14 @@ class QwkGuiApp:
         if key == "slash" or event.char == "/":
             self._focus_search()
             return "break"
+        if event.keysym == "bracketleft" or event.char == "[":
+            self._navigate_conference(-1)
+            return "break"
+        if event.keysym == "bracketright" or event.char == "]":
+            self._navigate_conference(1)
+            return "break"
 
-        # Allow text navigation keys
+        # Allow text navigation keys and search controls
         if event.keysym in (
             "Up",
             "Down",
@@ -505,6 +511,8 @@ class QwkGuiApp:
             "Right",
             "Home",
             "End",
+            "Escape",
+            "F3",
         ):
             return None
         return "break"


### PR DESCRIPTION
**PR Title:** [UI/UX] Enable global keyboard shortcuts during message reading

**Description:**
* **Context:** GUI
* **Problem:** Standard application shortcuts (like Ctrl+F for Find or Ctrl+S for Export) and navigation keys (like [ / ] for Conference switching) are blocked when the message detail viewer has focus. This creates friction as users have to manually click away from the text area to perform common actions.
* **Solution:** Updated `_block_text_input` in `pyqwk/gui.py` to allow propagation of common Control key combinations and search-related keys (F3, Escape). Added explicit handling for conference navigation keys. This ensures a seamless reading experience without losing access to global commands.

**Changes:**
```python
<<<<<<< SEARCH
        # Allow Control+C (copy) and Control+A (select all)
        if event.state & 0x4:  # Control mask
            if event.keysym.lower() in ("c", "a"):
                return None

        # Handle message navigation shortcuts
=======
        # Allow common Control key shortcuts to propagate to root bindings
        if event.state & 0x4:  # Control mask
            if event.keysym.lower() in ("c", "a", "f", "g", "o", "s", "i", "q"):
                return None

        # Handle message navigation shortcuts
>>>>>>> REPLACE
<<<<<<< SEARCH
        if key == "slash" or event.char == "/":
            self._focus_search()
            return "break"

        # Allow text navigation keys
        if event.keysym in (
            "Up",
            "Down",
            "Left",
            "Right",
            "Home",
            "End",
        ):
            return None
        return "break"
=======
        if key == "slash" or event.char == "/":
            self._focus_search()
            return "break"
        if event.keysym == "bracketleft" or event.char == "[":
            self._navigate_conference(-1)
            return "break"
        if event.keysym == "bracketright" or event.char == "]":
            self._navigate_conference(1)
            return "break"

        # Allow text navigation keys and search controls
        if event.keysym in (
            "Up",
            "Down",
            "Left",
            "Right",
            "Home",
            "End",
            "Escape",
            "F3",
        ):
            return None
        return "break"
>>>>>>> REPLACE
```

---
*PR created automatically by Jules for task [14126822845713512567](https://jules.google.com/task/14126822845713512567) started by @RainRat*