### PR TITLE
Consolidate redundant subject normalization logic in core.py

### DIFF
--- a/pyqwk/core.py
+++ b/pyqwk/core.py
@@ -2971,12 +2971,7 @@ def _get_message_mapping(
         else:
             my_name_val = author
 
-    subject_clean = subject
-    while True:
-        new_subject_clean = RE_SUBJECT_PREFIX_PATTERN.sub("", subject_clean)
-        if new_subject_clean == subject_clean:
-            break
-        subject_clean = new_subject_clean
+    subject_clean = _normalize_subject(subject, lowercase=False)
 
     if redact_pii:
         author = _redact_pii(author)
@@ -6658,7 +6653,7 @@ def process_multiple_files(
     return had_errors
 
 
-def _normalize_subject(subject: str) -> str:
+def _normalize_subject(subject: str, lowercase: bool = True) -> str:
     """Normalize subject line for conversation grouping by removing prefixes."""
     s = subject.strip()
     while True:
@@ -6666,7 +6661,8 @@ def _normalize_subject(subject: str) -> str:
         if new_s == s:
             break
         s = new_s
-    return s.strip().lower()
+    s = s.strip()
+    return s.lower() if lowercase else s
 
 
 def _order_messages_by_thread(


### PR DESCRIPTION
This PR resolves a **Duplication** issue by consolidating redundant subject prefix cleaning logic into a single utility function.

**Changes:**
1.  **Refactor `_normalize_subject`:** The function now accepts a `lowercase` boolean parameter (defaulting to `True`). This allows it to be used in contexts where case preservation is required (like template variable generation) while maintaining backward compatibility for existing callers (like threading and search).
2.  **Clean up `_get_message_mapping`:** The manual `while True` loop and `RE_SUBJECT_PREFIX_PATTERN` usage previously found in `_get_message_mapping` have been replaced with a clean call to `_normalize_subject(subject, lowercase=False)`.

**Benefits:**
- **Readability:** The mapping logic is now more concise and easier to follow.
- **Maintainability:** Fixes or improvements to subject normalization now only need to be applied in one place.
- **Safety:** The change is non-breaking. Existing tests for threading, search, and template mapping all pass, and the default behavior of `_normalize_subject` remains unchanged.

---
*PR created automatically by Jules for task [9115671718816850380](https://jules.google.com/task/9115671718816850380) started by @RainRat*