### PR TITLE
[UI/UX] [GUI] Add BBS navigation buttons and shortcuts for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ qwk-gui messages.db
 - **Ctrl + G**: Jump to a specific message number.
 - **r**: Select a random message.
 - **[** or **]**: Move to the previous or next conference.
+- **{** or **}**: Move to the previous or next BBS archive.
 
 ## Usage Examples
 

--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -503,6 +503,12 @@ class QwkGuiApp:
         if event.keysym == "bracketright" or event.char == "]":
             self._navigate_conference(1)
             return "break"
+        if event.keysym == "braceleft" or event.char == "{":
+            self._navigate_bbs(-1)
+            return "break"
+        if event.keysym == "braceright" or event.char == "}":
+            self._navigate_bbs(1)
+            return "break"
 
         # Allow text navigation keys and search controls
         if event.keysym in (
@@ -581,6 +587,7 @@ class QwkGuiApp:
                     ("Ctrl + G", "Go to Message Number"),
                     ("R", "Random Message"),
                     ("[ / ]", "Prev / Next Conference"),
+                    ("{ / }", "Prev / Next BBS"),
                 ],
             ),
         ]
@@ -729,6 +736,8 @@ class QwkGuiApp:
         self.root.bind("<Next>", self._on_space_pressed)
         self.root.bind("[", lambda e: self._navigate_conference(-1))
         self.root.bind("]", lambda e: self._navigate_conference(1))
+        self.root.bind("{", lambda e: self._navigate_bbs(-1))
+        self.root.bind("}", lambda e: self._navigate_bbs(1))
         self.root.bind("/", self._focus_search)
         self.root.bind("r", self._select_random_message)
 
@@ -800,6 +809,27 @@ class QwkGuiApp:
             new_idx = (current_idx + delta) % num_values
 
         self.conf_combo.current(new_idx)
+        self.reload_messages()
+
+    def _navigate_bbs(self, delta: int) -> None:
+        """Change the selected BBS in the combobox by a given offset."""
+        if not self.bbs_combo["values"]:
+            return
+
+        # Avoid changing BBSes while the user is typing in a search or exclude field
+        focused_widget = self.root.focus_get()
+        if focused_widget in (self.search_entry, self.exclude_entry):
+            return
+
+        current_idx = self.bbs_combo.current()
+        num_values = len(self.bbs_combo["values"])
+
+        if current_idx == -1:
+            new_idx = 0 if delta > 0 else num_values - 1
+        else:
+            new_idx = (current_idx + delta) % num_values
+
+        self.bbs_combo.current(new_idx)
         self.reload_messages()
 
     def _on_space_pressed(self, event: tk.Event) -> str | None:
@@ -1020,12 +1050,18 @@ class QwkGuiApp:
 
         archives_frame = ttk.Labelframe(row2, text="Archives", padding=(5, 5))
         archives_frame.pack(side=tk.LEFT, padx=5)
+        ttk.Button(
+            archives_frame, text="◀", width=2, command=lambda: self._navigate_bbs(-1)
+        ).pack(side=tk.LEFT, padx=(2, 0))
         self.bbs_combo = ttk.Combobox(archives_frame, state="readonly", width=18)
         self.bbs_combo.pack(side=tk.LEFT, padx=2)
