### PR TITLE
[DOCS] Harmonize filtering flag help strings for consistency and clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,12 +411,12 @@ for msg in messages:
 | `-p, --private` | Include private messages. |
 | `--mine` | Show messages sent to or from your user name. |
 | `--my-name` | Set your name for the `--mine` filter and QWK exports. |
-| `--has-attachments` | Only show messages that have attachments. |
-| `--has-links` | Only show messages that contain web links. |
-| `--has-emails` | Only show messages that contain email addresses. |
-| `--has-phones` | Only show messages that contain phone numbers. |
-| `--has-ansi` | Only show messages that contain color codes. |
-| `--has-msg-links` | Only show messages that contain references to other messages (e.g., 'msg #123'). |
+| `--has-attachments` | Show messages that contain attachments (UUE, yEnc, Base64). |
+| `--has-links` | Show messages that contain web, gopher, ftp, or telnet links. |
+| `--has-emails` | Show messages that contain email addresses. |
+| `--has-phones` | Show messages that contain phone numbers. |
+| `--has-ansi` | Show messages that contain color codes. |
+| `--has-msg-links` | Show messages that contain references to other messages (e.g., 'msg #123'). |
 | `-A, --strip-ansi` | Remove color codes and other formatting symbols. |
 | `-H, --headers-only` | Show only the message details (metadata). |
 | `-E, --encoding` | Set text encoding (default is `cp437`). |
@@ -435,7 +435,7 @@ for msg in messages:
 | `--exclude-bbs` | Hide messages from a specific BBS. Supports partial matches. |
 | `--after` | Show messages sent on or after a date (YYYY-MM-DD). |
 | `--before` | Show messages sent on or before a date (YYYY-MM-DD). |
-| `--tail` | Show only the last specific number of matching messages. Alias: `--last`. |
+| `--tail` | Show the final NUM messages from the matching set. Alias: `--last`. |
 | `--on-this-day` | Show messages from the same month and day. |
 | `-N, --msgnum` | Show specific message numbers or ranges. |
 | `-L, --limit` | Stop after a specific number of matching messages. |

--- a/pyqwk/cli.py
+++ b/pyqwk/cli.py
@@ -476,7 +476,7 @@ examples:
         "--tail",
         "--last",
         metavar="NUM",
-        help="Show only the last NUM matching messages.",
+        help="Show the final NUM messages from the matching set.",
         type=int,
         default=None,
     )
@@ -565,27 +565,27 @@ examples:
     )
     filter_group.add_argument(
         "--has-links",
-        help="Only show messages that contain web, gopher, ftp, or telnet links.",
+        help="Show messages that contain web, gopher, ftp, or telnet links.",
         action="store_true",
     )
     filter_group.add_argument(
         "--has-emails",
-        help="Only show messages that contain email addresses.",
+        help="Show messages that contain email addresses.",
         action="store_true",
     )
     filter_group.add_argument(
         "--has-phones",
-        help="Only show messages that contain phone numbers.",
+        help="Show messages that contain phone numbers.",
         action="store_true",
     )
     filter_group.add_argument(
         "--has-ansi",
-        help="Only show messages that contain ANSI color codes.",
+        help="Show messages that contain ANSI color codes.",
         action="store_true",
     )
     filter_group.add_argument(
         "--has-msg-links",
-        help="Only show messages that contain references to other messages (e.g., 'msg #123').",
+        help="Show messages that contain references to other messages (e.g., 'msg #123').",
         action="store_true",
     )
 


### PR DESCRIPTION
This change harmonizes the help strings for CLI filtering flags in both `pyqwk/cli.py` and `README.md`. 

The improvements include:
- Switching to active voice ("Show messages..." instead of "Only show messages...") for better readability and consistency.
- Adding specific technical context for flags like `--has-attachments` (mentioning UUE, yEnc, Base64) and `--has-links` (listing supported protocols).
- Clarifying the behavior of the `--tail` (alias `--last`) flag as applying to the final matching set.

These updates ensure that the internal help text and external documentation are synchronized and easy to understand for all users.

---
*PR created automatically by Jules for task [11013212937031182466](https://jules.google.com/task/11013212937031182466) started by @RainRat*