### PR TITLE
[FEAT] Detection and filtering for internal message links

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,7 @@ for msg in messages:
 | `--has-emails` | Only show messages that contain email addresses. |
 | `--has-phones` | Only show messages that contain phone numbers. |
 | `--has-ansi` | Only show messages that contain color codes. |
+| `--has-msg-links` | Only show messages that contain references to other messages (e.g., 'msg #123'). |
 | `-A, --strip-ansi` | Remove color codes and other formatting symbols. |
 | `-H, --headers-only` | Show only the message headers. |
 | `-E, --encoding` | Set text encoding (default is `cp437`). |
@@ -492,6 +493,8 @@ You can use custom patterns with `--oneline-pattern` (for summaries on the scree
 | Variable | Description |
 | :--- | :--- |
 | `{msgid}` | A unique identifier for the message (`conf.msg@bbs`). |
+| `{msg_links}` | A list of message numbers referenced in the text. |
+| `{msg_link_count}` | The number of message references found in the text. |
 | `{refnum}` | The message number being replied to. |
 | `{status}` | The status code (e.g., `*` for private). |
 | `{msgflag}` | Technical flags from the message header. |

--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -72,8 +72,8 @@ def main() -> None:
         "  Basic Information:\n"
         "    {author}, {to}, {subject}, {subject_clean}, {body}, {body_clean},\n"
         "    {confname}, {confnum}, {confname_or_num}, {msgnum}, {snippet},\n"
-        "    {url_count}, {email_count}, {phone_count}, {my_name},\n"
-        "    {urls}, {emails}, {phones}\n"
+        "    {url_count}, {email_count}, {phone_count}, {msg_link_count}, {my_name},\n"
+        "    {urls}, {emails}, {phones}, {msg_links}\n"
         "  Dates & Times:\n"
         "    {date}, {time}, {year}, {month}, {day}, {hour}, {minute}, {second},\n"
         "    {iso_date}, {iso_time}\n"
@@ -574,6 +574,11 @@ examples:
         help="Only show messages that contain ANSI color codes.",
         action="store_true",
     )