+        ttk.Button(
+            archives_frame, text="▶", width=2, command=lambda: self._navigate_bbs(1)
+        ).pack(side=tk.LEFT, padx=(0, 5))
 
         ttk.Button(
             archives_frame, text="◀", width=2, command=lambda: self._navigate_conference(-1)
-        ).pack(side=tk.LEFT, padx=(5, 0))
+        ).pack(side=tk.LEFT, padx=(2, 0))
         self.conf_combo = ttk.Combobox(archives_frame, state="readonly", width=18)
         self.conf_combo.pack(side=tk.LEFT, padx=2)
         ttk.Button(

--- a/tests/test_gui_bbs_nav.py
+++ b/tests/test_gui_bbs_nav.py
@@ -1,0 +1,105 @@
+from unittest.mock import MagicMock, patch
+import sys
+
+def test_navigate_bbs():
+    mock_root = MagicMock()
+    with patch('pyqwk.gui.tk'), \
+         patch('pyqwk.gui.ttk') as mock_ttk, \
+         patch('pyqwk.gui.font'):
+
+        from pyqwk.gui import QwkGuiApp
+
+        # Setup app
+        app = QwkGuiApp(mock_root)
+
+        # Configure mock BBS combo
+        # We need to mock how __getitem__ works for "values"
+        app.bbs_combo = MagicMock()
+        values = ["BBS 1", "BBS 2", "BBS 3"]
+        app.bbs_combo.__getitem__.side_effect = lambda key: values if key == "values" else None
+        app.bbs_combo.current.return_value = 0
+
+        # Mock reload_messages to avoid heavy lifting
+        app.reload_messages = MagicMock()
+
+        # Test navigation forward
+        app._navigate_bbs(1)
+        app.bbs_combo.current.assert_called_with(1)
+        app.reload_messages.assert_called()
+
+        # Test navigation backward (wrap around)
+        app.bbs_combo.current.return_value = 0
+        app._navigate_bbs(-1)
+        app.bbs_combo.current.assert_called_with(2)
+
+def test_bbs_navigation_buttons_present():
+    mock_root = MagicMock()
+    with patch('pyqwk.gui.tk'), \
+         patch('pyqwk.gui.ttk') as mock_ttk, \
+         patch('pyqwk.gui.font'):
+
+        from pyqwk.gui import QwkGuiApp
+
+        # We need to track the created buttons and their commands
+        button_commands = []
+
+        def mock_button_init(master, **kwargs):
+            btn = MagicMock()
+            if 'command' in kwargs:
+                button_commands.append(kwargs['command'])
+            return btn
+
+        mock_ttk.Button.side_effect = mock_button_init
+
+        app = QwkGuiApp(mock_root)
+
+        # Verify that _navigate_bbs is being used in some of the buttons
+        # We can mock _navigate_bbs and trigger the commands to see if it's called
+        app._navigate_bbs = MagicMock()
+
+        found_prev = False
+        found_next = False
+
+        for cmd in button_commands:
+            if callable(cmd):
+                # Reset mock for each call
+                app._navigate_bbs.reset_mock()
+                try:
+                    cmd()
+                    if app._navigate_bbs.called:
+                        args = app._navigate_bbs.call_args[0]
+                        if args == (-1,):
+                            found_prev = True
+                        elif args == (1,):
+                            found_next = True
+                except:
+                    pass
+
+        assert found_prev, "BBS Prev button not found or not linked to _navigate_bbs(-1)"
+        assert found_next, "BBS Next button not found or not linked to _navigate_bbs(1)"
+
+def test_welcome_screen_updated():
+    mock_root = MagicMock()
+    with patch('pyqwk.gui.tk') as mock_tk, \
+         patch('pyqwk.gui.ttk'), \
+         patch('pyqwk.gui.font'):
+
+        from pyqwk.gui import QwkGuiApp
+
+        mock_text = MagicMock()
+        mock_tk.Text.return_value = mock_text
+
+        app = QwkGuiApp(mock_root)
+        app._render_welcome_screen()
+
+        # Check if "{ / }" and "Prev / Next BBS" were inserted
+        found_shortcut = False
+        for call in mock_text.insert.call_args_list:
+            args, _ = call
+            if len(args) > 1:
+                content = str(args[1])
+                if "{ / }" in content or "Prev / Next BBS" in content:
+                    found_shortcut = True
+                    break
+
+        assert found_shortcut


### PR DESCRIPTION
### Context
GUI (Graphical Reader)

### Problem
Users had to manually select a BBS from the dropdown menu to cycle through different archives. This was inconsistent with the conference selector, which featured dedicated navigation buttons and keyboard shortcuts ([/]), creating a friction point when browsing multi-archive sets.

### Solution
Added dedicated navigation buttons (◀/▶) flanking the BBS selector in the toolbar and bound the `{` and `}` keys for quick archive switching. This improvement harmonizes the archive and conference navigation workflows, enabling faster traversal of heterogeneous message collections without repetitive mouse clicks.

### Changes
- **pyqwk/gui.py**:
    - Implemented `_navigate_bbs(delta)` to handle index wrapping and state-safe navigation.
    - Updated `_build_toolbar` to include the new buttons.
    - Bound `{` and `}` in `_build_menu` and updated `_block_text_input` to support them during continuous reading.
    - Updated the welcome screen shortcuts list.
- **README.md**: Added `{ / }` shortcuts to the Navigation section.
- **tests/test_gui_bbs_nav.py**: Added new unit tests for BBS navigation logic and button/shortcut mapping.

---
*PR created automatically by Jules for task [15026552343010970091](https://jules.google.com/task/15026552343010970091) started by @RainRat*