### PR TITLE
[FEAT] Add --tail flag and {word_count} variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,7 @@ for msg in messages:
 | `--exclude-bbs` | Hide messages from a specific BBS. Supports partial matches. |
 | `--after` | Show messages sent on or after a date (YYYY-MM-DD). |
 | `--before` | Show messages sent on or before a date (YYYY-MM-DD). |
+| `--tail` | Show only the last specific number of matching messages. Alias: `--last`. |
 | `--on-this-day` | Show messages from the same month and day. |
 | `-N, --msgnum` | Show specific message numbers or ranges. |
 | `-L, --limit` | Stop after a specific number of matching messages. |
@@ -505,6 +506,7 @@ You can use custom patterns with `--oneline-pattern` (for summaries on the scree
 | `{parent_msgnum}` | The message number of the post being replied to. |
 | `{depth}` | The depth of the message in the conversation (0 for original posts). |
 | `{length}` | The number of characters in the message. |
+| `{word_count}` | The number of words in the message text. |
 | `{size}` | The readable size of the message (e.g., `1.2 KB`). |
 | `{flags}` | Short indicators (e.g., `*` for private, `@` for attachments). |
 | `{indent}` | Spaces and symbols used for organizing conversations on the screen. |

--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -81,7 +81,8 @@ def main() -> None:
         "    {bbs_name}, {bbs_id}, {source_file}\n"
         "  Technical Details:\n"
         "    {msgid}, {refnum}, {status}, {msgflag}, {is_private}, {is_reply},\n"
-        "    {length}, {size}, {flags}, {indent}, {thread_id}, {parent_msgnum}, {depth}\n"
+        "    {length}, {word_count}, {size}, {flags}, {indent}, {thread_id},\n"
+        "    {parent_msgnum}, {depth}\n"
         "  Attachments:\n"
         "    {attachments}, {attachment_count}"
     )
@@ -472,6 +473,14 @@ examples:
         default=None,
     )
     filter_group.add_argument(
+        "--tail",
+        "--last",
+        metavar="NUM",
+        help="Show only the last NUM matching messages.",
+        type=int,
+        default=None,
+    )
+    filter_group.add_argument(
         "--max-length",
         help="Show messages with at most this many characters.",
         type=int,
@@ -765,6 +774,7 @@ examples:
         exclude_bbs_names=args.exclude_bbs_names,
         filename_pattern=getattr(args, "filename_pattern", None),
         organize_pattern=getattr(args, "organize_pattern", None),
+        tail=args.tail,
         min_length=getattr(args, "min_length", None),
         max_length=getattr(args, "max_length", None),
     )

--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -597,6 +597,7 @@ class ProcessingSettings:
     exclude_conferences: list[str] | None = None
     exclude_bbs_names: list[str] | None = None
     organize_pattern: str | None = None
+    tail: int | None = None
 
 
 @dataclass