+    filter_group.add_argument(
+        "--has-msg-links",
+        help="Only show messages that contain references to other messages (e.g., 'msg #123').",
+        action="store_true",
+    )
 
     parser.add_argument(
         "-I",
@@ -750,6 +755,7 @@ examples:
         has_emails=getattr(args, "has_emails", False),
         has_phones=getattr(args, "has_phones", False),
         has_ansi=getattr(args, "has_ansi", False),
+        has_msg_links=getattr(args, "has_msg_links", False),
         body_search=args.body_search,
         exclude_search=args.exclude_search,
         exclude_authors=args.exclude_authors,

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -587,6 +587,7 @@ class ProcessingSettings:
     has_emails: bool = False
     has_phones: bool = False
     has_ansi: bool = False
+    has_msg_links: bool = False
     my_name: str | None = None
     body_search: str | None = None
     exclude_search: str | None = None
@@ -2828,6 +2829,11 @@ def matches_filters(
         if not (message.text and RE_ANSI_ESCAPE_PATTERN.search(message.text)):
             return False
 
+    # 9f. Message Links Filter
+    if settings.has_msg_links:
+        if not (message.text and RE_MSG_LINK_PATTERN.search(message.text)):
+            return False
+
     # 10. Length Filter
     msg_len = len(message.text) if message.text else 0
     if settings.min_length is not None and msg_len < settings.min_length:
@@ -3000,10 +3006,12 @@ def _get_message_mapping(
     urls_list = [e[3] for e in entities if e[2] == "url"]
     emails_list = [e[3] for e in entities if e[2] == "email"]
     phones_list = [e[3] for e in entities if e[2] == "phone"]
+    msg_links_list = [e[3] for e in entities if e[2] == "msg_link"]
 
     url_count = len(urls_list)
     email_count = len(emails_list)
     phone_count = len(phones_list)
+    msg_link_count = len(msg_links_list)
 
     msgnum_val = header.msgnum if header.msgnum is not None else 0
     bbs_id_val = message.bbs_id or ""
@@ -3047,6 +3055,8 @@ def _get_message_mapping(
         "emails": ", ".join(emails_list),
         "phone_count": phone_count,
         "phones": ", ".join(phones_list),
+        "msg_link_count": msg_link_count,
+        "msg_links": ", ".join(msg_links_list),
         "my_name": my_name_val,
         "thread_id": message.thread_id or "",
         "parent_msgnum": message.parent_msgnum if message.parent_msgnum is not None else 0,

--- a/pyqwk/gui.py
+++ b/pyqwk/gui.py
@@ -100,6 +100,7 @@ class QwkGuiApp:
         self.has_emails_var = tk.BooleanVar(value=False)
         self.has_phones_var = tk.BooleanVar(value=False)
         self.has_ansi_var = tk.BooleanVar(value=False)
+        self.has_msg_links_var = tk.BooleanVar(value=False)
         self.redact_pii_var = tk.BooleanVar(value=False)
         self.embed_attach_var = tk.BooleanVar(value=False)
 
@@ -633,6 +634,7 @@ class QwkGuiApp:
             ("Emails", self.has_emails_var),
             ("Phones", self.has_phones_var),
             ("Colors", self.has_ansi_var),
+            ("Message Links", self.has_msg_links_var),
         ]:
             if var.get():
                 active_bools.append(text)
@@ -880,6 +882,7 @@ class QwkGuiApp:
         self.has_emails_var.set(False)
         self.has_phones_var.set(False)
         self.has_ansi_var.set(False)
+        self.has_msg_links_var.set(False)
         self.redact_pii_var.set(False)
         self.wrap_var.set(True)
         self._update_wrap()
@@ -1043,6 +1046,7 @@ class QwkGuiApp:
                 ("Emails", self.has_emails_var),
                 ("Phones", self.has_phones_var),
                 ("Colors", self.has_ansi_var),
+                ("Message Links", self.has_msg_links_var),
             ]
         ):
             ttk.Checkbutton(
@@ -1290,6 +1294,7 @@ class QwkGuiApp:
             has_emails=self.has_emails_var.get(),
             has_phones=self.has_phones_var.get(),
             has_ansi=self.has_ansi_var.get(),
+            has_msg_links=self.has_msg_links_var.get(),
             embed_attachments=self.embed_attach_var.get(),
         )
 

--- a/tests/test_msg_links_feature.py
+++ b/tests/test_msg_links_feature.py
@@ -1,0 +1,75 @@
+import pytest
+from pyqwk.core import ParsedMessage, MessageHeader, ProcessingSettings, matches_filters, _get_message_mapping
+
+def test_msg_links_filtering():
+    header = MessageHeader(
+        status=" ", msgnum=1, msgdate="01-01-23", msgtime="12:00",
+        msgto="All", msgfrom="Author", msgsubject="Test",
+        msgpassword="", refnum=None, numblocks=1, msgflag=" ",
+        confnum=1, lognum=0, nettag=" "
+    )
+
+    msg_with_link = ParsedMessage(text="Check msg #123 for details.", msgnum=1, refnum=None, confnum=1, header=header)
+    msg_without_link = ParsedMessage(text="No links here.", msgnum=2, refnum=None, confnum=1, header=header)
+
+    settings = ProcessingSettings(
+        verbose=False, private=True, no_header=True, truncate_signatures=False,
+        cut_quoting=False, individual_files=False, threaded=False,
+        binaries_removal=False, redact_pii=False, format="text",
+        separator="none", output_mode="stdout", output_path=None, encoding="cp437",
+        has_msg_links=True
+    )
+
+    assert matches_filters(msg_with_link, settings, set()) is True
+    assert matches_filters(msg_without_link, settings, set()) is False
+
+def test_msg_links_template_variables():
+    header = MessageHeader(
+        status=" ", msgnum=1, msgdate="01-01-23", msgtime="12:00",
+        msgto="All", msgfrom="Author", msgsubject="Test",
+        msgpassword="", refnum=None, numblocks=1, msgflag=" ",
+        confnum=1, lognum=0, nettag=" "
+    )
+
+    text = "See msg #10 and message 20."
+    msg = ParsedMessage(text=text, msgnum=1, refnum=None, confnum=1, header=header)
+
+    mapping = _get_message_mapping(msg, 1)
+
+    assert mapping["msg_link_count"] == 2
+    assert "msg #10" in mapping["msg_links"]
+    assert "message 20" in mapping["msg_links"]
+
+def test_cli_has_msg_links_flag(capsys, monkeypatch):
+    import pyqwk.cli
+    import json
+    import os
+
+    # Create a dummy jsonl file with two messages
+    test_file = "test_msg_links.jsonl"
+    with open(test_file, "w") as f:
+        f.write(json.dumps({
+            "header": {"msgfrom": "A", "msgto": "B", "msgsubject": "S", "msgdate": "01-01-23", "msgtime": "12:00", "confnum": 1, "status": " ", "msgnum": 1},
+            "text": "Link to msg #100"
+        }) + "\n")
+        f.write(json.dumps({
+            "header": {"msgfrom": "A", "msgto": "B", "msgsubject": "S", "msgdate": "01-01-23", "msgtime": "12:00", "confnum": 1, "status": " ", "msgnum": 2},
+            "text": "No link"
+        }) + "\n")
+
+    try:
+        monkeypatch.setattr("sys.argv", ["qwk", test_file, "--has-msg-links", "--oneline"])
+        pyqwk.cli.main()
+
+        out, err = capsys.readouterr()
+        assert "Successfully processed 1 message." in out
+
+        monkeypatch.setattr("sys.argv", ["qwk", test_file, "--oneline-pattern", "{msg_link_count} links: {msg_links}"])
+        pyqwk.cli.main()
+        out, err = capsys.readouterr()
+        assert "1 links: msg #100" in out
+        assert "0 links: " in out
+
+    finally:
+        if os.path.exists(test_file):
+            os.remove(test_file)


### PR DESCRIPTION
I've implemented a new feature that allows users to detect and filter messages containing internal references like "msg #123" or "message 456". This is a common way BBS users cross-referenced posts, and having a dedicated filter and template variables makes it much easier to research threads and build indexes.

### Changes:
- **Core:** Integrated `RE_MSG_LINK_PATTERN` into the filtering pipeline and template mapping.
- **CLI:** Added the `--has-msg-links` flag and expanded the help text with new template variables.
- **GUI:** Added a "Message Links" checkbox to the filter toolbar for easy access in the Graphical Reader.
- **Docs:** Updated `README.md` with descriptions of the new flag and variables.
- **Tests:** Added `tests/test_msg_links_feature.py` to ensure correctness across CLI and library usage.

---
*PR created automatically by Jules for task [8166217985847242932](https://jules.google.com/task/8166217985847242932) started by @RainRat*