### PR TITLE
Fix binary attachment loss in EML/MBOX exports

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -343,6 +343,9 @@ def _is_binary_line(
             return True, in_yenc_block, True, in_base64_block
         in_uue_block = False
 
+    if stripped_line == "end" and previous_line and previous_line.strip() == "`":
+        return True, in_yenc_block, False, in_base64_block
+
     if RE_BASE64_PATTERN.match(stripped_line):
         return True, in_yenc_block, in_uue_block, True
     elif RE_UUE_DATA_PATTERN.match(stripped_line) or RE_UUE_PATTERN.match(
@@ -4592,7 +4595,8 @@ def _serialize_rfc822(
 
     # 1. Identify and extract attachments from the body
     # We remove them from the text part so the email looks modern
-    found_binaries = extract_binaries(message.text) if message.text else []
+    text_to_scan = message.original_text or message.text
+    found_binaries = extract_binaries(text_to_scan) if text_to_scan else []
     clean_body = message.text or ""
     if found_binaries:
         # Simple removal of lines that look like parts of UUE/Base64/yEnc blocks

--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -1908,6 +1908,7 @@ class QwkGuiApp:
                                     parsed_message,
                                     text=processed_buffer,
                                     attachments=attachments,
+                                    original_text=parsed_message.text,
                                 )
                             )
 


### PR DESCRIPTION
This PR fixes a data loss issue during message export to EML or MBOX formats. When messages were processed for display (e.g., in the GUI) or when binary removal was enabled, the attachments were often stripped from the body before the RFC 822 serialization could extract them into proper MIME parts.

By utilizing the `original_text` field in `ParsedMessage`, we ensure that `extract_binaries` always has access to the raw source data during export. Additionally, the UUE cleaning logic was refined to prevent leaving 'end' markers in the text when a backtick terminator was used.

Tested with a reproduction script and the existing test suite.

---
*PR created automatically by Jules for task [16308723850518742478](https://jules.google.com/task/16308723850518742478) started by @RainRat*