@@ -3062,6 +3063,7 @@ def _get_message_mapping(
         "parent_msgnum": message.parent_msgnum if message.parent_msgnum is not None else 0,
         "depth": message.depth,
         "length": len(message.text) if message.text else 0,
+        "word_count": len(message.text.split()) if message.text else 0,
         "size": format_size(len(message.text)) if message.text else "0 B",
         "flags": flags,
         "snippet": snippet,
@@ -3199,7 +3201,9 @@ def process_merged_files(
     processed_count = 0
     estimated_bytes = 0
     potential_files = 0
-    use_streaming = not (settings.sort or settings.reverse or settings.threaded)
+    use_streaming = not (
+        settings.sort or settings.reverse or settings.threaded or settings.tail
+    )
     sort_buffer: list[tuple[ParsedMessage, dict[int, str]]] = []
     collected_for_index: list[dict[str, Any]] = []
     bbs_info_to_use = None
@@ -3666,9 +3670,29 @@ def process_merged_files(
         if reversal_needed:
             sort_buffer.reverse()
 
-        for parsed_message, board_dict in sort_buffer:
-            if handle_output(parsed_message, board_dict):
-                break
+        # Apply skip, limit, and tail to the buffer
+        if settings.skip:
+            sort_buffer = sort_buffer[settings.skip :]
+
+        if settings.limit:
+            sort_buffer = sort_buffer[: settings.limit]
+
+        if settings.tail:
+            sort_buffer = sort_buffer[-settings.tail :]
+
+        # Temporarily clear skip/limit in settings to avoid redundant filtering in handle_output
+        original_skip = settings.skip
+        original_limit = settings.limit
+        settings.skip = None
+        settings.limit = None
+
+        try:
+            for parsed_message, board_dict in sort_buffer:
+                if handle_output(parsed_message, board_dict):
+                    break
+        finally:
+            settings.skip = original_skip
+            settings.limit = original_limit
 
     if settings.individual_files:
         if not settings.dry_run and collected_for_index:
@@ -4064,6 +4088,9 @@ def _render_stats_html(stats: dict[str, Any]) -> list[str]:
     parts.append(
         f"<div><strong>Avg Length:</strong> {int(stats.get('avg_message_length', 0))} characters</div>"
     )
+    parts.append(
+        f"<div><strong>Avg Words:</strong> {stats.get('avg_word_count', 0)}</div>"
+    )
 
     if stats.get("conversation"):
         conv = stats["conversation"]
@@ -4323,6 +4350,7 @@ def _render_stats_markdown(stats: dict[str, Any]) -> list[str]:
     parts.append(
         f"- **Avg Length:** {int(stats.get('avg_message_length', 0))} characters"
     )
+    parts.append(f"- **Avg Words:** {stats.get('avg_word_count', 0)}")
 
     if stats.get("conversation"):
         conv = stats["conversation"]
@@ -6018,6 +6046,7 @@ def _compute_stats_from_messages(
         "reply_count": 0,
         "reply_rate": 0.0,
         "avg_message_length": 0.0,
+        "avg_word_count": 0.0,
         "conversation": {
             "avg_response_time": 0,
             "min_response_time": 0,
@@ -6053,6 +6082,7 @@ def _compute_stats_from_messages(
     processed_count = 0
     reply_count = 0
     total_chars = 0
+    total_words = 0
 
     msg_timestamps = {}
     response_deltas = []
@@ -6116,6 +6146,7 @@ def _compute_stats_from_messages(
         # Check for attachments in the full message
         if message.text:
             total_chars += len(message.text)
+            total_words += len(message.text.split())
 
             # Use cached attachments if available to avoid re-scanning
             current_attachments = message.discover_attachments()
@@ -6161,6 +6192,9 @@ def _compute_stats_from_messages(
     )
     stats_entry["avg_message_length"] = (
         round(total_chars / processed_count, 1) if processed_count > 0 else 0.0
+    )
+    stats_entry["avg_word_count"] = (
+        round(total_words / processed_count, 1) if processed_count > 0 else 0.0
     )
 
     if earliest_dt:
@@ -6368,6 +6402,7 @@ def render_stats_as_text(stats: dict[str, Any], use_colors: bool = False) -> str
         f"    Reply Rate:    {stats['reply_rate']}% ({stats['reply_count']} replies)"
     )
     parts.append(f"    Avg Length:    {int(stats['avg_message_length'])} characters")
+    parts.append(f"    Avg Words:     {stats['avg_word_count']}")
 
     if stats.get("conversation"):
         conv = stats["conversation"]

--- a/tests/test_tail_wordcount.py
+++ b/tests/test_tail_wordcount.py
@@ -1,0 +1,177 @@
+import pytest
+import logging
+from dataclasses import replace
+from pyqwk.core import (
+    process_merged_files,
+    ProcessingSettings,
+    ParsedMessage,
+    MessageHeader,
+    _get_message_mapping,
+    calculate_archive_stats,
+)
+
+@pytest.fixture
+def mock_logger():
+    return logging.getLogger("test_tail_wordcount")
+
+@pytest.fixture
+def mock_messages():
+    header_template = MessageHeader(
+        status=" ",
+        msgnum=1,
+        msgdate="01-01-23",
+        msgtime="12:00",
+        msgto="Everyone",
+        msgfrom="Alice",
+        msgsubject="Subject",
+        msgpassword="",
+        refnum=None,
+        numblocks=2,
+        msgflag=" ",
+        confnum=1,
+        lognum=1,
+        nettag="",
+    )
+
+    msgs = []
+    for i in range(1, 11):
+        # Different word counts: i words
+        text = " ".join([f"word{j}" for j in range(i)])
+        msgs.append(
+            ParsedMessage(
+                text=text,
+                msgnum=i,
+                refnum=None,
+                confnum=1,
+                header=replace(header_template, msgnum=i),
+            )
+        )
+    return msgs
+
+def test_tail_restricts_output(tmp_path, mock_messages, mock_logger, monkeypatch):
+    output_path = tmp_path / "output.txt"
+
+    def fake_load_data(*args, **kwargs):
+        return bytearray(), {1: "General"}
+
+    def fake_parse_messages(*args, **kwargs):
+        yield from mock_messages
+
+    monkeypatch.setattr("pyqwk.core.load_data", fake_load_data)
+    monkeypatch.setattr("pyqwk.core.parse_messages", fake_parse_messages)
+
+    tail = 3
+    settings = ProcessingSettings(
+        verbose=False,
+        private=False,
+        no_header=True,
+        truncate_signatures=False,
+        cut_quoting=False,
+        individual_files=False,
+        threaded=False,
+        binaries_removal=False,
+        redact_pii=False,
+        format="text",
+        separator="none",
+        output_mode="file",
+        output_path=str(output_path),
+        encoding="cp437",
+        quiet=True,
+        tail=tail,
+    )
+
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
+
+    content = output_path.read_text(encoding="latin1")
+    # Should contain Message 8, 9, 10 but not 7
+    # Note: our messages have text "word0 word1 ..."
+    assert "word0" in content # Message 1-10 all have word0
+    assert "word7" in content # Message 8, 9, 10
+    assert "word9" in content # Message 10
+
+    # Verify count of messages by counting "word0" which appears once per message
+    assert content.count("word0") == 3
+
+def test_word_count_variable(mock_messages):
+    msg = mock_messages[4] # Message 5, should have 5 words
+    mapping = _get_message_mapping(msg, 1)
+    assert mapping["word_count"] == 5
+
+def test_avg_word_count_stats(mock_messages, mock_logger, monkeypatch):
+    def fake_load_data(*args, **kwargs):
+        return bytearray(), {1: "General"}
+
+    def fake_parse_messages(*args, **kwargs):
+        yield from mock_messages
+
+    monkeypatch.setattr("pyqwk.core.load_data", fake_load_data)
+    monkeypatch.setattr("pyqwk.core.parse_messages", fake_parse_messages)
+
+    settings = ProcessingSettings(
+        verbose=False,
+        private=False,
+        no_header=True,
+        truncate_signatures=False,
+        cut_quoting=False,
+        individual_files=False,
+        threaded=False,
+        binaries_removal=False,
+        redact_pii=False,
+        format="text",
+        separator="none",
+        output_mode="stdout",
+        output_path=None,
+        encoding="cp437",
+        quiet=True,
+    )
+
+    stats = calculate_archive_stats(["dummy.qwk"], settings, mock_logger)
+    # Total words: 1+2+3+4+5+6+7+8+9+10 = 55
+    # Average: 55 / 10 = 5.5
+    assert stats["avg_word_count"] == 5.5
+
+def test_tail_with_skip_and_limit(tmp_path, mock_messages, mock_logger, monkeypatch):
+    output_path = tmp_path / "output.txt"
+
+    def fake_load_data(*args, **kwargs):
+        return bytearray(), {1: "General"}
+
+    def fake_parse_messages(*args, **kwargs):
+        yield from mock_messages
+
+    monkeypatch.setattr("pyqwk.core.load_data", fake_load_data)
+    monkeypatch.setattr("pyqwk.core.parse_messages", fake_parse_messages)
+
+    # Original: 1, 2, 3, 4, 5, 6, 7, 8, 9, 10
+    # skip 2: 3, 4, 5, 6, 7, 8, 9, 10
+    # limit 5: 3, 4, 5, 6, 7
+    # tail 2: 6, 7
+
+    settings = ProcessingSettings(
+        verbose=False,
+        private=False,
+        no_header=True,
+        truncate_signatures=False,
+        cut_quoting=False,
+        individual_files=False,
+        threaded=False,
+        binaries_removal=False,
+        redact_pii=False,
+        format="text",
+        separator="none",
+        output_mode="file",
+        output_path=str(output_path),
+        encoding="cp437",
+        quiet=True,
+        skip=2,
+        limit=5,
+        tail=2,
+    )
+
+    process_merged_files(["dummy.qwk"], settings, mock_logger)
+
+    content = output_path.read_text(encoding="latin1")
+    assert content.count("word0") == 2
+    assert "word5" in content # Message 6 has word0..word5
+    assert "word6" in content # Message 7 has word0..word6
+    assert "word7" not in content # Message 8+ would have word7


### PR DESCRIPTION
This PR introduces a symmetric filtering option `--tail` and a new `word_count` metric.

### Core Changes:
- **`--tail` / `--last`**: Allows users to view the final N messages of a matching set. This is a logical companion to the existing `--limit` and `--skip` flags, following the principle of symmetry. The implementation handles non-streaming buffer management to correctly identify the end of the set.
- **`{word_count}`**: Adds a word count variable to message formatting patterns and includes an "Avg Words" metric in archive statistics across all report formats (Text, HTML, and Markdown). This complements the existing character-based `length` metric.

### Implementation Details:
- Modified `pyqwk/core.py` to handle buffer slicing for `tail` while ensuring `skip` and `limit` are not double-applied during the final output pass.
- Updated `ProcessingSettings` and CLI argument parsing in `pyqwk/cli.py`.
- Documentation updated in `README.md`.
- New test suite added in `tests/test_tail_wordcount.py` ensuring correct interaction between `skip`, `limit`, and `tail`.

---
*PR created automatically by Jules for task [1363982188650729959](https://jules.google.com/task/1363982188650729959) started by @RainRat*