### PR TITLE
Fix attachment loss in RFC 822 (EML/MBOX) exports

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -4592,7 +4592,8 @@ def _serialize_rfc822(
 
     # 1. Identify and extract attachments from the body
     # We remove them from the text part so the email looks modern
-    found_binaries = extract_binaries(message.text) if message.text else []
+    text_to_scan = message.original_text or message.text
+    found_binaries = extract_binaries(text_to_scan) if text_to_scan else []
     clean_body = message.text or ""
     if found_binaries:
         # Simple removal of lines that look like parts of UUE/Base64/yEnc blocks

--- a/tests/test_eml_attachments_regression.py
+++ b/tests/test_eml_attachments_regression.py
@@ -1,0 +1,50 @@
+import unittest
+import base64
+from pyqwk.core import MessageHeader, ProcessedMessage, _serialize_rfc822, _bytes_to_uue
+
+class TestEMLAttachmentsRegression(unittest.TestCase):
+    def test_serialize_rfc822_preserves_attachments_from_original_text(self):
+        header = MessageHeader(
+            status=" ",
+            msgnum=1,
+            msgdate="01-01-23",
+            msgtime="12:00",
+            msgto="Recipient",
+            msgfrom="Author",
+            msgsubject="Test Subject",
+            msgpassword="",
+            refnum=0,
+            numblocks=1,
+            msgflag="",
+            confnum=1,
+            lognum=0,
+            nettag=""
+        )
+
+        # Create a valid UUE block using the internal helper
+        test_data = b"Hello, this is a test attachment."
+        uue_block = _bytes_to_uue(test_data, "test.txt")
+
+        # Scenario: body is cleaned (binaries removed), but they are in original_text
+        msg = ProcessedMessage(
+            header=header,
+            text="This is the clean body.\n",
+            original_text="This is the original body.\n" + uue_block,
+            confnum=1,
+            depth=0,
+            msgnum=1,
+            refnum=0
+        )
+
+        # Act
+        eml = _serialize_rfc822(msg, include_mbox_header=False)
+
+        # Assert: The attachment should be present in the EML output
+        self.assertIn('Content-Disposition: attachment; filename="test.txt"', eml)
+
+        # The test_data should be base64 encoded in the EML
+        expected_b64 = base64.b64encode(test_data).decode('ascii')
+        self.assertIn(expected_b64, eml)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR fixes a logic bug in the RFC 822 (EML/MBOX) export functionality where binary attachments (UUE, Base64, or yEnc blocks) were lost if the message body had already been "cleaned" (binaries removed) prior to serialization.

By scanning the raw source text (`original_text`) for attachments, we ensure they are correctly detected and included as MIME parts in the output.

A new regression test has been added to verify that attachments are correctly preserved even when the primary message body is cleaned.

---
*PR created automatically by Jules for task [8804239503597429496](https://jules.google.com/task/8804239503597429496) started by @RainRat*