### PR TITLE
Fix UUE zero-length line handling in message processing

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -339,7 +339,7 @@ def _is_binary_line(
     if in_uue_block:
         if stripped_line in ("end", "`"):
             return True, in_yenc_block, False, in_base64_block
-        if RE_UUE_LOOSE_PATTERN.match(stripped_line):
+        if not stripped_line or RE_UUE_LOOSE_PATTERN.match(stripped_line):
             return True, in_yenc_block, True, in_base64_block
         in_uue_block = False
 

--- a/tests/test_parser_robustness.py
+++ b/tests/test_parser_robustness.py
@@ -6,7 +6,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from pyqwk.core import parse_messages
+from pyqwk.core import parse_messages, process_message
 
 
 def build_header_bytes(**kwargs) -> bytes:
@@ -93,3 +93,23 @@ class TestParserRobustness:
         assert len(messages) == 2
         assert messages[0].header.msgsubject.strip() == "Valid 1"
         assert messages[1].header.msgsubject.strip() == "Valid 2"
+
+    def test_process_message_with_zero_length_uue_line(self):
+        """
+        Regression test: Verify that a UUE block with a zero-length line (a single space)
+        is correctly identified and removed, reaching the 'end' terminator.
+        """
+        text = (
+            "begin 644 test.txt\r\n"
+            "M123456789012345678901234567890123456789012345\r\n"
+            " \r\n"
+            "end\r\n"
+            "Keep this part"
+        )
+        # process_message arguments:
+        # truncate_signatures=False, cut_quoting=False, binaries_removal=True, redact_pii=False
+        processed = process_message(text, False, False, True, False)
+
+        assert "M12345" not in processed
+        assert "end" not in processed
+        assert "Keep this part" in processed


### PR DESCRIPTION
* **What:** Modified `_is_binary_line` in `pyqwk/core.py` to correctly handle empty or space-only lines within UUE blocks. Added a regression test in `tests/test_parser_robustness.py`.
* **Why:** Zero-length UUE lines are represented by a single space character, which was being stripped and incorrectly causing the parser to exit the UUE block before reaching the 'end' terminator. This ensures proper removal of binary attachments during text cleaning. No breaking changes were introduced.

---
*PR created automatically by Jules for task [16432653279584885758](https://jules.google.com/task/16432653279584885758) started by @RainRat*