### PR TITLE
[UI/UX] Improve CLI feedback with relative message processing counts

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -3196,6 +3196,7 @@ def process_merged_files(
         separator_str = "\r\n"
 
     total_matching = 0
+    total_encountered = 0
     processed_count = 0
     estimated_bytes = 0
     potential_files = 0
@@ -3557,6 +3558,7 @@ def process_merged_files(
                 )
 
             for parsed_message in messages_to_process:
+                total_encountered += 1
                 if is_structured and progress_bar is not None:
                     progress_bar.update(1)
 
@@ -3737,7 +3739,11 @@ def process_merged_files(
         GREEN = "32"
 
         count_label = "message" if processed_count == 1 else "messages"
-        msg = f"Successfully processed {processed_count} {count_label}"
+
+        if total_encountered > processed_count:
+            msg = f"Successfully processed {processed_count} of {total_encountered} messages"
+        else:
+            msg = f"Successfully processed {processed_count} {count_label}"
 
         if total_attachments > 0:
             attach_label = "attachment" if total_attachments == 1 else "attachments"

--- a/tests/test_msg_links_feature.py
+++ b/tests/test_msg_links_feature.py
@@ -62,7 +62,7 @@ def test_cli_has_msg_links_flag(capsys, monkeypatch):
         pyqwk.cli.main()
 
         out, err = capsys.readouterr()
-        assert "Successfully processed 1 message." in out
+        assert "Successfully processed 1 of 2 messages." in out
 
         monkeypatch.setattr("sys.argv", ["qwk", test_file, "--oneline-pattern", "{msg_link_count} links: {msg_links}"])
         pyqwk.cli.main()


### PR DESCRIPTION
**PR Title:** [UI/UX] Improve CLI feedback with relative message processing counts

**Description:**
* **Context:** CLI
* **Problem:** When users apply filters (such as `--search`, `--after`, or `--mine`), the final output only reports the number of matching messages. If no messages match (e.g., due to a typo in a search term), the output "Successfully processed 0 messages" can be confusing, leading users to believe the archive is empty or the tool failed silently.
* **Solution:** Updated `process_merged_files` to track both the number of matching messages and the total number of messages encountered in the archives. If any messages are filtered out, the success message now uses the format "Successfully processed X of Y messages". This provides immediate confirmation that the archives were read correctly and that the result count is a consequence of the applied filters.

**Changes:**
```python
# pyqwk/core.py

# In process_merged_files:
# Added total_encountered tracking and updated the final success message logic.

    total_matching = 0
    total_encountered = 0
    processed_count = 0
# ...
            for parsed_message in messages_to_process:
                total_encountered += 1
# ...
        if total_encountered > processed_count:
            msg = f"Successfully processed {processed_count} of {total_encountered} messages"
        else:
            msg = f"Successfully processed {processed_count} {count_label}"
```

---
*PR created automatically by Jules for task [11753657319964176413](https://jules.google.com/task/11753657319964176413) started by @RainRat*